### PR TITLE
added NOM and metaB to file type enum for #72

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -407,10 +407,10 @@ enums:
       QC_metrics.tsv:
         description: Tab delimited file of aggregate statistics derived from workflow results.
       NOM:
-        data_object_type: Natural Organic Matter Results
+        data object type: Natural Organic Matter Results
         description: FT-MS high resolution molecular formula assignment results table
       metaB:
-        data_object_type: GC-MS Metabolomics Results
+        data object type: GC-MS Metabolomics Results
         description: GC-MS-based metabolite assignment results table
 
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -406,8 +406,14 @@ enums:
         description: Tab delimited file of protein results derived from ~5% FDR filtered peptide data, including aggregated abundance information.
       QC_metrics.tsv:
         description: Tab delimited file of aggregate statistics derived from workflow results.
-      
-      
+      NOM:
+        data_object_type: Natural Organic Matter Results
+        description: FT-MS high resolution molecular formula assignment results table
+      metaB:
+        data_object_type: GC-MS Metabolomics Results
+        description: GC-MS-based metabolite assignment results table
+
+
 slots:
 
   object set:


### PR DESCRIPTION
Also addd requested `description` and `data_object_type` annotations

`data_object_type property` already existed but doesn't seem to be mentioned anywhere else in the schema yet. I'm not sure I completely understand when to use whitespaces vs underscores for delimiters.