### PR TITLE
fix: set python version to >= 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changes to the schema are documented in this file.
 ### Removed
   - N/A
 
+## [2021.11.19rc3](https://github.com/microbiomedata/nmdc-schema/releases/tag/2021.11.19rc3)
+### Added
+  - N/A
+### Fixed
+  - N/A
+### Changed 
+  - set python version in setup.py to >=3.7
+### Removed
+  - N/A
+
 ## [2021.11.19rc2](https://github.com/microbiomedata/nmdc-schema/releases/tag/2021.11.19rc2)
 ### Added
   - N/A

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,11 @@ setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.9",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     ],
     install_requires=["linkml"],
-    python_requires=">=3.9",
+    python_requires=">=3.7",
     keywords="NMDC, schema",
 )


### PR DESCRIPTION
set python version to >=3.7 in setup.py
this is needed for nmdc-runtime, which uses python 3.8﻿
