### PR TITLE
Add source_mat_id slot to biosample

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -228,6 +228,7 @@ classes:
       - sodium
       - soil_type
       - soil_type_meth
+      - source_mat_id
       - store_cond
       - sulfate
       - sulfide


### PR DESCRIPTION
This is needed for @StantonMartin's biosamples [submission](https://www.dropbox.com/s/7vq0di5oxei8lm9/ornl-martins-nmdc-2021-04-09.json?dl=0) to validate:
```bash
validate-nmdc-json -i ornl-martins-nmdc-2021-04-09.json
Additional properties are not allowed ('source_mat_id' was unexpected)
ornl-martins-nmdc-2021-04-09.json: The JSON data is ** NOT ** valid for NMDC schema.
```

