### PR TITLE
Add invalid test JSON schema files

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -58,3 +58,4 @@ jobs:
     - name: Validate JSON Schema
       run: |
         make test-jsonschema
+        make test-jsonschema_invalid

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,12 @@ SCHEMA_TEST_EXAMPLES := \
 	study_credit_test
 
 SCHEMA_TEST_EXAMPLES_INVALID := \
-	invalid_study_test \
+	biosample_invalid_range \
+	biosample_mismatch_regex \
+	biosample_missing_required_field \
+	biosample_single_multi_value_mixup \
+	biosample_undeclared_slot \
+	study_credit_enum_mangle
 
 # 	functional_annotation_set_invalid has invalid ID pattern but regex tests aren't applied yet? MAM 2021-06-24
 
@@ -213,6 +218,5 @@ validate-%: test/data/%.json jsonschema/nmdc.schema.json
 # util/validate_nmdc_json.py -i $< # example of validating data using the cli
 	pipenv run jsonschema -i $< $(word 2, $^)
 
-validate-invalid-%: test/data/%.json jsonschema/nmdc.schema.json
-	@echo $(word 2, $^)
-	! jsonschema -i $< $(word 2, $^)
+validate-invalid-%: test/data/invalid_schemas/%.json jsonschema/nmdc.schema.json
+	! pipenv run jsonschema -i $< $(word 2, $^)

--- a/test/data/invalid_schemas/README.md
+++ b/test/data/invalid_schemas/README.md
@@ -1,0 +1,14 @@
+## Invalid Schemas Description
+
+
+The below table summarizes why each of the test JSON files in this folder are invalid.
+
+
+| Filename                      | Invalidity Reason      |
+| ----------------------------- | ---------------------- |
+| [biosample_invalid_range.json](biosample_invalid_range.json)                       | Invalid types of values passed to `has_raw_value`, `latitude` and `longitude` |
+| [biosample_mismatch_regex.json](biosample_mismatch_regex.json)                     | Array of values passed to `GOLD_sample_identifiers` do not fit regex |
+| [biosample_missing_required_field.json](biosample_missing_required_field.json)     | Missing `id` field |
+| [biosample_single_multi_value_mixup.json](biosample_single_multi_value_mixup.json) | Passing multiple values to `type` field |
+| [biosample_undeclared_slot.json](biosample_undeclared_slot.json)                   | Added out of schema `foo` field |
+| [study_credit_enum_mangle.json](study_credit_enum_mangle.json)                     | Passing values outside of enum to `applied_role` |

--- a/test/data/invalid_schemas/biosample_invalid_range.json
+++ b/test/data/invalid_schemas/biosample_invalid_range.json
@@ -1,0 +1,109 @@
+{
+  "biosample_set": [
+    {
+      "id": "gold:Gb0101224",
+      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": 100.0,
+        "latitude": "-33.460524",
+        "longitude": "150.168149"
+      },
+      "ecosystem": "Environmental", 
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101225",
+      "name": "Lithgow State Coal Mine Calcium nutrients Extra",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101226",
+      "name": "Lithgow State Coal Mine Calcium nutrients",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    }
+  ]
+}

--- a/test/data/invalid_schemas/biosample_mismatch_regex.json
+++ b/test/data/invalid_schemas/biosample_mismatch_regex.json
@@ -1,7 +1,7 @@
 {
   "biosample_set": [
     {
-      "GOLD_sample_identifiers": ["GOLD:Gb1234A", "GOLD:Gb1234B"],
+      "GOLD_sample_identifiers": "ABCD:Ab@#",
       "id": "gold:Gb0101224",
       "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "description": "Bulk Aqueous phase filtered water",
@@ -37,6 +37,7 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
+      "GOLD_sample_identifiers": ["GOLD:Gb1234"],
       "id": "gold:Gb0101225",
       "name": "Lithgow State Coal Mine Calcium nutrients Extra",
       "description": "Bulk Aqueous phase filtered water",
@@ -72,6 +73,7 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
+      "GOLD_sample_identifiers": ["ABCD:Ab@#@", "WXYZ:Wx()"],
       "id": "gold:Gb0101226",
       "name": "Lithgow State Coal Mine Calcium nutrients",
       "description": "Bulk Aqueous phase filtered water",

--- a/test/data/invalid_schemas/biosample_mismatch_regex.json
+++ b/test/data/invalid_schemas/biosample_mismatch_regex.json
@@ -1,0 +1,110 @@
+{
+  "biosample_set": [
+    {
+      "GOLD_sample_identifiers": ["GOLD:Gb1234A", "GOLD:Gb1234B"],
+      "id": "gold:Gb0101224",
+      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental", 
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101225",
+      "name": "Lithgow State Coal Mine Calcium nutrients Extra",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101226",
+      "name": "Lithgow State Coal Mine Calcium nutrients",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    }
+  ]
+}

--- a/test/data/invalid_schemas/biosample_missing_required_field.json
+++ b/test/data/invalid_schemas/biosample_missing_required_field.json
@@ -1,0 +1,106 @@
+{
+  "biosample_set": [
+    {
+      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental", 
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "name": "Lithgow State Coal Mine Calcium nutrients Extra",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "name": "Lithgow State Coal Mine Calcium nutrients",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    }
+  ]
+}

--- a/test/data/invalid_schemas/biosample_single_multi_value_mixup.json
+++ b/test/data/invalid_schemas/biosample_single_multi_value_mixup.json
@@ -1,0 +1,109 @@
+{
+  "biosample_set": [
+    {
+      "id": ["gold:Gb0101224", "gold:Gb0101225"],
+      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": ["nmdc:Biosample", "nmdc:FunctionalAnnotation"],
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental", 
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101225",
+      "name": "Lithgow State Coal Mine Calcium nutrients Extra",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101226",
+      "name": "Lithgow State Coal Mine Calcium nutrients",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    }
+  ]
+}

--- a/test/data/invalid_schemas/biosample_undeclared_slot.json
+++ b/test/data/invalid_schemas/biosample_undeclared_slot.json
@@ -1,0 +1,110 @@
+{
+  "biosample_set": [
+    {
+      "foo": "bar",
+      "id": "gold:Gb0101224",
+      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental", 
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101225",
+      "name": "Lithgow State Coal Mine Calcium nutrients Extra",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    },
+    {
+      "id": "gold:Gb0101226",
+      "name": "Lithgow State Coal Mine Calcium nutrients",
+      "description": "Bulk Aqueous phase filtered water",
+      "type": "nmdc:Biosample",
+      "env_broad_scale": {
+        "has_raw_value": "ENVO:00002030"
+      },
+      "env_local_scale": {
+        "has_raw_value": "ENVO:00002169"
+      },
+      "env_medium": {
+        "has_raw_value": "ENVO:00005792"
+      },
+      "geo_loc_name": {
+        "has_raw_value": "Lithgow"
+      },
+      "lat_lon": {
+        "has_raw_value": "-33.460524 150.168149",
+        "latitude": -33.460524,
+        "longitude": 150.168149
+      },
+      "ecosystem": "Environmental",
+      "ecosystem_category": "Aquatic",
+      "ecosystem_type": "Freshwater",
+      "ecosystem_subtype": "Groundwater",
+      "specific_ecosystem": "Coalbed water",
+      "add_date": "28-JUL-14 12.00.00.000000000 AM",
+      "community": "microbial communities",
+      "habitat": "Coalbed water",
+      "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+      "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+      "ncbi_taxonomy_name": "coal metagenome",
+      "sample_collection_site": "Lithgow State Coal Mine"
+    }
+  ]
+}

--- a/test/data/invalid_schemas/study_credit_enum_mangle.json
+++ b/test/data/invalid_schemas/study_credit_enum_mangle.json
@@ -1,0 +1,26 @@
+{
+  "study_set": [
+    {
+      "type": "study",
+      "id": "example:123",
+      "has_credit_associations": [
+        {
+          "type": "credit association",
+          "applied_role": "Value Not In Enum 1",
+          "applies_to_person": {
+            "type": "PersonValue",
+            "orcid": "orcid:0000-0002-1825-00"
+          }
+        },
+        {
+          "type": "credit association",
+          "applied_role": "ValueNotInEnum2",
+          "applies_to_person": {
+            "type": "PersonValue",
+            "orcid": "orcid:0000-0001-9076-6066"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR seeks to resolve issue #220. Here, we add invalid test JSON schema files to the repo so we can run the JSON Schema Validator and ensure that invalid schemas fail validation, as detailed in `2.` of the issue.