### PR TITLE
Issue 56: generate jsonld context and use pipenv to build targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ SCHEMA_SRC = $(SCHEMA_DIR)/$(SCHEMA_NAME).yaml
 TGTS = jsonschema python docs
 
 #GEN_OPTS = --no-mergeimports
-GEN_OPTS = --closed
+GEN_OPTS =
 
 all: gen stage
 gen: $(patsubst %,gen-%,$(TGTS))
+.PHONY: all gen stage clean t echo test install docserve gh-deploy .FORCE
 clean:
 	rm -rf target/
 	rm -f docs/*.md
@@ -26,8 +27,8 @@ echo:
 test: all test-jsonschema
 
 install:
-	. environment.sh
-	pip install -r requirements.txt
+	#. environment.sh
+	pipenv install -r requirements.txt
 
 tdir-%:
 	mkdir -p target/$*
@@ -58,49 +59,57 @@ gen-python: $(patsubst %, target/python/%.py, $(SCHEMA_NAMES))
 target/python/%.py: $(SCHEMA_DIR)/%.yaml  tdir-python
 # --no-mergeimports was causing an import error
 #	gen-py-classes --no-mergeimports $(GEN_OPTS) $< > $@
-	gen-py-classes --mergeimports $(GEN_OPTS) $< > $@
+	pipenv run gen-py-classes --mergeimports $(GEN_OPTS) $< > $@
 
 ###  -- MARKDOWN DOCS --
 # TODO: modularize imports. For now imports are merged.
 gen-graphql:target/graphql/$(SCHEMA_NAME).graphql 
+.PHONY: gen-graphql
 target/graphql/%.graphql: $(SCHEMA_DIR)/%.yaml tdir-graphql
-	gen-graphql $(GEN_OPTS) $< > $@
+	pipenv run gen-graphql $(GEN_OPTS) $< > $@
 
 ###  -- JSON schema --
 # TODO: modularize imports. For now imports are merged.
 gen-jsonschema: target/jsonschema/$(SCHEMA_NAME).schema.json
+.PHONY: gen-jsonschema
 target/jsonschema/%.schema.json: $(SCHEMA_DIR)/%.yaml tdir-jsonschema
-	gen-json-schema $(GEN_OPTS) -t database $< > $@
-	
+	pipenv run gen-json-schema $(GEN_OPTS) --closed -t database $< > $@
+
+###  -- JSONLD Context --
+
 ###  -- Shex --
 # one file per module
 gen-shex: $(patsubst %, target/shex/%.shex, $(SCHEMA_NAMES))
+.PHONY: gen-shex
 target/shex/%.shex: $(SCHEMA_DIR)/%.yaml tdir-shex
-	gen-shex --no-mergeimports $(GEN_OPTS) $< > $@
+	pipenv run gen-shex --no-mergeimports $(GEN_OPTS) $< > $@
 
 ###  -- CSV --
 # one file per module
 gen-csv: $(patsubst %, target/csv/%.csv, $(SCHEMA_NAMES))
+.PHONY: gen-csv
 target/csv/%.csv: $(SCHEMA_DIR)/%.yaml tdir-csv
-	gen-csv $(GEN_OPTS) $< > $@
+	pipenv run gen-csv $(GEN_OPTS) $< > $@
 
 ###  -- OWL --
 # TODO: modularize imports. For now imports are merged.
 gen-owl: target/owl/$(SCHEMA_NAME).owl.ttl
 .PHONY: gen-owl
 target/owl/%.owl.ttl: $(SCHEMA_DIR)/%.yaml tdir-owl
-	gen-owl $(GEN_OPTS) $< > $@
+	pipenv run gen-owl $(GEN_OPTS) $< > $@
 
 ###  -- RDF (direct mapping) --
 # TODO: modularize imports. For now imports are merged.
 gen-rdf: target/rdf/$(SCHEMA_NAME).ttl
+.PHONY: gen-rdf
 target/rdf/%.ttl: $(SCHEMA_DIR)/%.yaml tdir-rdf
-	gen-rdf $(GEN_OPTS) $< > $@
+	pipenv run gen-rdf $(GEN_OPTS) $< > $@
 
 ###  -- LinkML --
 # linkml (copy)
 # one file per module
 gen-linkml: target/linkml/$(SCHEMA_NAME).yaml
+.PHONY: gen-linkml
 target/linkml/%.yaml: $(SCHEMA_DIR)/%.yaml tdir-limkml
 	cp $< > $@
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@ SCHEMA_NAMES = $(patsubst $(SCHEMA_DIR)/%.yaml, %, $(SOURCE_FILES))
 
 SCHEMA_NAME = nmdc
 SCHEMA_SRC = $(SCHEMA_DIR)/$(SCHEMA_NAME).yaml
-TGTS = graphql jsonschema docs shex owl csv graphql python
+#TGTS = graphql jsonschema docs shex owl csv  python
+TGTS = jsonschema python docs
 
 #GEN_OPTS = --no-mergeimports
-GEN_OPTS = 
+GEN_OPTS = --closed
 
 all: gen stage
 gen: $(patsubst %,gen-%,$(TGTS))
@@ -70,11 +71,7 @@ target/graphql/%.graphql: $(SCHEMA_DIR)/%.yaml tdir-graphql
 gen-jsonschema: target/jsonschema/$(SCHEMA_NAME).schema.json
 target/jsonschema/%.schema.json: $(SCHEMA_DIR)/%.yaml tdir-jsonschema
 	gen-json-schema $(GEN_OPTS) -t database $< > $@
-
-# This is temporary fix to apply additionalProperties: false gloabally
-# see: https://github.com/linkml/linkml/issues/106
-	jq '. += {"additionalProperties": false}' $@ > $@.tmp && mv $@.tmp $@
-
+	
 ###  -- Shex --
 # one file per module
 gen-shex: $(patsubst %, target/shex/%.shex, $(SCHEMA_NAMES))

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SCHEMA_NAMES = $(patsubst $(SCHEMA_DIR)/%.yaml, %, $(SOURCE_FILES))
 SCHEMA_NAME = nmdc
 SCHEMA_SRC = $(SCHEMA_DIR)/$(SCHEMA_NAME).yaml
 #TGTS = graphql jsonschema docs shex owl csv  python
-TGTS = jsonschema python docs
+TGTS = jsonschema jsonld-context python docs
 
 #GEN_OPTS = --no-mergeimports
 GEN_OPTS =
@@ -32,6 +32,7 @@ install:
 
 tdir-%:
 	mkdir -p target/$*
+
 docs:
 	mkdir $@
 
@@ -76,6 +77,10 @@ target/jsonschema/%.schema.json: $(SCHEMA_DIR)/%.yaml tdir-jsonschema
 	pipenv run gen-json-schema $(GEN_OPTS) --closed -t database $< > $@
 
 ###  -- JSONLD Context --
+gen-jsonld-context: target/jsonld-context/$(SCHEMA_NAME).context.jsonld
+.PHONY: gen-jsonld-context
+target/jsonld-context/%.context.jsonld: $(SCHEMA_DIR)/%.yaml tdir-jsonld-context
+	pipenv run gen-jsonld-context $(GEN_OPTS) $< > $@
 
 ###  -- Shex --
 # one file per module

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+linkml = ">=1.0.3"
+jq = "*"
+mkdocs = "*"
+twine = "*"
+build = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,826 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "71476433102655ec01788ef5855de2bf6409810c0b3b21a3fe4ab36700a5ce95"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "antlr4-python3-runtime": {
+            "hashes": [
+                "sha256:31f5abdc7faf16a1a6e9bf2eb31565d004359b821b09944436a34361929ae85a"
+            ],
+            "version": "==4.9.2"
+        },
+        "argparse": {
+            "hashes": [
+                "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4",
+                "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314"
+            ],
+            "version": "==1.4.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:306483a5a9795474160ad57fce3ddd1b50551e981eed8e15a582d34cef28aafa",
+                "sha256:ae976d7174bba988c0b632def82fdc94235756edfb14e6558a9c5be555c9fb78"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==3.3.1"
+        },
+        "build": {
+            "hashes": [
+                "sha256:0281eeec2697ee43114eb4fe3ba6e54c111ee2c4ef287b5cd24f82cb24cc1bdb",
+                "sha256:16897cac845b50cca04f3c92cf8d3e9e0868b21b29b96b577333c14473baa916"
+            ],
+            "index": "pypi",
+            "version": "==0.5.1"
+        },
+        "cachetools": {
+            "hashes": [
+                "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001",
+                "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"
+            ],
+            "markers": "python_version ~= '3.5'",
+            "version": "==4.2.2"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:2bbf76fd432960138b3ef6dda3dde0544f27cbf8546c458e60baf371917ba9ee",
+                "sha256:50b1e4f8446b06f41be7dd6338db18e0990601dce795c2b1686458aa7e8fa7d8"
+            ],
+            "version": "==2021.5.30"
+        },
+        "cfgraph": {
+            "hashes": [
+                "sha256:b57fe7044a10b8ff65aa3a8a8ddc7d4cd77bf511b42e57289cd52cbc29f8fe74"
+            ],
+            "version": "==0.2.1"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:88fce3fa5b1a84fdcb3f603d889f723d1dd89b26059d0123ca435570e848d5e1",
+                "sha256:c46c3ace2d744cfbdebceaa3c19ae691f53ae621b39fd7570f59d14fb7f2fd12"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==2.0.3"
+        },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
+                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.4.4"
+        },
+        "deprecated": {
+            "hashes": [
+                "sha256:08452d69b6b5bc66e8330adde0a4f8642e969b9e1702904d137eeb29c8ffc771",
+                "sha256:6d2de2de7931a968874481ef30208fd4e08da39177d61d3d4ebdf4366e7dbca1"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.2.12"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125",
+                "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.17.1"
+        },
+        "frozendict": {
+            "hashes": [
+                "sha256:163c616188beb97fdc8ef6e73ec2ebd70a844d4cf19d2e383aa94d1b8376653d",
+                "sha256:58143e2d3d11699bc295d9e7e05f10dde99a727e2295d7f43542ecdc42c5ec70"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.3"
+        },
+        "ghp-import": {
+            "hashes": [
+                "sha256:753de2eace6e0f7d4edfb3cce5e3c3b98cd52aadb80163303d1d036bda7b4483"
+            ],
+            "version": "==2.0.1"
+        },
+        "graphviz": {
+            "hashes": [
+                "sha256:5dadec94046d82adaae6019311a30e0487536d9d5a60d85451f0ba32f9fc6559",
+                "sha256:ef6e2c5deb9cdcc0c7eece1d89625fd07b0f2208ea2bcb483520907ddf8b4e12"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.17"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:03f28a5ea20201e70ab70518d151116ce939b412961c33827519ce620957d44c",
+                "sha256:06d7ac89e6094a0a8f8dc46aa61898e9e1aec79b0f8b47b2400dd51a44dbc832",
+                "sha256:06ecb43b04480e6bafc45cb1b4b67c785e183ce12c079473359e04a709333b08",
+                "sha256:096cb0217d1505826ba3d723e8981096f2622cde1eb91af9ed89a17c10aa1f3e",
+                "sha256:0c557c809eeee215b87e8a7cbfb2d783fb5598a78342c29ade561440abae7d22",
+                "sha256:0de64d419b1cb1bfd4ea544bedea4b535ef3ae1e150b0f2609da14bbf48a4a5f",
+                "sha256:14927b15c953f8f2d2a8dffa224aa78d7759ef95284d4c39e1745cf36e8cdd2c",
+                "sha256:16183fa53bc1a037c38d75fdc59d6208181fa28024a12a7f64bb0884434c91ea",
+                "sha256:206295d270f702bc27dbdbd7651e8ebe42d319139e0d90217b2074309a200da8",
+                "sha256:22002259e5b7828b05600a762579fa2f8b33373ad95a0ee57b4d6109d0e589ad",
+                "sha256:2325123ff3a8ecc10ca76f062445efef13b6cf5a23389e2df3c02a4a527b89bc",
+                "sha256:258f9612aba0d06785143ee1cbf2d7361801c95489c0bd10c69d163ec5254a16",
+                "sha256:3096286a6072553b5dbd5efbefc22297e9d06a05ac14ba017233fedaed7584a8",
+                "sha256:3d13da093d44dee7535b91049e44dd2b5540c2a0e15df168404d3dd2626e0ec5",
+                "sha256:408071b64e52192869129a205e5b463abda36eff0cebb19d6e63369440e4dc99",
+                "sha256:598bcfd841e0b1d88e32e6a5ea48348a2c726461b05ff057c1b8692be9443c6e",
+                "sha256:5d928e2e3c3906e0a29b43dc26d9b3d6e36921eee276786c4e7ad9ff5665c78a",
+                "sha256:5f75e7f237428755d00e7460239a2482fa7e3970db56c8935bd60da3f0733e56",
+                "sha256:60848099b76467ef09b62b0f4512e7e6f0a2c977357a036de602b653667f5f4c",
+                "sha256:6b1d08f2e7f2048d77343279c4d4faa7aef168b3e36039cba1917fffb781a8ed",
+                "sha256:70bd1bb271e9429e2793902dfd194b653221904a07cbf207c3139e2672d17959",
+                "sha256:76ed710b4e953fc31c663b079d317c18f40235ba2e3d55f70ff80794f7b57922",
+                "sha256:7920e3eccd26b7f4c661b746002f5ec5f0928076bd738d38d894bb359ce51927",
+                "sha256:7db68f15486d412b8e2cfcd584bf3b3a000911d25779d081cbbae76d71bd1a7e",
+                "sha256:8833e27949ea32d27f7e96930fa29404dd4f2feb13cce483daf52e8842ec246a",
+                "sha256:944fbdd540712d5377a8795c840a97ff71e7f3221d3fddc98769a15a87b36131",
+                "sha256:9a6b035aa2c5fcf3dbbf0e3a8a5bc75286fc2d4e6f9cfa738788b433ec894919",
+                "sha256:9bdcff4b9051fb1aa4bba4fceff6a5f770c6be436408efd99b76fc827f2a9319",
+                "sha256:a9017ff5fc2522e45562882ff481128631bf35da444775bc2776ac5c61d8bcae",
+                "sha256:aa4230234d02e6f32f189fd40b59d5a968fe77e80f59c9c933384fe8ba535535",
+                "sha256:ad80bb338cf9f8129c049837a42a43451fc7c8b57ad56f8e6d32e7697b115505",
+                "sha256:adb94a28225005890d4cf73648b5131e885c7b4b17bc762779f061844aabcc11",
+                "sha256:b3090631fecdf7e983d183d0fad7ea72cfb12fa9212461a9b708ff7907ffff47",
+                "sha256:b33b51ab057f8a20b497ffafdb1e79256db0c03ef4f5e3d52e7497200e11f821",
+                "sha256:b97c9a144bbeec7039cca44df117efcbeed7209543f5695201cacf05ba3b5857",
+                "sha256:be13a18cec649ebaab835dff269e914679ef329204704869f2f167b2c163a9da",
+                "sha256:be9768e56f92d1d7cd94185bab5856f3c5589a50d221c166cc2ad5eb134bd1dc",
+                "sha256:c1580087ab493c6b43e66f2bdd165d9e3c1e86ef83f6c2c44a29f2869d2c5bd5",
+                "sha256:c35872b2916ab5a240d52a94314c963476c989814ba9b519bc842e5b61b464bb",
+                "sha256:c70c7dd733a4c56838d1f1781e769081a25fade879510c5b5f0df76956abfa05",
+                "sha256:c767458511a59f6f597bfb0032a1c82a52c29ae228c2c0a6865cfeaeaac4c5f5",
+                "sha256:c87df8ae3f01ffb4483c796fe1b15232ce2b219f0b18126948616224d3f658ee",
+                "sha256:ca1c4a569232c063615f9e70ff9a1e2fee8c66a6fb5caf0f5e8b21a396deec3e",
+                "sha256:cc407b68e0a874e7ece60f6639df46309376882152345508be94da608cc0b831",
+                "sha256:da862b8f7de577bc421323714f63276acb2f759ab8c5e33335509f0b89e06b8f",
+                "sha256:dfe7eac0d253915116ed0cd160a15a88981a1d194c1ef151e862a5c7d2f853d3",
+                "sha256:ed1377feed808c9c1139bdb6a61bcbf030c236dd288d6fca71ac26906ab03ba6",
+                "sha256:f42ad188466d946f1b3afc0a9e1a266ac8926461ee0786c06baac6bd71f8a6f3",
+                "sha256:f92731609d6625e1cc26ff5757db4d32b6b810d2a3363b0ff94ff573e5901f6f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.1.0"
+        },
+        "hbreader": {
+            "hashes": [
+                "sha256:9a6e76c9d1afc1b977374a5dc430a1ebb0ea0488205546d4678d6e31cc5f6801",
+                "sha256:d2c132f8ba6276d794c66224c3297cec25c8079d0a4cf019c061611e0a3b94fa"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.9.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a",
+                "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
+            ],
+            "markers": "python_version >= '3'",
+            "version": "==3.2"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:079ada16b7fc30dfbb5d13399a5113110dab1aa7c2bc62f66af75f0b717c8cac",
+                "sha256:9f55f560e116f8643ecf2922d9cd3e1c7e8d52e683178fecd9d08f6aa357e11e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.6.1"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.1"
+        },
+        "jq": {
+            "hashes": [
+                "sha256:03e17e9dcb906c3b10df5c675acebaccff3e61060dca3d5b3d60f35c2af38f8c",
+                "sha256:077bb47273e98e3d4f903909d35eb0f0499a942e488bd74aeef21ba29369cd1e",
+                "sha256:09bba3037b7dd667b9630e3b3d5b2d755a89a8751de302c6580aa0b551de8434",
+                "sha256:0e67d9723342fd1a09a8f0c7e64973e697ccfd611e049c65a5533eea7089a623",
+                "sha256:2437f3742ea7a33d8c259c9718811c54f0bfded5b06baf2efa9a12a0c2134d19",
+                "sha256:2a92329fb345476477377a3fb968ae1993544a08c10ed17e494d185cde465cf5",
+                "sha256:2d8cfdafbde9be2a970b34d8f47af0a57dd86238f2514e7706bdd8d49e989e94",
+                "sha256:392c5718c7b642e882a12e0d15cc52c59bc9b3e21c8b39330c10d052e3835abe",
+                "sha256:475a2a348f08b4be11638a6af3ae2799f9f266da65c81eb08b7c417bd3efcb06",
+                "sha256:47a10543439512c943376736ae53664f1a6a28d06c4e663c67f77dcc2153a341",
+                "sha256:4de997046cf7cc78e264ce2fac25b6df4350cc543e666541cc602046b107478e",
+                "sha256:53024d227e50d13d81cbd5288085ae5d7881c05f957951a16388f1723633961f",
+                "sha256:544a18a39cc123699f894486f74681a19d7e407660c42aa78967497d021b7b23",
+                "sha256:594f660f97ef71bd2aa112a285246da11f11b54a21af4af5c567cd29853dd273",
+                "sha256:5ed01ec10241460f5f78a08aa05da3b740037f9c840c4f6c8e9a79f7aeaf2f1c",
+                "sha256:5efccce1c9653ef8893b4b9cdbfe8049dbe8b0c80fc143eb3cd3503056dbc9a0",
+                "sha256:6c90e2e93256d53fd41318f5e835a31c49a458e8866d46685a40f06537e6833d",
+                "sha256:7367f67e8f232587694cd1840bf7dbfc59b1204caec5620a77b68a53c7770ddf",
+                "sha256:76bf0aacd04584ea72555dc1c61803ccb8c76f55b5910cc15e328513cbae3a04",
+                "sha256:81dad8a1768d40cbb8b523422b1ac8e618e66588974891ad72696943a8c50762",
+                "sha256:8e68a254216dbf343c9c2a240e17b28aecbe9987b557d396bf95bdda3ece82b1",
+                "sha256:8fcf5042228c7a7c8573b2de8ddfc427b2f4c5633e5eb96e07b7351ad01c8ce2",
+                "sha256:9576faff90a7cf0c04c2b7d5c3b3c72e8ed7fc428e434fa8ba40994c1f92fcd4",
+                "sha256:995ce5a147879a84f7689462c49469ce4353e7b8f64eba46ead569343901009c",
+                "sha256:a1d3df8221e393dcfa70b566b44ac36d51701bd85eeba05fd17336320d499c0f",
+                "sha256:a876e74391c3e1e402304b9421f99ff8187c71e1f250ae52138f93ff9c82239a",
+                "sha256:af4cf18ab201f6f8fcdce3611f0a0c09910d70e794796a9232705619e432d2cc",
+                "sha256:b42490d80c5a8d46ade11f39a9e5353e893208dea66c3e434c483ab916372070",
+                "sha256:bae856359ad00306424c026767fef6843dc680ce5c1d3352f762bb2432e49513",
+                "sha256:be94ac6eabad84fedc198380fcad04adfe879d8b64ca09e0dab9a6770b55c583",
+                "sha256:c14f3803955f9e80795d5c630b9c0b7b1d3601b90721bad1645c624878783039",
+                "sha256:c4691b058ed4f390ef8bfbbf3abfcb3afe60d6e91e6da43a6bab972d9b7b9907",
+                "sha256:d09a150e18246d7245347011de6b711e9e1ec5abb00fb2baa9c96c810e10afb6",
+                "sha256:d23d16f3d216da74136d9102ebeb0514a1e64b9ca71bcb4e23389e229a975faa",
+                "sha256:db4ad30759b0a33bb3f2dbf4a5f4d7e2a3ff9c363ed7bf32f5a8cd79bace82b6",
+                "sha256:e2d96a54978055159bdc338bb6ddf589d171643d7f54bda2d54c5a0309bdaed6",
+                "sha256:e60a31097d34659a13581fbae07f207c4fcf9a302754476be19521c886858f5e",
+                "sha256:ed1117b5eda08821bf8084a7cab5ee4b010f96afa3663290ebfcf24da7682d4f",
+                "sha256:eee674fc6b647ddf9c981ddad9826eee6149a0760fafd6531818b3ca1040ca61",
+                "sha256:f628b1fc32e3c5121aa15e1d72827fd167e404b9a53372c8fb94b2b72c919c30",
+                "sha256:f8a250c94f16b84e632090050bd2e8170628755bb3d97e93059e9dd6f83c5e06",
+                "sha256:f9568fb1344fba6e298cc03f09425caac3d076e1509c6b06bb78eb34b975bc10",
+                "sha256:f9ec1dfa7f9875b04495f3e08e85ee96f37a3b843e5bca738a3300732865dde7",
+                "sha256:fac8e8a20415469470d38e209cf7c87ac91cac9d5234b2ea3e22e83ca97ed7ef"
+            ],
+            "index": "pypi",
+            "version": "==1.1.3"
+        },
+        "jsonasobj": {
+            "hashes": [
+                "sha256:b9e329dc1ceaae7cf5d5b214684a0b100e0dad0be6d5bbabac281ec35ddeca65",
+                "sha256:d52e0544a54a08f6ea3f77fa3387271e3648655e0eace2f21e825c26370e44a2"
+            ],
+            "version": "==1.3.1"
+        },
+        "jsonasobj2": {
+            "hashes": [
+                "sha256:12e86f86324d54fcf60632db94ea74488d5314e3da554c994fe1e2c6f29acb79",
+                "sha256:f50b1668ef478004aa487b2d2d094c304e5cb6b79337809f4a1f2975cc7fbb4e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.4"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163",
+                "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"
+            ],
+            "version": "==3.2.0"
+        },
+        "keyring": {
+            "hashes": [
+                "sha256:045703609dd3fccfcdb27da201684278823b72af515aedec1a8515719a038cb8",
+                "sha256:8f607d7d1cc502c43a932a275a56fe47db50271904513a379d39df1af277ac48"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==23.0.1"
+        },
+        "linkml": {
+            "hashes": [
+                "sha256:1e615f6a2a01ce6a5315ed0d1063960b984d39070f9a0b9454596f661335ecbe",
+                "sha256:a6479b71d1563a3f8336b0bcd8c4b4112d0cf83ae51dd8c1d0448e556b9b7671"
+            ],
+            "index": "pypi",
+            "version": "==1.0.3"
+        },
+        "linkml-runtime": {
+            "hashes": [
+                "sha256:aa7e11e64d4c20f3a5e7d3495488f73a196102b0fe52033fc28169f16f4057b2",
+                "sha256:f1d8826dffcfd19147df2e51ce7af829637086f9b5891619174a5c5593608001"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.11"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:079f3ae844f38982d156efce585bc540c16a926d4436712cf4baee0cce487a3d",
+                "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3",
+                "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2",
+                "sha256:1b38116b6e628118dea5b2186ee6820ab138dbb1e24a13e478490c7db2f326ae",
+                "sha256:1b7584d421d254ab86d4f0b13ec662a9014397678a7c4265a02a6d7c2b18a75f",
+                "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927",
+                "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3",
+                "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7",
+                "sha256:3082c518be8e97324390614dacd041bb1358c882d77108ca1957ba47738d9d59",
+                "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f",
+                "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade",
+                "sha256:36108c73739985979bf302006527cf8a20515ce444ba916281d1c43938b8bb96",
+                "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468",
+                "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b",
+                "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4",
+                "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354",
+                "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83",
+                "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04",
+                "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16",
+                "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791",
+                "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a",
+                "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51",
+                "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1",
+                "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a",
+                "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f",
+                "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee",
+                "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec",
+                "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969",
+                "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28",
+                "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a",
+                "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa",
+                "sha256:bc4313cbeb0e7a416a488d72f9680fffffc645f8a838bd2193809881c67dd106",
+                "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d",
+                "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617",
+                "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4",
+                "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92",
+                "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0",
+                "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4",
+                "sha256:d916d31fd85b2f78c76400d625076d9124de3e4bda8b016d25a050cc7d603f24",
+                "sha256:df7c53783a46febb0e70f6b05df2ba104610f2fb0d27023409734a3ecbb78fb2",
+                "sha256:e1cbd3f19a61e27e011e02f9600837b921ac661f0c40560eefb366e4e4fb275e",
+                "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0",
+                "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654",
+                "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2",
+                "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23",
+                "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.6.3"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:31b5b491868dcc87d6c24b7e3d19a0d730d59d3e46f4eea6430a321bed387a49",
+                "sha256:96c3ba1261de2f7547b46a00ea8463832c921d3f9d6aba3f255a6f71386db20c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.4"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.1"
+        },
+        "mergedeep": {
+            "hashes": [
+                "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8",
+                "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.3.4"
+        },
+        "mkdocs": {
+            "hashes": [
+                "sha256:a334f5bd98ec960638511366eb8c5abc9c99b9083a0ed2401d8791b112d6b078",
+                "sha256:d019ff8e17ec746afeb54eb9eb4112b5e959597aebc971da46a5c9486137f0ff"
+            ],
+            "index": "pypi",
+            "version": "==1.2.2"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
+        },
+        "parse": {
+            "hashes": [
+                "sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b"
+            ],
+            "version": "==1.19.0"
+        },
+        "pep517": {
+            "hashes": [
+                "sha256:3fa6b85b9def7ba4de99fb7f96fe3f02e2d630df8aa2720a5cf3b183f087a738",
+                "sha256:e1ba5dffa3a131387979a68ff3e391ac7d645be409216b961bc2efe6468ab0b2"
+            ],
+            "version": "==0.11.0"
+        },
+        "pkginfo": {
+            "hashes": [
+                "sha256:37ecd857b47e5f55949c41ed061eb51a0bee97a87c969219d144c0e023982779",
+                "sha256:e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd"
+            ],
+            "version": "==1.7.1"
+        },
+        "prefixcommons": {
+            "hashes": [
+                "sha256:2ff99e9f2c27f41e6beb831742ca88ddae129b2de6dcc81b0b27f0de69cb2e8a",
+                "sha256:a4a6decd6c1a2497b2b10193fa4ed69ed91cea20deb3a9781815b6bf3f3e1003",
+                "sha256:f820dc69f0eba1f6fd80bdb2e78420e4970f20dfb4c307fed77c607198ca69f2"
+            ],
+            "version": "==0.1.9"
+        },
+        "prologterms": {
+            "hashes": [
+                "sha256:9b8f6272dcae5a0a9257daa41cd455d5b060147486cea36623f91a3226a656e9",
+                "sha256:c63cfc291ccfa3e2eeea89eed93bc7fc0214a1f2d748a200de0a5fdd90e0426a"
+            ],
+            "version": "==0.0.6"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:a18f47b506a429f6f4b9df81bb02beab9ca21d0a5fee38ed15aef65f0545519f",
+                "sha256:d66e804411278594d764fc69ec36ec13d9ae9147193a1740cd34d272ca383b8e"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==2.9.0"
+        },
+        "pyjsg": {
+            "hashes": [
+                "sha256:08d9a80f6996af8862e8a2a4e2d90049af695c4ccd84187e7d7a48f600d37952",
+                "sha256:3c98d3153a2e4ca8ae8942a4bb213477c68519b145ca2d973648bcb9495208e7"
+            ],
+            "version": "==0.11.6"
+        },
+        "pyldmod": {
+            "hashes": [
+                "sha256:afe7515a4c2b53bbff436c93af128599b4f52791cc71e34baecb7662c694feed"
+            ],
+            "version": "==2.0.5"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2",
+                "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7",
+                "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea",
+                "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426",
+                "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710",
+                "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1",
+                "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396",
+                "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2",
+                "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680",
+                "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35",
+                "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427",
+                "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b",
+                "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b",
+                "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f",
+                "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef",
+                "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c",
+                "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4",
+                "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d",
+                "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78",
+                "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b",
+                "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.18.0"
+        },
+        "pyshex": {
+            "hashes": [
+                "sha256:3ea61c2a3f7436bac725bd5001072ba08d2dff5b836d5388ce9ff6f5251c2707",
+                "sha256:6c9cecd7726461c2105330a9b2d5fd054f0e7966bfc9e3a73e7136b8be63d089"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.7.20"
+        },
+        "pyshexc": {
+            "hashes": [
+                "sha256:6f75e26dfda605c994031a72ca74b2b0079e1f7b12ab713e030078d8fa05dc3a",
+                "sha256:ad83bb2a645f64becbf946d4bd170e35fd9b903616c7ee25d5a4ed188cf2d1dd"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.8.3"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==5.4.1"
+        },
+        "pyyaml-env-tag": {
+            "hashes": [
+                "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb",
+                "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.1"
+        },
+        "rdflib": {
+            "hashes": [
+                "sha256:78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155",
+                "sha256:88208ea971a87886d60ae2b1a4b2cdc263527af0454c422118d43fe64b357877"
+            ],
+            "version": "==5.0.0"
+        },
+        "rdflib-jsonld": {
+            "hashes": [
+                "sha256:4f7d55326405071c7bce9acf5484643bcb984eadb84a6503053367da207105ed"
+            ],
+            "version": "==0.5.0"
+        },
+        "rdflib-pyldmod-compat": {
+            "hashes": [
+                "sha256:68aa05d4f4d8f46241e0c37e631b4747f18a356d8accc5bae204350d2f314196",
+                "sha256:bfba0064d8b2584afdbef5d54bac3ac1dd4c13b64aaeba7a43812c2f35ca13c6"
+            ],
+            "version": "==0.1.2"
+        },
+        "readme-renderer": {
+            "hashes": [
+                "sha256:63b4075c6698fcfa78e584930f07f39e05d46f3ec97f65006e430b595ca6348c",
+                "sha256:92fd5ac2bf8677f310f3303aa4bce5b9d5f9f2094ab98c29f13791d7b805a3db"
+            ],
+            "version": "==29.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==2.26.0"
+        },
+        "requests-toolbelt": {
+            "hashes": [
+                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
+                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+            ],
+            "version": "==0.9.1"
+        },
+        "rfc3986": {
+            "hashes": [
+                "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835",
+                "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"
+            ],
+            "version": "==1.5.0"
+        },
+        "shexjsg": {
+            "hashes": [
+                "sha256:788991c4df2ca9b24258fb68c94107c3e140c70bbe398fb15f00338d2a9155e5",
+                "sha256:89fb39a4448f50fd4988108a0a2c7096aa51dd15cd89fef0bc3ad96e04929929"
+            ],
+            "version": "==0.7.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "sparqlslurper": {
+            "hashes": [
+                "sha256:0808cf53923c9ffbf069f80310c73a41d3ae170c266d805b56b6978a066f63e3",
+                "sha256:e1decb006837c5b8f1f404710d86a36a6cd09301910c79165094a1354ddae487"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.4.1"
+        },
+        "sparqlwrapper": {
+            "hashes": [
+                "sha256:17ec44b08b8ae2888c801066249f74fe328eec25d90203ce7eadaf82e64484c7",
+                "sha256:357ee8a27bc910ea13d77836dbddd0b914991495b8cc1bf70676578155e962a8",
+                "sha256:8cf6c21126ed76edc85c5c232fd6f77b9f61f8ad1db90a7147cdde2104aff145",
+                "sha256:c7f9c9d8ebb13428771bc3b6dee54197422507dcc3dea34e30d5dcfc53478dec",
+                "sha256:d6a66b5b8cda141660e07aeb00472db077a98d22cb588c973209c7336850fb3c"
+            ],
+            "version": "==1.8.5"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:09dbb4bc01a734ccddbf188deb2a69aede4b3c153a72b6d5c6900be7fb2945b1",
+                "sha256:12bac5fa1a6ea870bdccb96fe01610641dd44ebe001ed91ef7fcd980e9702db5",
+                "sha256:1fdae7d980a2fa617d119d0dc13ecb5c23cc63a8b04ffcb5298f2c59d86851e9",
+                "sha256:26daa429f039e29b1e523bf763bfab17490556b974c77b5ca7acb545b9230e9a",
+                "sha256:36a089dc604032d41343d86290ce85d4e6886012eea73faa88001260abf5ff81",
+                "sha256:39b5d36ab71f73c068cdcf70c38075511de73616e6c7fdd112d6268c2704d9f5",
+                "sha256:4014978de28163cd8027434916a92d0f5bb1a3a38dff5e8bf8bff4d9372a9117",
+                "sha256:44d23ea797a5e0be71bc5454b9ae99158ea0edc79e2393c6e9a2354de88329c0",
+                "sha256:488608953385d6c127d2dcbc4b11f8d7f2f30b89f6bd27c01b042253d985cc2f",
+                "sha256:5102b9face693e8b2db3b2539c7e1a5d9a5b4dc0d79967670626ffd2f710d6e6",
+                "sha256:5908ea6c652a050d768580d01219c98c071e71910ab8e7b42c02af4010608397",
+                "sha256:5d856cc50fd26fc8dd04892ed5a5a3d7eeb914fea2c2e484183e2d84c14926e0",
+                "sha256:68393d3fd31469845b6ba11f5b4209edbea0b58506be0e077aafbf9aa2e21e11",
+                "sha256:6a16c7c4452293da5143afa3056680db2d187b380b3ef4d470d4e29885720de3",
+                "sha256:756f5d2f5b92d27450167247fb574b09c4cd192a3f8c2e493b3e518a204ee543",
+                "sha256:891927a49b2363a4199763a9d436d97b0b42c65922a4ea09025600b81a00d17e",
+                "sha256:9bfe882d5a1bbde0245dca0bd48da0976bd6634cf2041d2fdf0417c5463e40e5",
+                "sha256:9fcbb4b4756b250ed19adc5e28c005b8ed56fdb5c21efa24c6822c0575b4964d",
+                "sha256:a00d9c6d3a8afe1d1681cd8a5266d2f0ed684b0b44bada2ca82403b9e8b25d39",
+                "sha256:a5e14cb0c0a4ac095395f24575a0e7ab5d1be27f5f9347f1762f21505e3ba9f1",
+                "sha256:b48148ceedfb55f764562e04c00539bb9ea72bf07820ca15a594a9a049ff6b0e",
+                "sha256:b7fb937c720847879c7402fe300cfdb2aeff22349fa4ea3651bca4e2d6555939",
+                "sha256:bc34a007e604091ca3a4a057525efc4cefd2b7fe970f44d20b9cfa109ab1bddb",
+                "sha256:c9373ef67a127799027091fa53449125351a8c943ddaa97bec4e99271dbb21f4",
+                "sha256:d09a760b0a045b4d799102ae7965b5491ccf102123f14b2a8cc6c01d1021a2d9",
+                "sha256:ec1be26cdccd60d180359a527d5980d959a26269a2c7b1b327a1eea0cab37ed8",
+                "sha256:eedd76f135461cf237534a6dc0d1e0f6bb88a1dc193678fab48a11d223462da5",
+                "sha256:f028ef6a1d828bc754852a022b2160e036202ac8658a6c7d34875aafd14a9a15",
+                "sha256:f814d80844969b0d22ea63663da4de5ca1c434cfbae226188901e5d368792c17",
+                "sha256:fd2102a8f8a659522719ed73865dff3d3cc76eb0833039dc473e0ad3041d04be"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.4.22"
+        },
+        "testfixtures": {
+            "hashes": [
+                "sha256:9bddf79b2dddb36420a20c25a65c827a8e7398c6ed4e2c75c2697857cb006be9",
+                "sha256:d4bd1c4f90eac90a73e1bdc59c31d03943f218d687f3c5a09e48478841a8af5f"
+            ],
+            "version": "==6.18.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:33d7984738f8bb699c9b0a816eb646a8178a69eaa792d258486776a5d21b8ca5",
+                "sha256:f4a182048010e89cbec0ae4686b21f550a7f2903f665e34a6de58ec15424f919"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.1.0"
+        },
+        "tqdm": {
+            "hashes": [
+                "sha256:5aa445ea0ad8b16d82b15ab342de6b195a722d75fc1ef9934a46bba6feafbc64",
+                "sha256:8bb94db0d4468fea27d004a0f1d1c02da3cdedc00fe491c0de986b76a04d6b0a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.61.2"
+        },
+        "twine": {
+            "hashes": [
+                "sha256:087328e9bb405e7ce18527a2dca4042a84c7918658f951110b38bc135acab218",
+                "sha256:4caec0f1ed78dc4c9b83ad537e453d03ce485725f2aea57f1bb3fdde78dae936"
+            ],
+            "index": "pypi",
+            "version": "==3.4.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.6"
+        },
+        "watchdog": {
+            "hashes": [
+                "sha256:0bcdf7b99b56a3ae069866c33d247c9994ffde91b620eaf0306b27e099bd1ae0",
+                "sha256:0bcfe904c7d404eb6905f7106c54873503b442e8e918cc226e1828f498bdc0ca",
+                "sha256:201cadf0b8c11922f54ec97482f95b2aafca429c4c3a4bb869a14f3c20c32686",
+                "sha256:3a7d242a7963174684206093846537220ee37ba9986b824a326a8bb4ef329a33",
+                "sha256:3e305ea2757f81d8ebd8559d1a944ed83e3ab1bdf68bcf16ec851b97c08dc035",
+                "sha256:431a3ea70b20962e6dee65f0eeecd768cd3085ea613ccb9b53c8969de9f6ebd2",
+                "sha256:44acad6f642996a2b50bb9ce4fb3730dde08f23e79e20cd3d8e2a2076b730381",
+                "sha256:54e057727dd18bd01a3060dbf5104eb5a495ca26316487e0f32a394fd5fe725a",
+                "sha256:6fe9c8533e955c6589cfea6f3f0a1a95fb16867a211125236c82e1815932b5d7",
+                "sha256:85b851237cf3533fabbc034ffcd84d0fa52014b3121454e5f8b86974b531560c",
+                "sha256:8805a5f468862daf1e4f4447b0ccf3acaff626eaa57fbb46d7960d1cf09f2e6d",
+                "sha256:9628f3f85375a17614a2ab5eac7665f7f7be8b6b0a2a228e6f6a2e91dd4bfe26",
+                "sha256:a12539ecf2478a94e4ba4d13476bb2c7a2e0a2080af2bb37df84d88b1b01358a",
+                "sha256:acc4e2d5be6f140f02ee8590e51c002829e2c33ee199036fcd61311d558d89f4",
+                "sha256:b5fc5c127bad6983eecf1ad117ab3418949f18af9c8758bd10158be3647298a9",
+                "sha256:b8ddb2c9f92e0c686ea77341dcb58216fa5ff7d5f992c7278ee8a392a06e86bb",
+                "sha256:bf84bd94cbaad8f6b9cbaeef43080920f4cb0e61ad90af7106b3de402f5fe127",
+                "sha256:d9456f0433845e7153b102fffeb767bde2406b76042f2216838af3b21707894e",
+                "sha256:e4929ac2aaa2e4f1a30a36751160be391911da463a8799460340901517298b13",
+                "sha256:e5236a8e8602ab6db4b873664c2d356c365ab3cac96fbdec4970ad616415dd45",
+                "sha256:fd8c595d5a93abd441ee7c5bb3ff0d7170e79031520d113d6f401d0cf49d7c8f"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.3"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"
+            ],
+            "version": "==1.12.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:957cfda87797e389580cb8b9e3870841ca991e2125350677b2ca83a0e99390a3",
+                "sha256:f5812b1e007e48cff63449a5e9f4e7ebea716b4111f9c4f9a645f91d579bf0c4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.5.0"
+        }
+    },
+    "develop": {}
+}

--- a/jsonld-context/nmdc.context.jsonld
+++ b/jsonld-context/nmdc.context.jsonld
@@ -1,0 +1,3008 @@
+{
+   "_comments": "Auto generated from nmdc.yaml by jsonldcontextgen.py version: 0.1.1\n    Generation date: 2021-07-29 22:35\n    Schema: NMDC\n    \n    id: https://microbiomedata/schema\n    description: Schema for National Microbiome Data Collaborative (NMDC). This schem is organized into 3 separate modules:\n  \nThis schema is organized into distinct modules:\n  \n * a set of core types for representing data values\n * the mixs schema (auto-translated from mixs excel)\n * annotation schema\n * the NMDC schema itself\n    license: https://creativecommons.org/publicdomain/zero/1.0/\n    ",
+   "@context": {
+      "CAS": "http://identifiers.org/cas/",
+      "CATH": "http://identifiers.org/cath/",
+      "CHEBI": {
+         "@id": "http://purl.obolibrary.org/obo/CHEBI_",
+         "@prefix": true
+      },
+      "CHEMBL.COMPOUND": "http://identifiers.org/chembl.compound/",
+      "COG": "http://example.org/UNKNOWN/COG/",
+      "DRUGBANK": "http://identifiers.org/drugbank/",
+      "EC": "http://example.org/UNKNOWN/EC/",
+      "EGGNOG": "http://identifiers.org/eggnog/",
+      "GO": {
+         "@id": "http://purl.obolibrary.org/obo/GO_",
+         "@prefix": true
+      },
+      "GOLD": "https://identifiers.org/gold/",
+      "HMDB": "http://identifiers.org/hmdb/",
+      "ISA": "http://example.org/UNKNOWN/ISA/",
+      "KEGG.COMPOUND": "http://identifiers.org/kegg.compound/",
+      "KEGG.ORTHOLOGY": "http://identifiers.org/kegg.orthology/",
+      "KEGG.PATHWAY": "http://identifiers.org/kegg.pathway/",
+      "KEGG.REACTION": "http://identifiers.org/kegg.reaction/",
+      "MESH": "http://identifiers.org/mesh/",
+      "MS": {
+         "@id": "http://purl.obolibrary.org/obo/MS_",
+         "@prefix": true
+      },
+      "MetaCyc": "http://example.org/UNKNOWN/MetaCyc/",
+      "MetaNetX": "http://example.org/UNKNOWN/MetaNetX/",
+      "NCIT": {
+         "@id": "http://purl.obolibrary.org/obo/NCIT_",
+         "@prefix": true
+      },
+      "OBI": {
+         "@id": "http://purl.obolibrary.org/obo/OBI_",
+         "@prefix": true
+      },
+      "PANTHER.FAMILY": "http://identifiers.org/panther.family/",
+      "PFAM": "http://identifiers.org/pfam/",
+      "PR": {
+         "@id": "http://purl.obolibrary.org/obo/PR_",
+         "@prefix": true
+      },
+      "PUBCHEM.COMPOUND": "http://identifiers.org/pubchem.compound/",
+      "RHEA": "http://identifiers.org/rhea/",
+      "RO": {
+         "@id": "http://purl.obolibrary.org/obo/RO_",
+         "@prefix": true
+      },
+      "RetroRules": "http://example.org/UNKNOWN/RetroRules/",
+      "SEED": "http://identifiers.org/seed/",
+      "SUPFAM": "http://identifiers.org/supfam/",
+      "TIGRFAM": "http://identifiers.org/tigrfam/",
+      "UniProtKB": "http://example.org/UNKNOWN/UniProtKB/",
+      "biolink": "https://w3id.org/biolink/vocab/",
+      "dcterms": "http://purl.org/dc/terms/",
+      "gtpo": "http://example.org/UNKNOWN/gtpo/",
+      "igsn": "https://app.geosamples.org/sample/igsn/",
+      "insdc.srs": "http://example.org/UNKNOWN/insdc.srs/",
+      "linkml": "https://w3id.org/linkml/",
+      "mgnify": "http://example.org/UNKNOWN/mgnify/",
+      "mixs": "https://w3id.org/gensc/",
+      "nmdc": "https://microbiomedata/meta/",
+      "prov": "http://www.w3.org/ns/prov#",
+      "qud": "http://qudt.org/1.1/schema/qudt#",
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "rdfs": "http://example.org/UNKNOWN/rdfs/",
+      "schema": "http://schema.org/",
+      "sio": {
+         "@id": "http://semanticscience.org/resource/SIO_",
+         "@prefix": true
+      },
+      "skos": "http://www.w3.org/2004/02/skos/core#",
+      "wgs": {
+         "@id": "http://www.w3.org/2003/01/geo/wgs84_pos",
+         "@prefix": true
+      },
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "@vocab": "https://microbiomedata/meta/",
+      "_16s_recover": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/_16s_recover"
+      },
+      "_16s_recover_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/_16s_recover_software"
+      },
+      "abs_air_humidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/abs_air_humidity"
+      },
+      "acted_on_behalf_of": {
+         "@type": "@id"
+      },
+      "activity_set": {
+         "@type": "@id"
+      },
+      "adapters": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/adapters"
+      },
+      "add_recov_method": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/add_recov_method"
+      },
+      "additional_info": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/additional_info"
+      },
+      "address": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/address"
+      },
+      "adj_room": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/adj_room"
+      },
+      "aero_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/aero_struc"
+      },
+      "agrochem_addition": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/agrochem_addition"
+      },
+      "air_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/air_temp"
+      },
+      "air_temp_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/air_temp_regm"
+      },
+      "al_sat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/al_sat"
+      },
+      "al_sat_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/al_sat_meth"
+      },
+      "alkalinity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/alkalinity"
+      },
+      "alkalinity_method": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/alkalinity_method"
+      },
+      "alkyl_diethers": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/alkyl_diethers"
+      },
+      "all_proteins": {
+         "@type": "@id"
+      },
+      "alt": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/alt"
+      },
+      "aminopept_act": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/aminopept_act"
+      },
+      "ammonium": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ammonium"
+      },
+      "amniotic_fluid_color": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/amniotic_fluid_color"
+      },
+      "amount_light": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/amount_light"
+      },
+      "analysis_identifiers": {
+         "@type": "@id"
+      },
+      "ances_data": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ances_data"
+      },
+      "annot": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/annot"
+      },
+      "annual_precpt": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/annual_precpt"
+      },
+      "annual_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/annual_temp"
+      },
+      "antibiotic_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/antibiotic_regm"
+      },
+      "api": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/api"
+      },
+      "arch_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/arch_struc"
+      },
+      "aromatics_pc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/aromatics_pc"
+      },
+      "asm_score": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/asm_score"
+      },
+      "asphaltenes_pc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/asphaltenes_pc"
+      },
+      "assembly_name": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/assembly_name"
+      },
+      "assembly_qual": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/assembly_qual"
+      },
+      "assembly_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/assembly_software"
+      },
+      "atmospheric_data": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/atmospheric_data"
+      },
+      "avg_dew_point": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/avg_dew_point"
+      },
+      "avg_occup": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/avg_occup"
+      },
+      "avg_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/avg_temp"
+      },
+      "bac_prod": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bac_prod"
+      },
+      "bac_resp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bac_resp"
+      },
+      "bacteria_carb_prod": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bacteria_carb_prod"
+      },
+      "barometric_press": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/barometric_press"
+      },
+      "basin": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/basin"
+      },
+      "bathroom_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bathroom_count"
+      },
+      "bedroom_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bedroom_count"
+      },
+      "benzene": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/benzene"
+      },
+      "best_protein": {
+         "@type": "@id"
+      },
+      "bin_param": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bin_param"
+      },
+      "bin_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bin_software"
+      },
+      "binned_contig_num": {
+         "@type": "xsd:integer",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/binned_contig_num"
+      },
+      "biochem_oxygen_dem": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biochem_oxygen_dem"
+      },
+      "biocide": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biocide"
+      },
+      "biocide_admin_method": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biocide_admin_method"
+      },
+      "biol_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biol_stat"
+      },
+      "biomass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biomass"
+      },
+      "biosample_set": {
+         "@type": "@id"
+      },
+      "biotic_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biotic_regm"
+      },
+      "biotic_relationship": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/biotic_relationship"
+      },
+      "birth_control": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/birth_control"
+      },
+      "bishomohopanol": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bishomohopanol"
+      },
+      "blood_blood_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/blood_blood_disord"
+      },
+      "bromide": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/bromide"
+      },
+      "build_docs": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/build_docs"
+      },
+      "build_occup_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/build_occup_type"
+      },
+      "building_setting": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/building_setting"
+      },
+      "built_struc_age": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/built_struc_age"
+      },
+      "built_struc_set": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/built_struc_set"
+      },
+      "built_struc_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/built_struc_type"
+      },
+      "calcium": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/calcium"
+      },
+      "carb_dioxide": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/carb_dioxide"
+      },
+      "carb_monoxide": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/carb_monoxide"
+      },
+      "carb_nitro_ratio": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/carb_nitro_ratio"
+      },
+      "ceil_area": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_area"
+      },
+      "ceil_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_cond"
+      },
+      "ceil_finish_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_finish_mat"
+      },
+      "ceil_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_struc"
+      },
+      "ceil_texture": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_texture"
+      },
+      "ceil_thermal_mass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_thermal_mass"
+      },
+      "ceil_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_type"
+      },
+      "ceil_water_mold": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ceil_water_mold"
+      },
+      "chem_administration": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chem_administration"
+      },
+      "chem_mutagen": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chem_mutagen"
+      },
+      "chem_oxygen_dem": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chem_oxygen_dem"
+      },
+      "chem_treatment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chem_treatment"
+      },
+      "chem_treatment_method": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chem_treatment_method"
+      },
+      "chemical": {
+         "@type": "@id"
+      },
+      "chimera_check": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chimera_check"
+      },
+      "chloride": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chloride"
+      },
+      "chlorophyll": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/chlorophyll"
+      },
+      "climate_environment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/climate_environment"
+      },
+      "collection_date": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/collection_date"
+      },
+      "compl_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/compl_appr"
+      },
+      "compl_score": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/compl_score"
+      },
+      "compl_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/compl_software"
+      },
+      "conduc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/conduc"
+      },
+      "contam_score": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/contam_score"
+      },
+      "contam_screen_input": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/contam_screen_input"
+      },
+      "contam_screen_param": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/contam_screen_param"
+      },
+      "contig_bp": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/contig_bp"
+      },
+      "contigs": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/contigs"
+      },
+      "cool_syst_id": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/cool_syst_id"
+      },
+      "crop_rotation": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/crop_rotation"
+      },
+      "ctg_L50": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_L50"
+      },
+      "ctg_L90": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_L90"
+      },
+      "ctg_logsum": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_logsum"
+      },
+      "ctg_max": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_max"
+      },
+      "ctg_N50": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_N50"
+      },
+      "ctg_N90": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_N90"
+      },
+      "ctg_powsum": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ctg_powsum"
+      },
+      "cult_root_med": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/cult_root_med"
+      },
+      "cur_land_use": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/cur_land_use"
+      },
+      "cur_vegetation": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/cur_vegetation"
+      },
+      "cur_vegetation_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/cur_vegetation_meth"
+      },
+      "data_object_set": {
+         "@type": "@id"
+      },
+      "data_object_type": {
+         "@context": {
+            "@vocab": "@null",
+            "text": "skos:notation",
+            "description": "skos:prefLabel",
+            "meaning": "@id"
+         }
+      },
+      "date_last_rain": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/date_last_rain"
+      },
+      "decontam_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/decontam_software"
+      },
+      "density": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/density"
+      },
+      "depos_env": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/depos_env"
+      },
+      "depth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/depth"
+      },
+      "depth2": {
+         "@type": "@id"
+      },
+      "dermatology_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/dermatology_disord"
+      },
+      "description": {
+         "@id": "dcterms:description"
+      },
+      "detec_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/detec_type"
+      },
+      "dew_point": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/dew_point"
+      },
+      "diet_last_six_month": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diet_last_six_month"
+      },
+      "diether_lipids": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diether_lipids"
+      },
+      "diss_carb_dioxide": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_carb_dioxide"
+      },
+      "diss_hydrogen": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_hydrogen"
+      },
+      "diss_inorg_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_inorg_carb"
+      },
+      "diss_inorg_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_inorg_nitro"
+      },
+      "diss_inorg_phosp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_inorg_phosp"
+      },
+      "diss_iron": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_iron"
+      },
+      "diss_org_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_org_carb"
+      },
+      "diss_org_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_org_nitro"
+      },
+      "diss_oxygen": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_oxygen"
+      },
+      "diss_oxygen_fluid": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/diss_oxygen_fluid"
+      },
+      "doi": {
+         "@type": "@id"
+      },
+      "dominant_hand": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/dominant_hand"
+      },
+      "door_comp_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_comp_type"
+      },
+      "door_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_cond"
+      },
+      "door_direct": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_direct"
+      },
+      "door_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_loc"
+      },
+      "door_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_mat"
+      },
+      "door_move": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_move"
+      },
+      "door_size": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_size"
+      },
+      "door_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_type"
+      },
+      "door_type_metal": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_type_metal"
+      },
+      "door_type_wood": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_type_wood"
+      },
+      "door_water_mold": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/door_water_mold"
+      },
+      "douche": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/douche"
+      },
+      "down_par": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/down_par"
+      },
+      "drainage_class": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/drainage_class"
+      },
+      "drawings": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/drawings"
+      },
+      "drug_usage": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/drug_usage"
+      },
+      "efficiency_percent": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/efficiency_percent"
+      },
+      "elev": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/elev"
+      },
+      "elevator": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/elevator"
+      },
+      "emulsions": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/emulsions"
+      },
+      "encoded_traits": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/encoded_traits"
+      },
+      "encodes": {
+         "@type": "@id"
+      },
+      "end": {
+         "@type": "xsd:integer"
+      },
+      "env_broad_scale": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/env_broad_scale"
+      },
+      "env_local_scale": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/env_local_scale"
+      },
+      "env_medium": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/env_medium"
+      },
+      "env_package": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/env_package"
+      },
+      "escalator": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/escalator"
+      },
+      "estimated_size": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/estimated_size"
+      },
+      "ethylbenzene": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ethylbenzene"
+      },
+      "exp_duct": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/exp_duct"
+      },
+      "exp_pipe": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/exp_pipe"
+      },
+      "experimental_factor": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/experimental_factor"
+      },
+      "ext_door": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ext_door"
+      },
+      "ext_wall_orient": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ext_wall_orient"
+      },
+      "ext_window_orient": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ext_window_orient"
+      },
+      "external_database_identifiers": {
+         "@type": "@id"
+      },
+      "extrachrom_elements": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/extrachrom_elements"
+      },
+      "extreme_event": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/extreme_event"
+      },
+      "extreme_salinity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/extreme_salinity"
+      },
+      "fao_class": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/fao_class"
+      },
+      "feat_pred": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/feat_pred"
+      },
+      "fertilizer_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/fertilizer_regm"
+      },
+      "field": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/field"
+      },
+      "file_size_bytes": {
+         "@type": "xsd:int"
+      },
+      "filter_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/filter_type"
+      },
+      "fire": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/fire"
+      },
+      "fireplace_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/fireplace_type"
+      },
+      "flooding": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/flooding"
+      },
+      "floor_age": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_age"
+      },
+      "floor_area": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_area"
+      },
+      "floor_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_cond"
+      },
+      "floor_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_count"
+      },
+      "floor_finish_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_finish_mat"
+      },
+      "floor_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_struc"
+      },
+      "floor_thermal_mass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_thermal_mass"
+      },
+      "floor_water_mold": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/floor_water_mold"
+      },
+      "fluor": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/fluor"
+      },
+      "foetal_health_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/foetal_health_stat"
+      },
+      "freq_clean": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/freq_clean"
+      },
+      "freq_cook": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/freq_cook"
+      },
+      "functional_annotation_set": {
+         "@type": "@id"
+      },
+      "fungicide_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/fungicide_regm"
+      },
+      "furniture": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/furniture"
+      },
+      "gap_pct": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/gap_pct"
+      },
+      "gaseous_environment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gaseous_environment"
+      },
+      "gaseous_substances": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gaseous_substances"
+      },
+      "gastrointest_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gastrointest_disord"
+      },
+      "gc_avg": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/gc_avg"
+      },
+      "gc_std": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/gc_std"
+      },
+      "gender_restroom": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gender_restroom"
+      },
+      "genetic_mod": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/genetic_mod"
+      },
+      "genome_feature_set": {
+         "@type": "@id"
+      },
+      "geo_loc_name": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/geo_loc_name"
+      },
+      "gestation_state": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gestation_state"
+      },
+      "gff_coordinate": {
+         "@type": "xsd:integer",
+         "@id": "https://microbiomedata/schema/annotation/gff_coordinate"
+      },
+      "glucosidase_act": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/glucosidase_act"
+      },
+      "GOLD_analysis_project_identifiers": {
+         "@type": "@id"
+      },
+      "GOLD_sample_identifiers": {
+         "@type": "@id"
+      },
+      "GOLD_sequencing_project_identifiers": {
+         "@type": "@id"
+      },
+      "GOLD_study_identifiers": {
+         "@type": "@id"
+      },
+      "gravidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gravidity"
+      },
+      "gravity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gravity"
+      },
+      "growth_facil": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/growth_facil"
+      },
+      "growth_habit": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/growth_habit"
+      },
+      "growth_hormone_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/growth_hormone_regm"
+      },
+      "gynecologic_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/gynecologic_disord"
+      },
+      "hall_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hall_count"
+      },
+      "handidness": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/handidness"
+      },
+      "has_boolean_value": {
+         "@type": "xsd:boolean"
+      },
+      "has_function": {
+         "@id": "https://microbiomedata/schema/annotation/has_function"
+      },
+      "has_input": {
+         "@type": "@id"
+      },
+      "has_metabolite_quantifications": {
+         "@type": "@id"
+      },
+      "has_numeric_value": {
+         "@type": "xsd:float"
+      },
+      "has_output": {
+         "@type": "@id"
+      },
+      "has_participants": {
+         "@id": "https://microbiomedata/schema/annotation/has_participants"
+      },
+      "has_peptide_quantifications": {
+         "@type": "@id"
+      },
+      "has_part": {
+         "@type": "@id"
+      },
+      "hc_produced": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hc_produced"
+      },
+      "hcr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hcr"
+      },
+      "hcr_fw_salinity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hcr_fw_salinity"
+      },
+      "hcr_geol_age": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hcr_geol_age"
+      },
+      "hcr_pressure": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hcr_pressure"
+      },
+      "hcr_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hcr_temp"
+      },
+      "health_disease_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/health_disease_stat"
+      },
+      "heat_cool_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/heat_cool_type"
+      },
+      "heat_deliv_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/heat_deliv_loc"
+      },
+      "heat_system_deliv_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/heat_system_deliv_meth"
+      },
+      "heat_system_id": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/heat_system_id"
+      },
+      "heavy_metals": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/heavy_metals"
+      },
+      "heavy_metals_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/heavy_metals_meth"
+      },
+      "height_carper_fiber": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/height_carper_fiber"
+      },
+      "herbicide_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/herbicide_regm"
+      },
+      "highest_similarity_score": {
+         "@type": "xsd:float"
+      },
+      "horizon": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/horizon"
+      },
+      "horizon_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/horizon_meth"
+      },
+      "host_age": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_age"
+      },
+      "host_blood_press_diast": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_blood_press_diast"
+      },
+      "host_blood_press_syst": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_blood_press_syst"
+      },
+      "host_body_habitat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_body_habitat"
+      },
+      "host_body_mass_index": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_body_mass_index"
+      },
+      "host_body_product": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_body_product"
+      },
+      "host_body_site": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_body_site"
+      },
+      "host_body_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_body_temp"
+      },
+      "host_color": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_color"
+      },
+      "host_common_name": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_common_name"
+      },
+      "host_diet": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_diet"
+      },
+      "host_disease_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_disease_stat"
+      },
+      "host_dry_mass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_dry_mass"
+      },
+      "host_family_relationship": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_family_relationship"
+      },
+      "host_genotype": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_genotype"
+      },
+      "host_growth_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_growth_cond"
+      },
+      "host_height": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_height"
+      },
+      "host_hiv_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_hiv_stat"
+      },
+      "host_infra_specific_name": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_infra_specific_name"
+      },
+      "host_infra_specific_rank": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_infra_specific_rank"
+      },
+      "host_last_meal": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_last_meal"
+      },
+      "host_length": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_length"
+      },
+      "host_life_stage": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_life_stage"
+      },
+      "host_occupation": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_occupation"
+      },
+      "host_phenotype": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_phenotype"
+      },
+      "host_pred_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_pred_appr"
+      },
+      "host_pred_est_acc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_pred_est_acc"
+      },
+      "host_pulse": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_pulse"
+      },
+      "host_sex": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_sex"
+      },
+      "host_shape": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_shape"
+      },
+      "host_spec_range": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_spec_range"
+      },
+      "host_subject_id": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_subject_id"
+      },
+      "host_substrate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_substrate"
+      },
+      "host_taxid": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_taxid"
+      },
+      "host_tot_mass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_tot_mass"
+      },
+      "host_wet_mass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/host_wet_mass"
+      },
+      "hrt": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hrt"
+      },
+      "humidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/humidity"
+      },
+      "humidity_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/humidity_regm"
+      },
+      "hysterectomy": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/hysterectomy"
+      },
+      "id": "@id",
+      "ihmc_ethnicity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ihmc_ethnicity"
+      },
+      "ihmc_medication_code": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ihmc_medication_code"
+      },
+      "indoor_space": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/indoor_space"
+      },
+      "indoor_surf": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/indoor_surf"
+      },
+      "indust_eff_percent": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/indust_eff_percent"
+      },
+      "inorg_particles": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/inorg_particles"
+      },
+      "input_base_count": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/input_base_count"
+      },
+      "input_contig_num": {
+         "@type": "xsd:integer",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/input_contig_num"
+      },
+      "input_read_count": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/input_read_count"
+      },
+      "input_read_bases": {
+         "@type": "xsd:float"
+      },
+      "INSDC_analysis_identifiers": {
+         "@type": "@id"
+      },
+      "INSDC_bioproject_identifiers": {
+         "@type": "@id"
+      },
+      "INSDC_biosample_identifiers": {
+         "@type": "@id"
+      },
+      "INSDC_experiment_identifiers": {
+         "@type": "@id"
+      },
+      "INSDC_secondary_sample_identifiers": {
+         "@type": "@id"
+      },
+      "INSDC_SRA_ENA_study_identifiers": {
+         "@type": "@id"
+      },
+      "inside_lux": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/inside_lux"
+      },
+      "int_wall_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/int_wall_cond"
+      },
+      "investigation_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/investigation_type"
+      },
+      "is_balanced": {
+         "@type": "xsd:boolean"
+      },
+      "is_diastereoselective": {
+         "@type": "xsd:boolean"
+      },
+      "is_fully_characterized": {
+         "@type": "xsd:boolean"
+      },
+      "is_stereo": {
+         "@type": "xsd:boolean"
+      },
+      "is_transport": {
+         "@type": "xsd:boolean"
+      },
+      "isol_growth_condt": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/isol_growth_condt"
+      },
+      "iw_bt_date_well": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/iw_bt_date_well"
+      },
+      "iwf": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/iwf"
+      },
+      "kidney_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/kidney_disord"
+      },
+      "language": {
+         "@type": "xsd:language"
+      },
+      "last_clean": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/last_clean"
+      },
+      "lat_lon": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lat_lon"
+      },
+      "latitude": {
+         "@type": "xsd:decimal",
+         "@id": "wgs:lat"
+      },
+      "left_participants": {
+         "@type": "@id"
+      },
+      "lib_layout": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lib_layout"
+      },
+      "lib_reads_seqd": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lib_reads_seqd"
+      },
+      "lib_screen": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lib_screen"
+      },
+      "lib_size": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lib_size"
+      },
+      "lib_vector": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lib_vector"
+      },
+      "light_intensity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/light_intensity"
+      },
+      "light_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/light_regm"
+      },
+      "light_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/light_type"
+      },
+      "link_addit_analys": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/link_addit_analys"
+      },
+      "link_class_info": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/link_class_info"
+      },
+      "link_climate_info": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/link_climate_info"
+      },
+      "lithology": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/lithology"
+      },
+      "liver_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/liver_disord"
+      },
+      "local_class": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/local_class"
+      },
+      "local_class_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/local_class_meth"
+      },
+      "longitude": {
+         "@type": "xsd:decimal",
+         "@id": "wgs:long"
+      },
+      "lowDepth_contig_num": {
+         "@type": "xsd:integer",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/lowDepth_contig_num"
+      },
+      "mag_cov_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mag_cov_software"
+      },
+      "completeness": {
+         "@type": "xsd:float"
+      },
+      "contamination": {
+         "@type": "xsd:float"
+      },
+      "gene_count": {
+         "@type": "xsd:integer"
+      },
+      "num_16s": {
+         "@type": "xsd:integer"
+      },
+      "num_23s": {
+         "@type": "xsd:integer"
+      },
+      "num_5s": {
+         "@type": "xsd:integer"
+      },
+      "num_tRNA": {
+         "@type": "xsd:integer"
+      },
+      "number_of_contig": {
+         "@type": "xsd:integer"
+      },
+      "magnesium": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/magnesium"
+      },
+      "mags_activity_set": {
+         "@type": "@id"
+      },
+      "mags_list": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/mags_list"
+      },
+      "maternal_health_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/maternal_health_stat"
+      },
+      "max_occup": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/max_occup"
+      },
+      "mean_frict_vel": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mean_frict_vel"
+      },
+      "mean_peak_frict_vel": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mean_peak_frict_vel"
+      },
+      "mech_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mech_struc"
+      },
+      "mechanical_damage": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mechanical_damage"
+      },
+      "medic_hist_perform": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/medic_hist_perform"
+      },
+      "menarche": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/menarche"
+      },
+      "menopause": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/menopause"
+      },
+      "metabolite_quantified": {
+         "@type": "@id"
+      },
+      "metabolomics_analysis_activity_set": {
+         "@type": "@id"
+      },
+      "metagenome_annotation_activity_set": {
+         "@type": "@id"
+      },
+      "metagenome_assembly_parameter": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/metagenome_assembly_parameter"
+      },
+      "metagenome_assembly_set": {
+         "@type": "@id"
+      },
+      "metaproteomics_analysis_activity_set": {
+         "@type": "@id"
+      },
+      "metatranscriptome_activity_set": {
+         "@type": "@id"
+      },
+      "methane": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/methane"
+      },
+      "MGnify_analysis_identifiers": {
+         "@type": "@id"
+      },
+      "MGnify_project_identifiers": {
+         "@type": "@id"
+      },
+      "microbial_biomass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/microbial_biomass"
+      },
+      "microbial_biomass_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/microbial_biomass_meth"
+      },
+      "mid": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mid"
+      },
+      "min_q_value": {
+         "@type": "xsd:float"
+      },
+      "mineral_nutr_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mineral_nutr_regm"
+      },
+      "misc_param": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/misc_param"
+      },
+      "mixs_url": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/mixs_url"
+      },
+      "n_alkanes": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/n_alkanes"
+      },
+      "nitrate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nitrate"
+      },
+      "nitrite": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nitrite"
+      },
+      "nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nitro"
+      },
+      "nom_analysis_activity_set": {
+         "@type": "@id"
+      },
+      "non_mineral_nutr_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/non_mineral_nutr_regm"
+      },
+      "nose_mouth_teeth_throat_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nose_mouth_teeth_throat_disord"
+      },
+      "nose_throat_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nose_throat_disord"
+      },
+      "nucl_acid_amp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nucl_acid_amp"
+      },
+      "nucl_acid_ext": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/nucl_acid_ext"
+      },
+      "num_aligned_reads": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/num_aligned_reads"
+      },
+      "num_input_reads": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/num_input_reads"
+      },
+      "num_replicons": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/num_replicons"
+      },
+      "number_contig": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/number_contig"
+      },
+      "number_pets": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/number_pets"
+      },
+      "number_plants": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/number_plants"
+      },
+      "number_resident": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/number_resident"
+      },
+      "occup_density_samp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/occup_density_samp"
+      },
+      "occup_document": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/occup_document"
+      },
+      "occup_samp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/occup_samp"
+      },
+      "omics_processing_identifiers": {
+         "@type": "@id"
+      },
+      "omics_processing_set": {
+         "@type": "@id"
+      },
+      "omics_type": {
+         "@type": "@id"
+      },
+      "org_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/org_carb"
+      },
+      "org_matter": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/org_matter"
+      },
+      "org_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/org_nitro"
+      },
+      "org_particles": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/org_particles"
+      },
+      "organism_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/organism_count"
+      },
+      "organism_count_qpcr_info": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/organism_count_qpcr_info"
+      },
+      "output_base_count": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/output_base_count"
+      },
+      "output_read_count": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/output_read_count"
+      },
+      "output_read_bases": {
+         "@type": "xsd:float"
+      },
+      "owc_tvdss": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/owc_tvdss"
+      },
+      "oxy_stat_samp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/oxy_stat_samp"
+      },
+      "oxygen": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/oxygen"
+      },
+      "part_of": {
+         "@type": "@id",
+         "@id": "dcterms:isPartOf"
+      },
+      "part_org_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/part_org_carb"
+      },
+      "part_org_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/part_org_nitro"
+      },
+      "particle_class": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/particle_class"
+      },
+      "pathogenicity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pathogenicity"
+      },
+      "pcr_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pcr_cond"
+      },
+      "pcr_primers": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pcr_primers"
+      },
+      "peptide_sequence_count": {
+         "@type": "xsd:integer"
+      },
+      "peptide_spectral_count": {
+         "@type": "xsd:integer"
+      },
+      "peptide_sum_masic_abundance": {
+         "@type": "xsd:integer"
+      },
+      "permeability": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/permeability"
+      },
+      "perturbation": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/perturbation"
+      },
+      "pesticide_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pesticide_regm"
+      },
+      "pet_farm_animal": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pet_farm_animal"
+      },
+      "petroleum_hydrocarb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/petroleum_hydrocarb"
+      },
+      "ph": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ph"
+      },
+      "ph_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ph_meth"
+      },
+      "ph_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ph_regm"
+      },
+      "phaeopigments": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/phaeopigments"
+      },
+      "phase": {
+         "@type": "xsd:integer"
+      },
+      "phosphate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/phosphate"
+      },
+      "phosplipid_fatt_acid": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/phosplipid_fatt_acid"
+      },
+      "photon_flux": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/photon_flux"
+      },
+      "plant_growth_med": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/plant_growth_med"
+      },
+      "plant_product": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/plant_product"
+      },
+      "plant_sex": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/plant_sex"
+      },
+      "plant_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/plant_struc"
+      },
+      "ploidy": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ploidy"
+      },
+      "pollutants": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pollutants"
+      },
+      "pool_dna_extracts": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pool_dna_extracts"
+      },
+      "porosity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/porosity"
+      },
+      "potassium": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/potassium"
+      },
+      "pour_point": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pour_point"
+      },
+      "pre_treatment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pre_treatment"
+      },
+      "pred_genome_struc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pred_genome_struc"
+      },
+      "pred_genome_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pred_genome_type"
+      },
+      "pregnancy": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pregnancy"
+      },
+      "pres_animal": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pres_animal"
+      },
+      "pressure": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pressure"
+      },
+      "previous_land_use": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/previous_land_use"
+      },
+      "previous_land_use_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/previous_land_use_meth"
+      },
+      "primary_prod": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/primary_prod"
+      },
+      "primary_treatment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/primary_treatment"
+      },
+      "principal_investigator": {
+         "@type": "@id"
+      },
+      "prod_rate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/prod_rate"
+      },
+      "prod_start_date": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/prod_start_date"
+      },
+      "profile_position": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/profile_position"
+      },
+      "project_name": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/project_name"
+      },
+      "propagation": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/propagation"
+      },
+      "protein_spectral_count": {
+         "@type": "xsd:integer"
+      },
+      "protein_sum_masic_abundance": {
+         "@type": "xsd:integer"
+      },
+      "pulmonary_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/pulmonary_disord"
+      },
+      "quad_pos": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/quad_pos"
+      },
+      "radiation_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/radiation_regm"
+      },
+      "rainfall_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/rainfall_regm"
+      },
+      "reactor_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/reactor_type"
+      },
+      "read_based_analysis_activity_set": {
+         "@type": "@id"
+      },
+      "read_QC_analysis_activity_set": {
+         "@type": "@id"
+      },
+      "read_QC_analysis_statistic": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/read_QC_analysis_statistic"
+      },
+      "reassembly_bin": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/reassembly_bin"
+      },
+      "redox_potential": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/redox_potential"
+      },
+      "ref_biomaterial": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ref_biomaterial"
+      },
+      "ref_db": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ref_db"
+      },
+      "rel_air_humidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/rel_air_humidity"
+      },
+      "rel_humidity_out": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/rel_humidity_out"
+      },
+      "rel_samp_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/rel_samp_loc"
+      },
+      "rel_to_oxygen": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/rel_to_oxygen"
+      },
+      "reservoir": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/reservoir"
+      },
+      "resins_pc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/resins_pc"
+      },
+      "resp_part_matter": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/resp_part_matter"
+      },
+      "right_participants": {
+         "@type": "@id"
+      },
+      "room_air_exch_rate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_air_exch_rate"
+      },
+      "room_architec_element": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_architec_element"
+      },
+      "room_condt": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_condt"
+      },
+      "room_connected": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_connected"
+      },
+      "room_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_count"
+      },
+      "room_dim": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_dim"
+      },
+      "room_door_dist": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_door_dist"
+      },
+      "room_door_share": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_door_share"
+      },
+      "room_hallway": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_hallway"
+      },
+      "room_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_loc"
+      },
+      "room_moist_damage_hist": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_moist_damage_hist"
+      },
+      "room_net_area": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_net_area"
+      },
+      "room_occup": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_occup"
+      },
+      "room_samp_pos": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_samp_pos"
+      },
+      "room_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_type"
+      },
+      "room_vol": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_vol"
+      },
+      "room_wall_share": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_wall_share"
+      },
+      "room_window_count": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/room_window_count"
+      },
+      "root_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_cond"
+      },
+      "root_med_carbon": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_carbon"
+      },
+      "root_med_macronutr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_macronutr"
+      },
+      "root_med_micronutr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_micronutr"
+      },
+      "root_med_ph": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_ph"
+      },
+      "root_med_regl": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_regl"
+      },
+      "root_med_solid": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_solid"
+      },
+      "root_med_suppl": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/root_med_suppl"
+      },
+      "salinity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/salinity"
+      },
+      "salinity_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/salinity_meth"
+      },
+      "salt_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/salt_regm"
+      },
+      "samp_capt_status": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_capt_status"
+      },
+      "samp_collect_device": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_collect_device"
+      },
+      "samp_collection_point": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_collection_point"
+      },
+      "samp_dis_stage": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_dis_stage"
+      },
+      "samp_floor": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_floor"
+      },
+      "samp_loc_corr_rate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_loc_corr_rate"
+      },
+      "samp_mat_process": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_mat_process"
+      },
+      "samp_md": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_md"
+      },
+      "samp_preserv": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_preserv"
+      },
+      "samp_room_id": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_room_id"
+      },
+      "samp_salinity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_salinity"
+      },
+      "samp_size": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_size"
+      },
+      "samp_sort_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_sort_meth"
+      },
+      "samp_store_dur": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_store_dur"
+      },
+      "samp_store_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_store_loc"
+      },
+      "samp_store_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_store_temp"
+      },
+      "samp_subtype": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_subtype"
+      },
+      "samp_time_out": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_time_out"
+      },
+      "samp_transport_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_transport_cond"
+      },
+      "samp_tvdss": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_tvdss"
+      },
+      "samp_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_type"
+      },
+      "samp_vol_we_dna_ext": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_vol_we_dna_ext"
+      },
+      "samp_weather": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_weather"
+      },
+      "samp_well_name": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/samp_well_name"
+      },
+      "sample_identifiers": {
+         "@type": "@id"
+      },
+      "sample_collection_day": {
+         "@type": "xsd:integer"
+      },
+      "sample_collection_hour": {
+         "@type": "xsd:integer"
+      },
+      "sample_collection_minute": {
+         "@type": "xsd:integer"
+      },
+      "sample_collection_month": {
+         "@type": "xsd:integer"
+      },
+      "sample_collection_year": {
+         "@type": "xsd:integer"
+      },
+      "saturates_pc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/saturates_pc"
+      },
+      "scaf_bp": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_bp"
+      },
+      "scaf_L50": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_L50"
+      },
+      "scaf_L90": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_L90"
+      },
+      "scaf_l_gt50K": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_l_gt50K"
+      },
+      "scaf_logsum": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_logsum"
+      },
+      "scaf_max": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_max"
+      },
+      "scaf_N50": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_N50"
+      },
+      "scaf_N90": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_N90"
+      },
+      "scaf_n_gt50K": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_n_gt50K"
+      },
+      "scaf_pct_gt50K": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_pct_gt50K"
+      },
+      "scaf_powsum": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaf_powsum"
+      },
+      "scaffolds": {
+         "@type": "xsd:float",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/scaffolds"
+      },
+      "season": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/season"
+      },
+      "season_environment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/season_environment"
+      },
+      "season_precpt": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/season_precpt"
+      },
+      "season_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/season_temp"
+      },
+      "season_use": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/season_use"
+      },
+      "secondary_treatment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/secondary_treatment"
+      },
+      "sediment_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sediment_type"
+      },
+      "seq_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/seq_meth"
+      },
+      "seq_quality_check": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/seq_quality_check"
+      },
+      "sewage_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sewage_type"
+      },
+      "sexual_act": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sexual_act"
+      },
+      "shading_device_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/shading_device_cond"
+      },
+      "shading_device_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/shading_device_loc"
+      },
+      "shading_device_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/shading_device_mat"
+      },
+      "shading_device_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/shading_device_type"
+      },
+      "shading_device_water_mold": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/shading_device_water_mold"
+      },
+      "sieving": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sieving"
+      },
+      "silicate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/silicate"
+      },
+      "sim_search_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sim_search_meth"
+      },
+      "single_cell_lysis_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/single_cell_lysis_appr"
+      },
+      "single_cell_lysis_prot": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/single_cell_lysis_prot"
+      },
+      "size_frac": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/size_frac"
+      },
+      "size_frac_low": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/size_frac_low"
+      },
+      "size_frac_up": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/size_frac_up"
+      },
+      "slope_aspect": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/slope_aspect"
+      },
+      "slope_gradient": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/slope_gradient"
+      },
+      "sludge_retent_time": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sludge_retent_time"
+      },
+      "smoker": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/smoker"
+      },
+      "sodium": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sodium"
+      },
+      "soil_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/soil_type"
+      },
+      "soil_type_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/soil_type_meth"
+      },
+      "solar_irradiance": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/solar_irradiance"
+      },
+      "soluble_inorg_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/soluble_inorg_mat"
+      },
+      "soluble_org_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/soluble_org_mat"
+      },
+      "soluble_react_phosp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/soluble_react_phosp"
+      },
+      "sop": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sop"
+      },
+      "sort_tech": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sort_tech"
+      },
+      "source_mat_id": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/source_mat_id"
+      },
+      "source_uvig": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/source_uvig"
+      },
+      "space_typ_state": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/space_typ_state"
+      },
+      "special_diet": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/special_diet"
+      },
+      "specific": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/specific"
+      },
+      "specific_host": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/specific_host"
+      },
+      "specific_humidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/specific_humidity"
+      },
+      "sr_dep_env": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sr_dep_env"
+      },
+      "sr_geol_age": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sr_geol_age"
+      },
+      "sr_kerog_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sr_kerog_type"
+      },
+      "sr_lithology": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sr_lithology"
+      },
+      "standing_water_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/standing_water_regm"
+      },
+      "start": {
+         "@type": "xsd:integer"
+      },
+      "stoichiometry": {
+         "@type": "xsd:integer"
+      },
+      "store_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/store_cond"
+      },
+      "study_identifiers": {
+         "@type": "@id"
+      },
+      "study_set": {
+         "@type": "@id"
+      },
+      "study_complt_stat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/study_complt_stat"
+      },
+      "subject": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/annotation/subject"
+      },
+      "submitted_to_insdc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/submitted_to_insdc"
+      },
+      "subspecf_gen_lin": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/subspecf_gen_lin"
+      },
+      "substructure_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/substructure_type"
+      },
+      "subsurface_depth": {
+         "@type": "@id"
+      },
+      "subsurface_depth2": {
+         "@type": "@id"
+      },
+      "sulfate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sulfate"
+      },
+      "sulfate_fw": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sulfate_fw"
+      },
+      "sulfide": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/sulfide"
+      },
+      "surf_air_cont": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/surf_air_cont"
+      },
+      "surf_humidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/surf_humidity"
+      },
+      "surf_material": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/surf_material"
+      },
+      "surf_moisture": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/surf_moisture"
+      },
+      "surf_moisture_ph": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/surf_moisture_ph"
+      },
+      "surf_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/surf_temp"
+      },
+      "suspend_part_matter": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/suspend_part_matter"
+      },
+      "suspend_solids": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/suspend_solids"
+      },
+      "tan": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tan"
+      },
+      "target_gene": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/target_gene"
+      },
+      "target_subfragment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/target_subfragment"
+      },
+      "tax_class": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tax_class"
+      },
+      "tax_ident": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tax_ident"
+      },
+      "temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/temp"
+      },
+      "temp_out": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/temp_out"
+      },
+      "term": {
+         "@type": "@id",
+         "@id": "rdf:type"
+      },
+      "tertiary_treatment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tertiary_treatment"
+      },
+      "texture": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/texture"
+      },
+      "texture_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/texture_meth"
+      },
+      "tidal_stage": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tidal_stage"
+      },
+      "tillage": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tillage"
+      },
+      "time_last_toothbrush": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/time_last_toothbrush"
+      },
+      "time_since_last_wash": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/time_since_last_wash"
+      },
+      "tiss_cult_growth_med": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tiss_cult_growth_med"
+      },
+      "toluene": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/toluene"
+      },
+      "too_short_contig_num": {
+         "@type": "xsd:integer",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/too_short_contig_num"
+      },
+      "tot_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_carb"
+      },
+      "tot_depth_water_col": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_depth_water_col"
+      },
+      "tot_diss_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_diss_nitro"
+      },
+      "tot_inorg_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_inorg_nitro"
+      },
+      "tot_iron": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_iron"
+      },
+      "tot_nitro": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_nitro"
+      },
+      "tot_nitro_content": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_nitro_content"
+      },
+      "tot_nitro_content_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_nitro_content_meth"
+      },
+      "tot_org_c_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_org_c_meth"
+      },
+      "tot_org_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_org_carb"
+      },
+      "tot_part_carb": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_part_carb"
+      },
+      "tot_phosp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_phosp"
+      },
+      "tot_phosphate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_phosphate"
+      },
+      "tot_sulfur": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tot_sulfur"
+      },
+      "train_line": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/train_line"
+      },
+      "train_stat_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/train_stat_loc"
+      },
+      "train_stop_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/train_stop_loc"
+      },
+      "travel_out_six_month": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/travel_out_six_month"
+      },
+      "trna_ext_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/trna_ext_software"
+      },
+      "trnas": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/trnas"
+      },
+      "trophic_level": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/trophic_level"
+      },
+      "turbidity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/turbidity"
+      },
+      "tvdss_of_hcr_pressure": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tvdss_of_hcr_pressure"
+      },
+      "tvdss_of_hcr_temp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/tvdss_of_hcr_temp"
+      },
+      "twin_sibling": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/twin_sibling"
+      },
+      "typ_occup_density": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/typ_occup_density"
+      },
+      "unbinned_contig_num": {
+         "@type": "xsd:integer",
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/unbinned_contig_num"
+      },
+      "urine_collect_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/urine_collect_meth"
+      },
+      "urogenit_disord": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/urogenit_disord"
+      },
+      "urogenit_tract_disor": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/urogenit_tract_disor"
+      },
+      "ventilation_rate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ventilation_rate"
+      },
+      "ventilation_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/ventilation_type"
+      },
+      "vfa": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/vfa"
+      },
+      "vfa_fw": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/vfa_fw"
+      },
+      "vir_ident_software": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/vir_ident_software"
+      },
+      "virus_enrich_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/virus_enrich_appr"
+      },
+      "vis_media": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/vis_media"
+      },
+      "viscosity": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/viscosity"
+      },
+      "volatile_org_comp": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/volatile_org_comp"
+      },
+      "votu_class_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/votu_class_appr"
+      },
+      "votu_db": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/votu_db"
+      },
+      "votu_seq_comp_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/votu_seq_comp_appr"
+      },
+      "wall_area": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_area"
+      },
+      "wall_const_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_const_type"
+      },
+      "wall_finish_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_finish_mat"
+      },
+      "wall_height": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_height"
+      },
+      "wall_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_loc"
+      },
+      "wall_surf_treatment": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_surf_treatment"
+      },
+      "wall_texture": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_texture"
+      },
+      "wall_thermal_mass": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_thermal_mass"
+      },
+      "wall_water_mold": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wall_water_mold"
+      },
+      "was_associated_with": {
+         "@type": "@id"
+      },
+      "was_generated_by": {
+         "@type": "@id"
+      },
+      "was_informed_by": {
+         "@type": "@id"
+      },
+      "wastewater_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wastewater_type"
+      },
+      "water_content": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_content"
+      },
+      "water_content_soil_meth": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_content_soil_meth"
+      },
+      "water_current": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_current"
+      },
+      "water_cut": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_cut"
+      },
+      "water_feat_size": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_feat_size"
+      },
+      "water_feat_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_feat_type"
+      },
+      "water_production_rate": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_production_rate"
+      },
+      "water_temp_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/water_temp_regm"
+      },
+      "watering_regm": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/watering_regm"
+      },
+      "weekday": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/weekday"
+      },
+      "weight_loss_3_month": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/weight_loss_3_month"
+      },
+      "wga_amp_appr": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wga_amp_appr"
+      },
+      "wga_amp_kit": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wga_amp_kit"
+      },
+      "win": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/win"
+      },
+      "wind_direction": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wind_direction"
+      },
+      "wind_speed": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/wind_speed"
+      },
+      "window_cond": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_cond"
+      },
+      "window_cover": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_cover"
+      },
+      "window_horiz_pos": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_horiz_pos"
+      },
+      "window_loc": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_loc"
+      },
+      "window_mat": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_mat"
+      },
+      "window_open_freq": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_open_freq"
+      },
+      "window_size": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_size"
+      },
+      "window_status": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_status"
+      },
+      "window_type": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_type"
+      },
+      "window_vert_pos": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_vert_pos"
+      },
+      "window_water_mold": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/window_water_mold"
+      },
+      "xylene": {
+         "@type": "@id",
+         "@id": "https://microbiomedata/schema/mixs/xylene"
+      },
+      "FunctionalAnnotation": {
+         "@id": "https://microbiomedata/schema/annotation/FunctionalAnnotation"
+      },
+      "FunctionalAnnotationTerm": {
+         "@id": "https://microbiomedata/schema/annotation/FunctionalAnnotationTerm"
+      },
+      "GenomeFeature": {
+         "@id": "https://microbiomedata/schema/annotation/GenomeFeature"
+      },
+      "MAGsAnalysisActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MAGsAnalysisActivity"
+      },
+      "MetabolomicsAnalysisActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetabolomicsAnalysisActivity"
+      },
+      "MetagenomeAnnotationActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetagenomeAnnotationActivity"
+      },
+      "MetagenomeAssembly": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetagenomeAssembly"
+      },
+      "MetaproteomicsAnalysisActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetaproteomicsAnalysisActivity"
+      },
+      "MetatranscriptomeActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetatranscriptomeActivity"
+      },
+      "MetatranscriptomeAnnotationActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetatranscriptomeAnnotationActivity"
+      },
+      "MetatranscriptomeAssembly": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/MetatranscriptomeAssembly"
+      },
+      "NomAnalysisActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/NomAnalysisActivity"
+      },
+      "OrthologyGroup": {
+         "@id": "https://microbiomedata/schema/annotation/OrthologyGroup"
+      },
+      "Pathway": {
+         "@id": "https://microbiomedata/schema/annotation/Pathway"
+      },
+      "Reaction": {
+         "@id": "https://microbiomedata/schema/annotation/Reaction"
+      },
+      "ReactionParticipant": {
+         "@id": "https://microbiomedata/schema/annotation/ReactionParticipant"
+      },
+      "ReadBasedAnalysisActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ReadBasedAnalysisActivity"
+      },
+      "ReadQCAnalysisActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/ReadQCAnalysisActivity"
+      },
+      "WorkflowExecutionActivity": {
+         "@id": "https://microbiomedata/schema/workflow_execution_activity/WorkflowExecutionActivity"
+      }
+   }
+}
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-linkml >= 1.0.0
+linkml >= 1.0.3
 jq
 mkdocs
 twine


### PR DESCRIPTION
Fixes #56 

Add target to the `Makefile` to generate a jsonld context.  
As part of this, I'm switching to using `pipenv`.