### PR TITLE
Make "attribute value" slot abstract

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -89,6 +89,7 @@ classes:
     is_a: ontology class
 
   attribute value:
+    abstract: true
     description: >-
       The value for any value of a attribute for a sample. This object can hold both the un-normalized atomic
       value and the structured value

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -550,7 +550,7 @@ slots:
 
   doi:
     is_a: attribute
-    range: attribute value
+    range: text value
 
   add_date:
     range: string


### PR DESCRIPTION
Change sole slot with "attribute value" range to be "text value".
Can change doi slot to be another subclass of "attribute value" later.

Closes #12