### PR TITLE
Add `gen-linkml` target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SCHEMA_SRC = $(SCHEMA_DIR)/$(SCHEMA_NAME).yaml
 RUN=poetry run
 
 #TGTS = graphql jsonschema docs shex owl csv  python
-TGTS = jsonschema jsonld-context python docs
+TGTS = jsonschema jsonld-context python json docs
 
 #GEN_OPTS = --no-mergeimports
 GEN_OPTS =
@@ -138,13 +138,11 @@ gen-rdf: target/rdf/$(SCHEMA_NAME).ttl
 target/rdf/%.ttl: $(SCHEMA_DIR)/%.yaml tdir-rdf
 	$(RUN) gen-rdf $(GEN_OPTS) $< > $@
 
-###  -- LINKML --
-# linkml (copy)
-# one file per module
-gen-linkml: target/linkml/$(SCHEMA_NAME).yaml
-.PHONY: gen-linkml
-target/linkml/%.yaml: $(SCHEMA_DIR)/%.yaml tdir-limkml
-	cp $< > $@
+###  -- JSON --
+gen-json: target/json/$(SCHEMA_NAME).linkml.json
+.PHONY: gen-json
+target/json/%.linkml.json: $(SCHEMA_DIR)/%.yaml tdir-json
+	$(RUN) gen-linkml $(GEN_OPTS) --format json --materialize-attributes $< > $@
 
 # test docs locally.
 docserve:

--- a/json/nmdc.linkml.json
+++ b/json/nmdc.linkml.json
@@ -1,0 +1,19679 @@
+{
+  "name": "NMDC",
+  "description": "Schema for National Microbiome Data Collaborative (NMDC).\n  \nThis schema is organized into distinct modules:\n  \n * a set of core types for representing data values\n * the mixs schema (auto-translated from mixs excel)\n * annotation schema\n * the NMDC schema itself",
+  "title": "NMDC Schema",
+  "id": "https://microbiomedata/schema",
+  "version": "2.1.0",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "prefixes": {
+    "nmdc": {
+      "prefix_prefix": "nmdc",
+      "prefix_reference": "https://microbiomedata/meta/"
+    },
+    "GOLD": {
+      "prefix_prefix": "GOLD",
+      "prefix_reference": "https://identifiers.org/gold/"
+    },
+    "mixs": {
+      "prefix_prefix": "mixs",
+      "prefix_reference": "https://w3id.org/gensc/"
+    },
+    "wgs": {
+      "prefix_prefix": "wgs",
+      "prefix_reference": "http://www.w3.org/2003/01/geo/wgs84_pos"
+    },
+    "qud": {
+      "prefix_prefix": "qud",
+      "prefix_reference": "http://qudt.org/1.1/schema/qudt#"
+    },
+    "dcterms": {
+      "prefix_prefix": "dcterms",
+      "prefix_reference": "http://purl.org/dc/terms/"
+    },
+    "linkml": {
+      "prefix_prefix": "linkml",
+      "prefix_reference": "https://w3id.org/linkml/"
+    },
+    "MS": {
+      "prefix_prefix": "MS",
+      "prefix_reference": "http://purl.obolibrary.org/obo/MS_"
+    },
+    "OBI": {
+      "prefix_prefix": "OBI",
+      "prefix_reference": "http://purl.obolibrary.org/obo/OBI_"
+    },
+    "NCIT": {
+      "prefix_prefix": "NCIT",
+      "prefix_reference": "http://purl.obolibrary.org/obo/NCIT_"
+    },
+    "igsn": {
+      "prefix_prefix": "igsn",
+      "prefix_reference": "https://app.geosamples.org/sample/igsn/"
+    },
+    "img.taxon": {
+      "prefix_prefix": "img.taxon",
+      "prefix_reference": "http://img.jgi.doe.gov/cgi-bin/w/main.cgi?section=TaxonDetail&taxon_oid="
+    },
+    "prov": {
+      "prefix_prefix": "prov",
+      "prefix_reference": "http://www.w3.org/ns/prov#"
+    },
+    "schema": {
+      "prefix_prefix": "schema",
+      "prefix_reference": "http://schema.org/"
+    },
+    "igsnvoc": {
+      "prefix_prefix": "igsnvoc",
+      "prefix_reference": "https://igsn.org/voc/v1/"
+    },
+    "rdf": {
+      "prefix_prefix": "rdf",
+      "prefix_reference": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    },
+    "sio": {
+      "prefix_prefix": "sio",
+      "prefix_reference": "http://semanticscience.org/resource/SIO_"
+    },
+    "skos": {
+      "prefix_prefix": "skos",
+      "prefix_reference": "http://www.w3.org/2004/02/skos/core#"
+    },
+    "xsd": {
+      "prefix_prefix": "xsd",
+      "prefix_reference": "http://www.w3.org/2001/XMLSchema#"
+    },
+    "shex": {
+      "prefix_prefix": "shex",
+      "prefix_reference": "http://www.w3.org/ns/shex#"
+    },
+    "biolink": {
+      "prefix_prefix": "biolink",
+      "prefix_reference": "https://w3id.org/biolink/vocab/"
+    }
+  },
+  "emit_prefixes": [
+    "rdf",
+    "rdfs",
+    "xsd",
+    "skos"
+  ],
+  "default_curi_maps": [
+    "obo_context",
+    "idot_context"
+  ],
+  "default_prefix": "nmdc",
+  "default_range": "string",
+  "subsets": {
+    "sample subset": {
+      "name": "sample subset",
+      "description": "Subset consisting of entities linked to the processing of samples.  Currently, this subset consists of study, omics process, and biosample.",
+      "from_schema": "https://microbiomedata/schema"
+    },
+    "data object subset": {
+      "name": "data object subset",
+      "description": "Subset consisting of the data objects that either inputs or outputs of processes or workflows.",
+      "from_schema": "https://microbiomedata/schema"
+    }
+  },
+  "types": {
+    "external identifier": {
+      "name": "external identifier",
+      "description": "A CURIE representing an external identifier",
+      "see_also": [
+        "https://microbiomedata.github.io/nmdc-schema/identifiers.html"
+      ],
+      "typeof": "uriorcurie"
+    },
+    "bytes": {
+      "name": "bytes",
+      "description": "An integer value that corresponds to a size in bytes",
+      "see_also": [
+        "UO:0000233"
+      ],
+      "base": "int",
+      "uri": "xsd:int"
+    },
+    "decimal degree": {
+      "name": "decimal degree",
+      "description": "A decimal degree expresses latitude or longitude as decimal fractions.",
+      "see_also": [
+        "https://en.wikipedia.org/wiki/Decimal_degrees"
+      ],
+      "base": "float",
+      "uri": "xsd:decimal"
+    },
+    "language code": {
+      "name": "language code",
+      "description": "A language code conforming to ISO_639-1",
+      "see_also": [
+        "https://en.wikipedia.org/wiki/ISO_639-1"
+      ],
+      "base": "str",
+      "uri": "xsd:language"
+    },
+    "unit": {
+      "name": "unit",
+      "mappings": [
+        "qud:Unit",
+        "UO:0000000"
+      ],
+      "base": "str",
+      "uri": "xsd:string"
+    },
+    "string": {
+      "name": "string",
+      "description": "A character string",
+      "base": "str",
+      "uri": "xsd:string"
+    },
+    "integer": {
+      "name": "integer",
+      "description": "An integer",
+      "base": "int",
+      "uri": "xsd:integer"
+    },
+    "boolean": {
+      "name": "boolean",
+      "description": "A binary (true or false) value",
+      "base": "Bool",
+      "uri": "xsd:boolean",
+      "repr": "bool"
+    },
+    "float": {
+      "name": "float",
+      "description": "A real number that conforms to the xsd:float specification",
+      "base": "float",
+      "uri": "xsd:float"
+    },
+    "double": {
+      "name": "double",
+      "description": "A real number that conforms to the xsd:double specification",
+      "base": "float",
+      "uri": "xsd:double"
+    },
+    "decimal": {
+      "name": "decimal",
+      "description": "A real number with arbitrary precision that conforms to the xsd:decimal specification",
+      "base": "Decimal",
+      "uri": "xsd:decimal"
+    },
+    "time": {
+      "name": "time",
+      "description": "A time object represents a (local) time of day, independent of any particular day",
+      "notes": [
+        "URI is dateTime because OWL reasoners don't work with straight date or time"
+      ],
+      "base": "XSDTime",
+      "uri": "xsd:dateTime",
+      "repr": "str"
+    },
+    "date": {
+      "name": "date",
+      "description": "a date (year, month and day) in an idealized calendar",
+      "notes": [
+        "URI is dateTime because OWL reasoners don't work with straight date or time"
+      ],
+      "base": "XSDDate",
+      "uri": "xsd:date",
+      "repr": "str"
+    },
+    "datetime": {
+      "name": "datetime",
+      "description": "The combination of a date and time",
+      "base": "XSDDateTime",
+      "uri": "xsd:dateTime",
+      "repr": "str"
+    },
+    "uriorcurie": {
+      "name": "uriorcurie",
+      "description": "a URI or a CURIE",
+      "base": "URIorCURIE",
+      "uri": "xsd:anyURI",
+      "repr": "str"
+    },
+    "uri": {
+      "name": "uri",
+      "description": "a complete URI",
+      "base": "URI",
+      "uri": "xsd:anyURI",
+      "repr": "str"
+    },
+    "ncname": {
+      "name": "ncname",
+      "description": "Prefix part of CURIE",
+      "base": "NCName",
+      "uri": "xsd:string",
+      "repr": "str"
+    },
+    "objectidentifier": {
+      "name": "objectidentifier",
+      "description": "A URI or CURIE that represents an object in the model.",
+      "comments": [
+        "Used for inheritence and type checking"
+      ],
+      "base": "ElementIdentifier",
+      "uri": "shex:iri",
+      "repr": "str"
+    },
+    "nodeidentifier": {
+      "name": "nodeidentifier",
+      "description": "A URI, CURIE or BNODE that represents a node in a model.",
+      "base": "NodeIdentifier",
+      "uri": "shex:nonLiteral",
+      "repr": "str"
+    }
+  },
+  "enums": {
+    "file type enum": {
+      "name": "file type enum",
+      "from_schema": "https://microbiomedata/schema",
+      "permissible_values": {
+        "FT ICR-MS Analysis Results": {
+          "text": "FT ICR-MS Analysis Results",
+          "description": "FT ICR-MS-based molecular formula assignment results table"
+        },
+        "GC-MS Metabolomics Results": {
+          "text": "GC-MS Metabolomics Results",
+          "description": "GC-MS-based metabolite assignment results table"
+        },
+        "Metaproteomics Workflow Statistics": {
+          "text": "Metaproteomics Workflow Statistics",
+          "description": "Aggregate workflow statistics file"
+        },
+        "Protein Report": {
+          "text": "Protein Report",
+          "description": "Filtered protein report file"
+        },
+        "Peptide Report": {
+          "text": "Peptide Report",
+          "description": "Filtered peptide report file"
+        },
+        "Unfiltered Metaproteomics Results": {
+          "text": "Unfiltered Metaproteomics Results",
+          "description": "MSGFjobs and MASIC output file"
+        },
+        "Read Count and RPKM": {
+          "text": "Read Count and RPKM",
+          "description": "Annotation read count and RPKM per feature JSON"
+        },
+        "QC non-rRNA R2": {
+          "text": "QC non-rRNA R2",
+          "description": "QC removed rRNA reads (R2) fastq"
+        },
+        "QC non-rRNA R1": {
+          "text": "QC non-rRNA R1",
+          "description": "QC removed rRNA reads (R1) fastq"
+        },
+        "Metagenome Bins": {
+          "text": "Metagenome Bins",
+          "description": "Metagenome bin contigs fasta"
+        },
+        "CheckM Statistics": {
+          "text": "CheckM Statistics",
+          "description": "CheckM statistics report"
+        },
+        "GOTTCHA2 Krona Plot": {
+          "text": "GOTTCHA2 Krona Plot",
+          "description": "GOTTCHA2 krona plot HTML file"
+        },
+        "Kraken2 Krona Plot": {
+          "text": "Kraken2 Krona Plot",
+          "description": "Kraken2 krona plot HTML file"
+        },
+        "Centrifuge Krona Plot": {
+          "text": "Centrifuge Krona Plot",
+          "description": "Centrifug krona plot HTML file"
+        },
+        "Kraken2 Classification Report": {
+          "text": "Kraken2 Classification Report",
+          "description": "Kraken2 output report file"
+        },
+        "Kraken2 Taxonomic Classification": {
+          "text": "Kraken2 Taxonomic Classification",
+          "description": "Kraken2 output read classification file"
+        },
+        "Centrifuge Classification Report": {
+          "text": "Centrifuge Classification Report",
+          "description": "Centrifuge output report file"
+        },
+        "Centrifuge Taxonomic Classification": {
+          "text": "Centrifuge Taxonomic Classification",
+          "description": "Centrifuge output read classification file"
+        },
+        "Structural Annotation GFF": {
+          "text": "Structural Annotation GFF",
+          "description": "GFF3 format file with structural annotations"
+        },
+        "Functional Annotation GFF": {
+          "text": "Functional Annotation GFF",
+          "description": "GFF3 format file with functional annotations"
+        },
+        "Annotation Amino Acid FASTA": {
+          "text": "Annotation Amino Acid FASTA",
+          "description": "FASTA amino acid file for annotated proteins"
+        },
+        "Annotation Enzyme Commission": {
+          "text": "Annotation Enzyme Commission",
+          "description": "Tab delimited file for EC annotation"
+        },
+        "Annotation KEGG Orthology": {
+          "text": "Annotation KEGG Orthology",
+          "description": "Tab delimited file for KO annotation"
+        },
+        "Assembly Coverage BAM": {
+          "text": "Assembly Coverage BAM",
+          "description": "Sorted bam file of reads mapping back to the final assembly"
+        },
+        "Assembly AGP": {
+          "text": "Assembly AGP",
+          "description": "An AGP format file that describes the assembly"
+        },
+        "Assembly Scaffolds": {
+          "text": "Assembly Scaffolds",
+          "description": "Final assembly scaffolds fasta"
+        },
+        "Assembly Contigs": {
+          "text": "Assembly Contigs",
+          "description": "Final assembly contigs fasta"
+        },
+        "Assembly Coverage Stats": {
+          "text": "Assembly Coverage Stats",
+          "description": "Assembled contigs coverage information"
+        },
+        "Filtered Sequencing Reads": {
+          "text": "Filtered Sequencing Reads",
+          "description": "Reads QC result fastq (clean data)"
+        },
+        "QC Statistics": {
+          "text": "QC Statistics",
+          "description": "Reads QC summary statistics"
+        },
+        "TIGRFam Annotation GFF": {
+          "text": "TIGRFam Annotation GFF",
+          "description": "GFF3 format file with TIGRfam",
+          "annotations": {
+            "file_name_pattern": {
+              "tag": "file_name_pattern",
+              "value": "[GOLD-AP]_tigrfam.gff"
+            }
+          }
+        },
+        "Clusters of Orthologous Groups (COG) Annotation GFF": {
+          "text": "Clusters of Orthologous Groups (COG) Annotation GFF",
+          "description": "GFF3 format file with COGs",
+          "annotations": {
+            "file_name_pattern": {
+              "tag": "file_name_pattern",
+              "value": "[GOLD-AP]_cog.gff"
+            }
+          }
+        },
+        "CATH FunFams (Functional Families) Annotation GFF": {
+          "text": "CATH FunFams (Functional Families) Annotation GFF",
+          "description": "GFF3 format file with CATH FunFams",
+          "annotations": {
+            "file_name_pattern": {
+              "tag": "file_name_pattern",
+              "value": "[GOLD-AP]_cath_funfam.gff"
+            }
+          }
+        },
+        "SUPERFam Annotation GFF": {
+          "text": "SUPERFam Annotation GFF",
+          "description": "GFF3 format file with SUPERFam",
+          "annotations": {
+            "file_name_pattern": {
+              "tag": "file_name_pattern",
+              "value": "[GOLD-AP]_supfam.gff"
+            }
+          }
+        },
+        "SMART Annotation GFF": {
+          "text": "SMART Annotation GFF",
+          "description": "GFF3 format file with SMART",
+          "annotations": {
+            "file_name_pattern": {
+              "tag": "file_name_pattern",
+              "value": "[GOLD-AP]_smart.gff"
+            }
+          }
+        },
+        "Pfam Annotation GFF": {
+          "text": "Pfam Annotation GFF",
+          "description": "GFF3 format file with Pfam",
+          "annotations": {
+            "file_name_pattern": {
+              "tag": "file_name_pattern",
+              "value": "[GOLD-AP]_pfam.gff"
+            }
+          }
+        },
+        "Direct Infusion FT ICR-MS Raw Data": {
+          "text": "Direct Infusion FT ICR-MS Raw Data",
+          "description": "Direct infusion 21 Tesla Fourier Transform ion cyclotron resonance mass spectrometry raw data acquired in broadband full scan mode"
+        }
+      }
+    },
+    "credit enum": {
+      "name": "credit enum",
+      "comments": [
+        "credit enums come from https://casrai.org/credit/"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "permissible_values": {
+        "Conceptualization": {
+          "text": "Conceptualization",
+          "description": "Conceptualization"
+        },
+        "Data curation": {
+          "text": "Data curation",
+          "description": "Data curation"
+        },
+        "Formal Analysis": {
+          "text": "Formal Analysis",
+          "description": "Formal Analysis"
+        },
+        "Funding acquisition": {
+          "text": "Funding acquisition",
+          "description": "Funding acquisition"
+        },
+        "Investigation": {
+          "text": "Investigation",
+          "description": "Investigation"
+        },
+        "Methodology": {
+          "text": "Methodology",
+          "description": "Methodology"
+        },
+        "Project administration": {
+          "text": "Project administration",
+          "description": "Project administration"
+        },
+        "Resources": {
+          "text": "Resources",
+          "description": "Resources"
+        },
+        "Software": {
+          "text": "Software",
+          "description": "Software"
+        },
+        "Supervision": {
+          "text": "Supervision",
+          "description": "Supervision"
+        },
+        "Validation": {
+          "text": "Validation",
+          "description": "Validation"
+        },
+        "Visualization": {
+          "text": "Visualization",
+          "description": "Visualization"
+        },
+        "Writing original draft": {
+          "text": "Writing original draft",
+          "description": "Writing – original draft"
+        },
+        "Writing review and editing": {
+          "text": "Writing review and editing",
+          "description": "Writing – review & editing"
+        },
+        "Principal Investigator": {
+          "text": "Principal Investigator",
+          "description": "principal investigator role",
+          "meaning": "OBI:0000103"
+        }
+      }
+    }
+  },
+  "slots": {
+    "ess dive datasets": {
+      "name": "ess dive datasets",
+      "description": "List of ESS-DIVE dataset DOIs",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true
+    },
+    "has credit associations": {
+      "name": "has credit associations",
+      "description": "This slot links a study to a credit association.  The credit association will be linked to a person value and to a CRediT Contributor Roles term. Overall semantics: person should get credit X for their participation in the study",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "study",
+      "slot_uri": "prov:qualifiedAssociation",
+      "multivalued": true,
+      "inlined": true,
+      "range": "credit association"
+    },
+    "study image": {
+      "name": "study image",
+      "description": "Links a study to one or more images.",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "study",
+      "multivalued": true,
+      "inlined": true,
+      "range": "image value"
+    },
+    "relevant protocols": {
+      "name": "relevant protocols",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "funding sources": {
+      "name": "funding sources",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "applied role": {
+      "name": "applied role",
+      "deprecated": "A credit association may have multiple roles. So, use the applied roles slot.",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "credit association",
+      "slot_uri": "prov:hadRole",
+      "multivalued": false,
+      "range": "credit enum",
+      "required": false
+    },
+    "applied roles": {
+      "name": "applied roles",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "credit association",
+      "multivalued": true,
+      "range": "credit enum",
+      "required": true
+    },
+    "applies to person": {
+      "name": "applies to person",
+      "todos": [
+        "prov:agent takes an Agent object. Is a person value an Agent? Also try to relate to principal investigator slot? could include OBI:0000103 principal investigator role... do we need to define the OBI prefix?"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "credit association",
+      "slot_uri": "prov:agent",
+      "multivalued": false,
+      "range": "person value",
+      "required": true
+    },
+    "object set": {
+      "name": "object set",
+      "description": "Applies to a property that links a database object to a set of objects. This is necessary in a json document to provide context for a list, and to allow for a single json object that combines multiple object types",
+      "from_schema": "https://microbiomedata/schema",
+      "mixin": true,
+      "domain": "database",
+      "multivalued": true,
+      "inlined_as_list": true
+    },
+    "biosample set": {
+      "name": "biosample set",
+      "description": "This property links a database object to the set of samples within it.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "biosample"
+    },
+    "study set": {
+      "name": "study set",
+      "description": "This property links a database object to the set of studies within it.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "study"
+    },
+    "data object set": {
+      "name": "data object set",
+      "description": "This property links a database object to the set of data objects within it.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "data object"
+    },
+    "genome feature set": {
+      "name": "genome feature set",
+      "description": "This property links a database object to the set of all features",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "genome feature"
+    },
+    "functional annotation set": {
+      "name": "functional annotation set",
+      "description": "This property links a database object to the set of all functional annotations",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "functional annotation"
+    },
+    "activity set": {
+      "name": "activity set",
+      "description": "This property links a database object to the set of workflow activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "workflow execution activity"
+    },
+    "mags activity set": {
+      "name": "mags activity set",
+      "description": "This property links a database object to the set of MAGs analysis activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "MAGs analysis activity"
+    },
+    "metabolomics analysis activity set": {
+      "name": "metabolomics analysis activity set",
+      "description": "This property links a database object to the set of metabolomics analysis activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "metabolomics analysis activity"
+    },
+    "metaproteomics analysis activity set": {
+      "name": "metaproteomics analysis activity set",
+      "description": "This property links a database object to the set of metaproteomics analysis activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "metaproteomics analysis activity"
+    },
+    "metagenome annotation activity set": {
+      "name": "metagenome annotation activity set",
+      "description": "This property links a database object to the set of metagenome annotation activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "metagenome annotation activity"
+    },
+    "metagenome assembly set": {
+      "name": "metagenome assembly set",
+      "description": "This property links a database object to the set of metagenome assembly activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "metagenome assembly"
+    },
+    "metatranscriptome activity set": {
+      "name": "metatranscriptome activity set",
+      "description": "This property links a database object to the set of metatranscriptome analysis activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "metatranscriptome activity"
+    },
+    "read QC analysis activity set": {
+      "name": "read QC analysis activity set",
+      "description": "This property links a database object to the set of read QC analysis activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "read QC analysis activity"
+    },
+    "read based analysis activity set": {
+      "name": "read based analysis activity set",
+      "description": "This property links a database object to the set of read based analysis activities.\n  ",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "read based analysis activity"
+    },
+    "nom analysis activity set": {
+      "name": "nom analysis activity set",
+      "description": "This property links a database object to the set of natural organic matter (NOM) analysis activities.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "nom analysis activity"
+    },
+    "omics processing set": {
+      "name": "omics processing set",
+      "description": "This property links a database object to the set of omics processings within it.",
+      "from_schema": "https://microbiomedata/schema",
+      "mixins": [
+        "object set"
+      ],
+      "domain": "database",
+      "multivalued": true,
+      "range": "omics processing"
+    },
+    "omics type": {
+      "name": "omics type",
+      "description": "The type of omics data",
+      "examples": [
+        {
+          "value": "metatranscriptome"
+        },
+        {
+          "value": "metagenome"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "controlled term value"
+    },
+    "data object type": {
+      "name": "data object type",
+      "description": "The type of file represented by the data object.",
+      "examples": [
+        {
+          "value": "FT ICR-MS Analysis Results"
+        },
+        {
+          "value": "GC-MS Metabolomics Results"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "file type enum"
+    },
+    "compression type": {
+      "name": "compression type",
+      "description": "If provided, specifies the compression type",
+      "todos": [
+        "consider enum"
+      ],
+      "examples": [
+        {
+          "value": "gzip"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "instrument_name": {
+      "name": "instrument_name",
+      "description": "The name of the instrument that was used for processing the sample.\n   ",
+      "from_schema": "https://microbiomedata/schema"
+    },
+    "gold_path_field": {
+      "name": "gold_path_field",
+      "description": "This is a grouping for any of the gold path fields          ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "abstract": true,
+      "range": "string"
+    },
+    "ecosystem": {
+      "name": "ecosystem",
+      "description": "An ecosystem is a combination of a physical environment (abiotic factors) and all the organisms (biotic factors) that interact with this environment. Ecosystem is in position 1/5 in a GOLD path.",
+      "comments": [
+        "The abiotic factors play a profound role on the type and composition of organisms in a given environment. The GOLD Ecosystem at the top of the five-level classification system is aimed at capturing the broader environment from which an organism or environmental sample is collected. The three broad groups under Ecosystem are Environmental, Host-associated, and Engineered. They represent samples collected from a natural environment or from another organism or from engineered environments like bioreactors respectively."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/help"
+      ],
+      "is_a": "gold_path_field"
+    },
+    "ecosystem_category": {
+      "name": "ecosystem_category",
+      "description": "Ecosystem categories represent divisions within the ecosystem based on specific characteristics of the environment from where an organism or sample is isolated. Ecosystem category is in position 2/5 in a GOLD path.",
+      "comments": [
+        "The Environmental ecosystem (for example) is divided into Air, Aquatic and Terrestrial. Ecosystem categories for Host-associated samples can be individual hosts or phyla and for engineered samples it may be manipulated environments like bioreactors, solid waste etc."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/help"
+      ],
+      "is_a": "gold_path_field"
+    },
+    "ecosystem_type": {
+      "name": "ecosystem_type",
+      "description": "Ecosystem types represent things having common characteristics within the Ecosystem Category. These common characteristics based grouping is still broad but specific to the characteristics of a given environment. Ecosystem type is in position 3/5 in a GOLD path.",
+      "comments": [
+        "The Aquatic ecosystem category (for example) may have ecosystem types like Marine or Thermal springs etc. Ecosystem category Air may have Indoor air or Outdoor air as different Ecosystem Types. In the case of Host-associated samples, ecosystem type can represent Respiratory system, Digestive system, Roots etc."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/help"
+      ],
+      "is_a": "gold_path_field"
+    },
+    "ecosystem_subtype": {
+      "name": "ecosystem_subtype",
+      "description": "Ecosystem subtypes represent further subdivision of Ecosystem types into more distinct subtypes. Ecosystem subtype is in position 4/5 in a GOLD path.",
+      "comments": [
+        "Ecosystem Type Marine (Environmental -> Aquatic -> Marine) is further divided (for example) into Intertidal zone, Coastal, Pelagic, Intertidal zone etc. in the Ecosystem subtype category."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/help"
+      ],
+      "is_a": "gold_path_field"
+    },
+    "specific_ecosystem": {
+      "name": "specific_ecosystem",
+      "description": "Specific ecosystems represent specific features of the environment like aphotic zone in an ocean or gastric mucosa within a host digestive system. Specific ecosystem is in position 5/5 in a GOLD path.",
+      "comments": [
+        "Specific ecosystems help to define samples based on very specific characteristics of an environment under the five-level classification system."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/help"
+      ],
+      "is_a": "gold_path_field"
+    },
+    "principal investigator": {
+      "name": "principal investigator",
+      "aliases": [
+        "PI"
+      ],
+      "description": "Principal Investigator who led the study and/or generated the dataset.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "range": "person value"
+    },
+    "doi": {
+      "name": "doi",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "range": "attribute value"
+    },
+    "add_date": {
+      "name": "add_date",
+      "description": "The date on which the information was added to the database.",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "mod_date": {
+      "name": "mod_date",
+      "description": "The last date on which the database information was modified.",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "ecosystem_path_id": {
+      "name": "ecosystem_path_id",
+      "description": "A unique id representing the GOLD classifers associated with a sample.",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "habitat": {
+      "name": "habitat",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "location": {
+      "name": "location",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "community": {
+      "name": "community",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "ncbi_taxonomy_name": {
+      "name": "ncbi_taxonomy_name",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "ncbi_project_name": {
+      "name": "ncbi_project_name",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "sample_collection_site": {
+      "name": "sample_collection_site",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "identifier": {
+      "name": "identifier",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "sample_collection_year": {
+      "name": "sample_collection_year",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "sample_collection_month": {
+      "name": "sample_collection_month",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "sample_collection_day": {
+      "name": "sample_collection_day",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "sample_collection_hour": {
+      "name": "sample_collection_hour",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "sample_collection_minute": {
+      "name": "sample_collection_minute",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "salinity_category": {
+      "name": "salinity_category",
+      "description": "Categorcial description of the sample's salinity. Examples: halophile, halotolerant, hypersaline, huryhaline",
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://github.com/microbiomedata/nmdc-metadata/pull/297"
+      ],
+      "range": "string"
+    },
+    "soluble_iron_micromol": {
+      "name": "soluble_iron_micromol",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "host_name": {
+      "name": "host_name",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "depth2": {
+      "name": "depth2",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "quantity value"
+    },
+    "subsurface_depth": {
+      "name": "subsurface_depth",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "quantity value"
+    },
+    "subsurface_depth2": {
+      "name": "subsurface_depth2",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "quantity value"
+    },
+    "proport_woa_temperature": {
+      "name": "proport_woa_temperature",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "biogas_temperature": {
+      "name": "biogas_temperature",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "soil_annual_season_temp": {
+      "name": "soil_annual_season_temp",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "biogas_retention_time": {
+      "name": "biogas_retention_time",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "processing_institution": {
+      "name": "processing_institution",
+      "description": "The organization that processed the sample.",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "omics_type": {
+      "name": "omics_type",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "completion_date": {
+      "name": "completion_date",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "external database identifiers": {
+      "name": "external database identifiers",
+      "close_mappings": [
+        "skos:closeMatch"
+      ],
+      "description": "Link to corresponding identifier in external database",
+      "comments": [
+        "The value of this field is always a registered CURIE"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "alternative identifiers",
+      "abstract": true,
+      "multivalued": true,
+      "range": "external identifier"
+    },
+    "GOLD identifiers": {
+      "name": "GOLD identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/"
+      ],
+      "mixin": true
+    },
+    "MGnify identifiers": {
+      "name": "MGnify identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://www.ebi.ac.uk/metagenomics/"
+      ],
+      "mixin": true
+    },
+    "INSDC identifiers": {
+      "name": "INSDC identifiers",
+      "aliases": [
+        "EBI identifiers",
+        "NCBI identifiers",
+        "DDBJ identifiers"
+      ],
+      "description": "Any identifier covered by the International Nucleotide Sequence Database Collaboration",
+      "comments": [
+        "note that we deliberately abstract over which of the partner databases accepted the initial submission",
+        "{'the first letter of the accession indicates which partner accepted the initial submission': 'E for ENA, D for DDBJ, or S or N for NCBI.'}"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://www.insdc.org/",
+        "https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html"
+      ],
+      "mixin": true
+    },
+    "study identifiers": {
+      "name": "study identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "external database identifiers",
+      "abstract": true
+    },
+    "INSDC SRA ENA study identifiers": {
+      "name": "INSDC SRA ENA study identifiers",
+      "aliases": [
+        "EBI ENA study identifiers",
+        "NCBI SRA identifiers",
+        "DDBJ SRA identifiers"
+      ],
+      "description": "identifiers for corresponding project in INSDC SRA / ENA",
+      "examples": [
+        {
+          "value": "https://identifiers.org/insdc.sra:SRP121659",
+          "description": "Avena fatua rhizosphere microbial communities - H1_Rhizo_Litter_2 metatranscriptome"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://github.com/bioregistry/bioregistry/issues/109",
+        "https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies",
+        "https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies"
+      ],
+      "is_a": "study identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "multivalued": true,
+      "pattern": "^insdc.sra:(E|D|S)RP[0-9]{6,}$"
+    },
+    "INSDC bioproject identifiers": {
+      "name": "INSDC bioproject identifiers",
+      "aliases": [
+        "NCBI bioproject identifiers",
+        "DDBJ bioproject identifiers"
+      ],
+      "description": "identifiers for corresponding project in INSDC Bioproject",
+      "comments": [
+        "these are distinct IDs from INSDC SRA/ENA project identifiers, but are usually(?) one to one"
+      ],
+      "examples": [
+        {
+          "value": "https://identifiers.org/bioproject:PRJNA366857",
+          "description": "Avena fatua rhizosphere microbial communities - H1_Rhizo_Litter_2 metatranscriptome"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://www.ncbi.nlm.nih.gov/bioproject/",
+        "https://www.ddbj.nig.ac.jp/bioproject/index-e.html"
+      ],
+      "is_a": "study identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "pattern": "^bioproject:PRJ[DEN][A-Z][0-9]+$"
+    },
+    "GOLD study identifiers": {
+      "name": "GOLD study identifiers",
+      "description": "identifiers for corresponding project in GOLD",
+      "examples": [
+        {
+          "value": "https://identifiers.org/gold:Gs0110115"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://gold.jgi.doe.gov/studies"
+      ],
+      "is_a": "study identifiers",
+      "mixins": [
+        "GOLD identifiers"
+      ],
+      "multivalued": true,
+      "pattern": "^GOLD:Gs[0-9]+$"
+    },
+    "MGnify project identifiers": {
+      "name": "MGnify project identifiers",
+      "description": "identifiers for corresponding project in MGnify",
+      "examples": [
+        {
+          "value": "https://identifiers.org/mgnify.proj:MGYS00005757"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "study identifiers",
+      "pattern": "^mgnify.proj:[A-Z]+[0-9]+$"
+    },
+    "sample identifiers": {
+      "name": "sample identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "external database identifiers",
+      "abstract": true
+    },
+    "GOLD sample identifiers": {
+      "name": "GOLD sample identifiers",
+      "description": "identifiers for corresponding sample in GOLD",
+      "examples": [
+        {
+          "value": "https://identifiers.org/gold:Gb0312930"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "sample identifiers",
+      "mixins": [
+        "GOLD identifiers"
+      ],
+      "multivalued": true,
+      "pattern": "^GOLD:Gb[0-9]+$"
+    },
+    "INSDC biosample identifiers": {
+      "name": "INSDC biosample identifiers",
+      "aliases": [
+        "EBI biosample identifiers",
+        "NCBI biosample identifiers",
+        "DDBJ biosample identifiers"
+      ],
+      "description": "identifiers for corresponding sample in INSDC",
+      "examples": [
+        {
+          "value": "https://identifiers.org/biosample:SAMEA5989477"
+        },
+        {
+          "value": "https://identifiers.org/biosample:SAMD00212331",
+          "description": "I13_N_5-10 sample from Soil fungal diversity along elevational gradients"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://github.com/bioregistry/bioregistry/issues/108",
+        "https://www.ebi.ac.uk/biosamples/",
+        "https://www.ncbi.nlm.nih.gov/biosample",
+        "https://www.ddbj.nig.ac.jp/biosample/index-e.html"
+      ],
+      "is_a": "sample identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "multivalued": true,
+      "pattern": "^biosample:SAM[NED]([A-Z])?[0-9]+$"
+    },
+    "INSDC secondary sample identifiers": {
+      "name": "INSDC secondary sample identifiers",
+      "description": "secondary identifiers for corresponding sample in INSDC",
+      "comments": [
+        "ENA redirects these to primary IDs, e.g. https://www.ebi.ac.uk/ena/browser/view/DRS166340 -> SAMD00212331",
+        "MGnify uses these as their primary sample IDs"
+      ],
+      "examples": [
+        {
+          "value": "https://identifiers.org/insdc.sra:DRS166340",
+          "description": "I13_N_5-10 sample from Soil fungal diversity along elevational gradients"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "sample identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "pattern": "^biosample:(E|D|S)RS[0-9]{6,}$"
+    },
+    "omics processing identifiers": {
+      "name": "omics processing identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "external database identifiers",
+      "abstract": true
+    },
+    "GOLD sequencing project identifiers": {
+      "name": "GOLD sequencing project identifiers",
+      "description": "identifiers for corresponding sequencing project in GOLD",
+      "examples": [
+        {
+          "value": "https://identifiers.org/gold:Gp0108335"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "external database identifiers",
+      "mixins": [
+        "GOLD identifiers"
+      ],
+      "multivalued": true,
+      "pattern": "^GOLD:Gp[0-9]+$"
+    },
+    "INSDC experiment identifiers": {
+      "name": "INSDC experiment identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "external database identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "pattern": "^insdc.sra:(E|D|S)RX[0-9]{6,}$"
+    },
+    "analysis identifiers": {
+      "name": "analysis identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "external database identifiers",
+      "abstract": true
+    },
+    "GOLD analysis project identifiers": {
+      "name": "GOLD analysis project identifiers",
+      "description": "identifiers for corresponding analysis project in GOLD",
+      "examples": [
+        {
+          "value": "https://identifiers.org/gold:Ga0526289"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "analysis identifiers",
+      "mixins": [
+        "GOLD identifiers"
+      ],
+      "multivalued": true,
+      "pattern": "^GOLD:Ga[0-9]+$"
+    },
+    "INSDC analysis identifiers": {
+      "name": "INSDC analysis identifiers",
+      "comments": [
+        "in INSDC this is a run but it corresponds to a GOLD analysis"
+      ],
+      "examples": [
+        {
+          "value": "https://www.ebi.ac.uk/metagenomics/runs/DRR218479",
+          "description": "Illumina MiSeq paired end sequencing of SAMD00212331"
+        },
+        {
+          "value": "https://www.ebi.ac.uk/ena/browser/view/ERR436051"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "analysis identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "pattern": "^insdc.sra:(E|D|S)RR[0-9]{6,}$"
+    },
+    "MGnify analysis identifiers": {
+      "name": "MGnify analysis identifiers",
+      "examples": [
+        {
+          "value": "https://www.ebi.ac.uk/metagenomics/analyses/MGYA00002270",
+          "description": "combined analyses (taxonomic, functional) of sample ERS438107"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "analysis identifiers",
+      "mixins": [
+        "MGnify identifiers"
+      ]
+    },
+    "assembly identifiers": {
+      "name": "assembly identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "abstract": true
+    },
+    "INSDC assembly identifiers": {
+      "name": "INSDC assembly identifiers",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "assembly identifiers",
+      "mixins": [
+        "INSDC identifiers"
+      ],
+      "pattern": "^insdc.sra:[A-Z]+[0-9]+(\\.[0-9]+)?$"
+    },
+    "language": {
+      "name": "language",
+      "description": "Should use ISO 639-1 code e.g. \"en\", \"fr\"",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "language code"
+    },
+    "attribute": {
+      "name": "attribute",
+      "aliases": [
+        "field",
+        "property",
+        "template field",
+        "key",
+        "characteristic"
+      ],
+      "description": "A attribute of a biosample. Examples: depth, habitat, material. For NMDC, attributes SHOULD be mapped to terms within a MIxS template",
+      "from_schema": "https://microbiomedata/schema",
+      "abstract": true
+    },
+    "has raw value": {
+      "name": "has raw value",
+      "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "attribute value",
+      "multivalued": false,
+      "range": "string",
+      "required": false
+    },
+    "has unit": {
+      "name": "has unit",
+      "aliases": [
+        "scale"
+      ],
+      "mappings": [
+        "qud:unit",
+        "schema:unitCode"
+      ],
+      "description": "Links a quantity value to a unit",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "unit"
+    },
+    "has numeric value": {
+      "name": "has numeric value",
+      "mappings": [
+        "qud:quantityValue",
+        "schema:value"
+      ],
+      "description": "Links a quantity value to a number",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": false,
+      "range": "float"
+    },
+    "has minimum numeric value": {
+      "name": "has minimum numeric value",
+      "description": "The minimum value part, expressed as number, of the quantity value when the value covers a range.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "has numeric value"
+    },
+    "has maximum numeric value": {
+      "name": "has maximum numeric value",
+      "description": "The maximum value part, expressed as number, of the quantity value when the value covers a range.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "has numeric value"
+    },
+    "has boolean value": {
+      "name": "has boolean value",
+      "description": "Links a quantity value to a boolean",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": false,
+      "range": "boolean"
+    },
+    "latitude": {
+      "name": "latitude",
+      "mappings": [
+        "schema:latitude"
+      ],
+      "description": "latitude",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "geolocation value",
+      "slot_uri": "wgs:lat",
+      "range": "decimal degree"
+    },
+    "longitude": {
+      "name": "longitude",
+      "mappings": [
+        "schema:longitude"
+      ],
+      "description": "longitude",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "geolocation value",
+      "slot_uri": "wgs:long",
+      "range": "decimal degree"
+    },
+    "term": {
+      "name": "term",
+      "description": "pointer to an ontology class",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "controlled term value",
+      "slot_uri": "rdf:type",
+      "inlined": true,
+      "range": "ontology class"
+    },
+    "orcid": {
+      "name": "orcid",
+      "description": "The ORICD of a person.",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "person value",
+      "range": "string"
+    },
+    "email": {
+      "name": "email",
+      "description": "An email address for an entity such as a person. This should be the primarly email address used.",
+      "from_schema": "https://microbiomedata/schema",
+      "slot_uri": "schema:email",
+      "range": "string"
+    },
+    "alternate emails": {
+      "name": "alternate emails",
+      "description": "One or more other email addresses for an entity.",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "profile image url": {
+      "name": "profile image url",
+      "description": "A url that points to an image of a person.",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "person value",
+      "range": "string"
+    },
+    "has input": {
+      "name": "has input",
+      "aliases": [
+        "input"
+      ],
+      "description": "An input to a process.",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "named thing",
+      "multivalued": true,
+      "range": "named thing"
+    },
+    "has output": {
+      "name": "has output",
+      "aliases": [
+        "output"
+      ],
+      "description": "An output biosample to a processing step",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "named thing",
+      "multivalued": true,
+      "range": "named thing"
+    },
+    "part of": {
+      "name": "part of",
+      "aliases": [
+        "is part of"
+      ],
+      "description": "Links a resource to another resource that either logically or physically includes it.",
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "named thing",
+      "slot_uri": "dcterms:isPartOf",
+      "multivalued": true,
+      "range": "named thing"
+    },
+    "execution resource": {
+      "name": "execution resource",
+      "description": "Example: NERSC-Cori",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute"
+    },
+    "url": {
+      "name": "url",
+      "notes": [
+        "See issue 207 - this clashes with the mixs field"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "range": "string"
+    },
+    "display order": {
+      "name": "display order",
+      "description": "When rendering information, this attribute to specify the order in which the information should be rendered.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute"
+    },
+    "git url": {
+      "name": "git url",
+      "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "range": "string"
+    },
+    "file size bytes": {
+      "name": "file size bytes",
+      "description": "Size of the file in bytes",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "range": "bytes"
+    },
+    "md5 checksum": {
+      "name": "md5 checksum",
+      "description": "MD5 checksum of file (pre-compressed)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "range": "string"
+    },
+    "abstract": {
+      "name": "abstract",
+      "exact_mappings": [
+        "dcterms:abstract"
+      ],
+      "description": "The abstract of manuscript/grant associated with the entity; i.e., a summary of the resource.",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "keywords": {
+      "name": "keywords",
+      "mappings": [
+        "dcterms:subject"
+      ],
+      "description": "A list of keywords that used to associate the entity. Keywords SHOULD come from controlled vocabularies, including MESH, ENVO.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "objective": {
+      "name": "objective",
+      "mappings": [
+        "sio:000337"
+      ],
+      "description": "The scientific objectives associated with the entity. It SHOULD correspond to scientific norms for objectives field in a structured abstract.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": false,
+      "range": "string"
+    },
+    "websites": {
+      "name": "websites",
+      "description": "A list of websites that are assocatiated with the entity.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "publications": {
+      "name": "publications",
+      "description": "A list of publications that are assocatiated with the entity. The publicatons SHOULD be given using an identifier, such as a DOI or Pubmed ID, if possible.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "started at time": {
+      "name": "started at time",
+      "mappings": [
+        "prov:startedAtTime"
+      ],
+      "comments": [
+        "The regex for ISO-8601 format was taken from here: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ It may not be complete, but it is good enough for now."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "datetime",
+      "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+    },
+    "ended at time": {
+      "name": "ended at time",
+      "mappings": [
+        "prov:endedAtTime"
+      ],
+      "comments": [
+        "The regex for ISO-8601 format was taken from here: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ It may not be complete, but it is good enough for now."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "datetime",
+      "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+    },
+    "was informed by": {
+      "name": "was informed by",
+      "mappings": [
+        "prov:wasInformedBy"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "activity"
+    },
+    "was associated with": {
+      "name": "was associated with",
+      "mappings": [
+        "prov:wasAssociatedWith"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "agent"
+    },
+    "acted on behalf of": {
+      "name": "acted on behalf of",
+      "mappings": [
+        "prov:actedOnBehalfOf"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "agent"
+    },
+    "was generated by": {
+      "name": "was generated by",
+      "mappings": [
+        "prov:wasGeneratedBy"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "activity"
+    },
+    "used": {
+      "name": "used",
+      "mappings": [
+        "prov:used"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "domain": "activity"
+    },
+    "id": {
+      "name": "id",
+      "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": false,
+      "identifier": true
+    },
+    "name": {
+      "name": "name",
+      "description": "A human readable label for an entity",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": false,
+      "range": "string"
+    },
+    "description": {
+      "name": "description",
+      "description": "a human-readable description of a thing",
+      "from_schema": "https://microbiomedata/schema",
+      "slot_uri": "dcterms:description",
+      "multivalued": false,
+      "range": "string"
+    },
+    "type": {
+      "name": "type",
+      "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+      "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+      "examples": [
+        {
+          "value": "nmdc:Biosample"
+        },
+        {
+          "value": "nmdc:Study"
+        }
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "designates_type": true,
+      "range": "string"
+    },
+    "title": {
+      "name": "title",
+      "exact_mappings": [
+        "dcterms:title"
+      ],
+      "description": "A name given to the entity that differs from the name/label programatically assigned to it. For example, when extracting study information for GOLD, the GOLD system has assigned a name/label. However, for display purposes, we may also wish the capture the title of the proposal that was used to fund the study.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": false,
+      "range": "string"
+    },
+    "alternative titles": {
+      "name": "alternative titles",
+      "exact_mappings": [
+        "dcterms:alternative"
+      ],
+      "description": "A list of alternative titles for the entity. The distinction between title and alternative titles is application-specific.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "alternative names": {
+      "name": "alternative names",
+      "exact_mappings": [
+        "dcterms:alternative",
+        "skos:altLabel"
+      ],
+      "description": "A list of alternative names used to refer to the entity. The distinction between name and alternative names is application-specific.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "alternative descriptions": {
+      "name": "alternative descriptions",
+      "description": "A list of alternative descriptions for the entity. The distinction between desciption and alternative descriptions is application-specific.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "alternative identifiers": {
+      "name": "alternative identifiers",
+      "description": "A list of alternative identifiers for the entity.",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "string"
+    },
+    "subject": {
+      "name": "subject",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "gene product"
+    },
+    "has function": {
+      "name": "has function",
+      "comments": [
+        "the range for has_function was asserted as functional_annotation_term,",
+        "but is actually taking string arguments in the Polyneme MongoDB,",
+        "and those are frequently fulltext, not CURIEs. MAM 2021-06-23"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "string"
+    },
+    "has participants": {
+      "name": "has participants",
+      "exact_mappings": [
+        "RO:0000057"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "abstract": true
+    },
+    "gff coordinate": {
+      "name": "gff coordinate",
+      "description": "A positive 1-based integer coordinate indicating start or end",
+      "comments": [
+        "For features that cross the origin of a circular feature (e.g. most bacterial genomes, plasmids, and some viral genomes), the requirement for start to be less than or equal to end is satisfied by making end = the position of the end + the length of the landmark feature."
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer",
+      "minimum_value": 1
+    },
+    "metagenome assembly parameter": {
+      "name": "metagenome assembly parameter",
+      "from_schema": "https://microbiomedata/schema"
+    },
+    "asm_score": {
+      "name": "asm_score",
+      "description": "A score for comparing metagenomic assembly quality from same sample.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaffolds": {
+      "name": "scaffolds",
+      "description": "Total sequence count of all scaffolds.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_logsum": {
+      "name": "scaf_logsum",
+      "description": "The sum of the (length*log(length)) of all scaffolds, times some constant.  Increase the contiguity, the score will increase",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_powsum": {
+      "name": "scaf_powsum",
+      "description": "Powersum of all scaffolds is the same as logsum except that it uses the sum of (length*(length^P)) for some power P (default P=0.25).",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_max": {
+      "name": "scaf_max",
+      "description": "Maximum scaffold length.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_bp": {
+      "name": "scaf_bp",
+      "description": "Total size in bp of all scaffolds.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_N50": {
+      "name": "scaf_N50",
+      "description": "Given a set of scaffolds, each with its own length, the N50 count is defined as the smallest number of scaffolds whose length sum makes up half of genome size.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_N90": {
+      "name": "scaf_N90",
+      "description": "Given a set of scaffolds, each with its own length, the N90 count is defined as the smallest number of scaffolds whose length sum makes up 90% of genome size.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_L50": {
+      "name": "scaf_L50",
+      "description": "Given a set of scaffolds, the L50 is defined as the sequence length of the shortest scaffold at 50% of the total genome length.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_L90": {
+      "name": "scaf_L90",
+      "description": "The L90 statistic is less than or equal to the L50 statistic; it is the length for which the collection of all scaffolds of that length or longer contains at least 90% of the sum of the lengths of all scaffolds.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_n_gt50K": {
+      "name": "scaf_n_gt50K",
+      "description": "Total sequence count of scaffolds greater than 50 KB.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_l_gt50K": {
+      "name": "scaf_l_gt50K",
+      "description": "Total size in bp of all scaffolds greater than 50 KB.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "scaf_pct_gt50K": {
+      "name": "scaf_pct_gt50K",
+      "description": "Total sequence size percentage of scaffolds greater than 50 KB.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "contigs": {
+      "name": "contigs",
+      "description": "The sum of the (length*log(length)) of all contigs, times some constant.  Increase the contiguity, the score will increase",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "contig_bp": {
+      "name": "contig_bp",
+      "description": "Total size in bp of all contigs.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_N50": {
+      "name": "ctg_N50",
+      "description": "Given a set of contigs, each with its own length, the N50 count is defined as the smallest number of contigs whose length sum makes up half of genome size.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_L50": {
+      "name": "ctg_L50",
+      "description": "Given a set of contigs, the L50 is defined as the sequence length of the shortest contig at 50% of the total genome length.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_N90": {
+      "name": "ctg_N90",
+      "description": "Given a set of contigs, each with its own length, the N90 count is defined as the smallest number of contigs whose length sum makes up 90% of genome size.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_L90": {
+      "name": "ctg_L90",
+      "description": "The L90 statistic is less than or equal to the L50 statistic; it is the length for which the collection of all contigs of that length or longer contains at least 90% of the sum of the lengths of all contigs.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_logsum": {
+      "name": "ctg_logsum",
+      "description": "Maximum contig length.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_powsum": {
+      "name": "ctg_powsum",
+      "description": "Powersum of all contigs is the same as logsum except that it uses the sum of (length*(length^P)) for some power P (default P=0.25).",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "ctg_max": {
+      "name": "ctg_max",
+      "description": "Maximum contig length.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "gap_pct": {
+      "name": "gap_pct",
+      "description": "The gap size percentage of all scaffolds.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "gc_std": {
+      "name": "gc_std",
+      "description": "Standard deviation of GC content of all contigs.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "gc_avg": {
+      "name": "gc_avg",
+      "description": "Average of GC content of all contigs.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "num_input_reads": {
+      "name": "num_input_reads",
+      "description": "The sequence count number of input reads for assembly.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "num_aligned_reads": {
+      "name": "num_aligned_reads",
+      "description": "The sequence count number of input reads aligned to assembled contigs.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "metagenome assembly parameter",
+      "range": "float"
+    },
+    "read QC analysis statistic": {
+      "name": "read QC analysis statistic",
+      "from_schema": "https://microbiomedata/schema"
+    },
+    "mags list": {
+      "name": "mags list",
+      "from_schema": "https://microbiomedata/schema",
+      "multivalued": true,
+      "range": "MAG bin"
+    },
+    "too short contig num": {
+      "name": "too short contig num",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "binned contig num": {
+      "name": "binned contig num",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "input contig num": {
+      "name": "input contig num",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "unbinned contig num": {
+      "name": "unbinned contig num",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "lowDepth contig num": {
+      "name": "lowDepth contig num",
+      "from_schema": "https://microbiomedata/schema",
+      "range": "integer"
+    },
+    "input read count": {
+      "name": "input read count",
+      "description": "The sequence count number of input reads for QC analysis.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "read QC analysis statistic",
+      "range": "float"
+    },
+    "input base count": {
+      "name": "input base count",
+      "description": "The nucleotide base count number of input reads for QC analysis.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "read QC analysis statistic",
+      "range": "float"
+    },
+    "output read count": {
+      "name": "output read count",
+      "description": "After QC analysis sequence count number. ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "read QC analysis statistic",
+      "range": "float"
+    },
+    "output base count": {
+      "name": "output base count",
+      "description": "After QC analysis nucleotide base count number.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "read QC analysis statistic",
+      "range": "float"
+    },
+    "submitted_to_insdc": {
+      "name": "submitted_to_insdc",
+      "aliases": [
+        "submitted to insdc"
+      ],
+      "mappings": [
+        "mixs:submitted_to_insdc"
+      ],
+      "description": "Depending on the study (large-scale e.g. done with next generation sequencing technology, or small-scale) sequences have to be submitted to SRA (Sequence Read Archive), DRA (DDBJ Read Archive) or via the classical Webin/Sequin systems to Genbank, ENA and DDBJ. Although this field is mandatory, it is meant as a self-test field, therefore it is not necessary to include this field in contextual data submitted to databases",
+      "in_subset": [
+        "investigation"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "investigation_type": {
+      "name": "investigation_type",
+      "aliases": [
+        "investigation type"
+      ],
+      "mappings": [
+        "mixs:investigation_type"
+      ],
+      "description": "Nucleic Acid Sequence Report is the root element of all MIGS/MIMS compliant reports as standardized by Genomic Standards Consortium. This field is either eukaryote,bacteria,virus,plasmid,organelle, metagenome,mimarks-survey, mimarks-specimen, metatranscriptome, single amplified genome, metagenome-assembled genome, or uncultivated viral genome",
+      "in_subset": [
+        "investigation"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[eukaryote|bacteria_archaea|plasmid|virus|organelle|metagenome|metatranscriptome|mimarks\\-survey|mimarks\\-specimen|misag|mimag|miuvig]"
+    },
+    "project_name": {
+      "name": "project_name",
+      "aliases": [
+        "project name"
+      ],
+      "mappings": [
+        "mixs:project_name"
+      ],
+      "description": "Name of the project within which the sequencing was organized",
+      "in_subset": [
+        "investigation"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "experimental_factor": {
+      "name": "experimental_factor",
+      "aliases": [
+        "experimental factor"
+      ],
+      "mappings": [
+        "mixs:experimental_factor"
+      ],
+      "description": "Experimental factors are essentially the variable aspects of an experiment design which can be used to describe an experiment, or set of experiments, in an increasingly detailed manner. This field accepts ontology terms from Experimental Factor Ontology (EFO) and/or Ontology for Biomedical Investigations (OBI). For a browser of EFO (v 2.95) terms, please see http://purl.bioontology.org/ontology/EFO; for a browser of OBI (v 2018-02-12) terms please see http://purl.bioontology.org/ontology/OBI",
+      "in_subset": [
+        "investigation"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value"
+    },
+    "lat_lon": {
+      "name": "lat_lon",
+      "aliases": [
+        "geographic location (latitude and longitude)"
+      ],
+      "mappings": [
+        "mixs:lat_lon"
+      ],
+      "description": "The geographical origin of the sample as defined by latitude and longitude. The values should be reported in decimal degrees and in WGS84 system",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {float}",
+      "multivalued": false,
+      "range": "geolocation value",
+      "pattern": "\\d+[.\\d+] \\d+[.\\d+]"
+    },
+    "depth": {
+      "name": "depth",
+      "aliases": [
+        "geographic location (depth)"
+      ],
+      "mappings": [
+        "mixs:depth"
+      ],
+      "description": "Depth is defined as the vertical distance below local surface, e.g. For sediment or soil samples depth is measured from sediment or soil surface, respectively. Depth can be reported as an interval for subsurface samples",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "alt": {
+      "name": "alt",
+      "aliases": [
+        "altitude"
+      ],
+      "mappings": [
+        "mixs:alt"
+      ],
+      "description": "Altitude is a term used to identify heights of objects such as airplanes, space shuttles, rockets, atmospheric balloons and heights of places such as atmospheric layers and clouds. It is used to measure the height of an object which is above the earthbs surface. In this context, the altitude measurement is the vertical distance between the earth's surface above sea level and the sampled position in the air",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "elev": {
+      "name": "elev",
+      "aliases": [
+        "elevation"
+      ],
+      "mappings": [
+        "mixs:elev"
+      ],
+      "description": "Elevation of the sampling site is its height above a fixed reference point, most commonly the mean sea level. Elevation is mainly used when referring to points on the earth's surface, while altitude is used for points above the surface, such as an aircraft in flight or a spacecraft in orbit",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "geo_loc_name": {
+      "name": "geo_loc_name",
+      "aliases": [
+        "geographic location (country and/or sea,region)"
+      ],
+      "mappings": [
+        "mixs:geo_loc_name"
+      ],
+      "description": "The geographical origin of the sample as defined by the country or sea name followed by specific region name. Country or sea names should be chosen from the INSDC country list (http://insdc.org/country.html), or the GAZ ontology (v 1.512) (http://purl.bioontology.org/ontology/GAZ)",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "collection_date": {
+      "name": "collection_date",
+      "aliases": [
+        "collection date"
+      ],
+      "mappings": [
+        "mixs:collection_date"
+      ],
+      "description": "The time of sampling, either as an instance (single point in time) or interval. In case no exact time is available, the date/time can be right truncated i.e. all of these are valid times: 2008-01-23T19:23:10+00:00; 2008-01-23T19:23:10; 2008-01-23; 2008-01; 2008; Except: 2008-01; 2008 all are ISO8601 compliant",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "env_broad_scale": {
+      "name": "env_broad_scale",
+      "aliases": [
+        "broad-scale environmental context"
+      ],
+      "mappings": [
+        "mixs:env_broad_scale"
+      ],
+      "description": "In this field, report which major environmental system your sample or specimen came from. The systems identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. were you in the desert or a rainforest?). We recommend using subclasses of ENVOUs biome class: http://purl.obolibrary.org/obo/ENVO_00000428. Format (one term): termLabel [termID], Format (multiple terms): termLabel [termID]|termLabel [termID]|termLabel [termID]. Example: Annotating a water sample from the photic zone in middle of the Atlantic Ocean, consider: oceanic epipelagic zone biome [ENVO:01000033]. Example: Annotating a sample from the Amazon rainforest consider: tropical moist broadleaf forest biome [ENVO:01000228]. If needed, request new terms on the ENVO tracker, identified here: http://www.obofoundry.org/ontology/envo.html",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "env_local_scale": {
+      "name": "env_local_scale",
+      "aliases": [
+        "local environmental context"
+      ],
+      "mappings": [
+        "mixs:env_local_scale"
+      ],
+      "description": "In this field, report the entity or entities which are in your sample or specimenUs local vicinity and which you believe have significant causal influences on your sample or specimen. Please use terms that are present in ENVO and which are of smaller spatial grain than your entry for env_broad_scale. Format (one term): termLabel [termID]; Format (multiple terms): termLabel [termID]|termLabel [termID]|termLabel [termID]. Example: Annotating a pooled sample taken from various vegetation layers in a forest consider: canopy [ENVO:00000047]|herb and fern layer [ENVO:01000337]|litter layer [ENVO:01000338]|understory [01000335]|shrub layer [ENVO:01000336]. If needed, request new terms on the ENVO tracker, identified here: http://www.obofoundry.org/ontology/envo.html",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "env_medium": {
+      "name": "env_medium",
+      "aliases": [
+        "environmental medium"
+      ],
+      "mappings": [
+        "mixs:env_medium"
+      ],
+      "description": "In this field, report which environmental material or materials (pipe separated) immediately surrounded your sample or specimen prior to sampling, using one or more subclasses of ENVOUs environmental material class: http://purl.obolibrary.org/obo/ENVO_00010483. Format (one term): termLabel [termID]; Format (multiple terms): termLabel [termID]|termLabel [termID]|termLabel [termID]. Example: Annotating a fish swimming in the upper 100 m of the Atlantic Ocean, consider: ocean water [ENVO:00002151]. Example: Annotating a duck on a pond consider: pond water [ENVO:00002228]|air ENVO_00002005. If needed, request new terms on the ENVO tracker, identified here: http://www.obofoundry.org/ontology/envo.html",
+      "in_subset": [
+        "environment"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "env_package": {
+      "name": "env_package",
+      "aliases": [
+        "environmental package"
+      ],
+      "mappings": [
+        "mixs:env_package"
+      ],
+      "description": "MIxS extension for reporting of measurements and observations obtained from one or more of the environments where the sample was obtained. All environmental packages listed here are further defined in separate subtables. By giving the name of the environmental package, a selection of fields can be made from the subtables and can be reported",
+      "in_subset": [
+        "mixs extension"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[air|built environment|host\\-associated|human\\-associated|human\\-skin|human\\-oral|human\\-gut|human\\-vaginal|hydrocarbon resources\\-cores|hydrocarbon resources\\-fluids\\/swabs|microbial mat\\/biofilm|misc environment|plant\\-associated|sediment|soil|wastewater\\/sludge|water]"
+    },
+    "subspecf_gen_lin": {
+      "name": "subspecf_gen_lin",
+      "aliases": [
+        "subspecific genetic lineage"
+      ],
+      "mappings": [
+        "mixs:subspecf_gen_lin"
+      ],
+      "description": "This should provide further information about the genetic distinctness of the sequenced organism by recording additional information e.g. serovar, serotype, biotype, ecotype, or any relevant genetic typing schemes like Group I plasmid. It can also contain alternative taxonomic information. It should contain both the lineage name, and the lineage rank, i.e. biovar:abc123",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ploidy": {
+      "name": "ploidy",
+      "aliases": [
+        "ploidy"
+      ],
+      "mappings": [
+        "mixs:ploidy"
+      ],
+      "description": "The ploidy level of the genome (e.g. allopolyploid, haploid, diploid, triploid, tetraploid). It has implications for the downstream study of duplicated gene and regions of the genomes (and perhaps for difficulties in assembly). For terms, please select terms listed under class ploidy (PATO:001374) of Phenotypic Quality Ontology (PATO), and for a browser of PATO (v 2018-03-27) please refer to http://purl.bioontology.org/ontology/PATO",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "num_replicons": {
+      "name": "num_replicons",
+      "aliases": [
+        "number of replicons"
+      ],
+      "mappings": [
+        "mixs:num_replicons"
+      ],
+      "description": "Reports the number of replicons in a nuclear genome of eukaryotes, in the genome of a bacterium or archaea or the number of segments in a segmented virus. Always applied to the haploid chromosome count of a eukaryote",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "extrachrom_elements": {
+      "name": "extrachrom_elements",
+      "aliases": [
+        "extrachromosomal elements"
+      ],
+      "mappings": [
+        "mixs:extrachrom_elements"
+      ],
+      "description": "Do plasmids exist of significant phenotypic consequence (e.g. ones that determine virulence or antibiotic resistance). Megaplasmids? Other plasmids (borrelia has 15+ plasmids)",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "estimated_size": {
+      "name": "estimated_size",
+      "aliases": [
+        "estimated size"
+      ],
+      "mappings": [
+        "mixs:estimated_size"
+      ],
+      "description": "The estimated size of the genome prior to sequencing. Of particular importance in the sequencing of (eukaryotic) genome which could remain in draft form for a long or unspecified period.",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ref_biomaterial": {
+      "name": "ref_biomaterial",
+      "aliases": [
+        "reference for biomaterial"
+      ],
+      "mappings": [
+        "mixs:ref_biomaterial"
+      ],
+      "description": "Primary publication if isolated before genome publication; otherwise, primary genome report",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "source_mat_id": {
+      "name": "source_mat_id",
+      "aliases": [
+        "source material identifiers"
+      ],
+      "mappings": [
+        "mixs:source_mat_id"
+      ],
+      "description": "A unique identifier assigned to a material sample (as defined by http://rs.tdwg.org/dwc/terms/materialSampleID, and as opposed to a particular digital record of a material sample) used for extracting nucleic acids, and subsequent sequencing. The identifier can refer either to the original material collected or to any derived sub-samples. The INSDC qualifiers /specimen_voucher, /bio_material, or /culture_collection may or may not share the same value as the source_mat_id field. For instance, the /specimen_voucher qualifier and source_mat_id may both contain 'UAM:Herps:14' , referring to both the specimen voucher and sampled tissue with the same identifier. However, the /culture_collection qualifier may refer to a value from an initial culture (e.g. ATCC:11775) while source_mat_id would refer to an identifier from some derived culture from which the nucleic acids were extracted (e.g. xatc123 or ark:/2154/R2).",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pathogenicity": {
+      "name": "pathogenicity",
+      "aliases": [
+        "known pathogenicity"
+      ],
+      "mappings": [
+        "mixs:pathogenicity"
+      ],
+      "description": "To what is the entity pathogenic",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "biotic_relationship": {
+      "name": "biotic_relationship",
+      "aliases": [
+        "observed biotic relationship"
+      ],
+      "mappings": [
+        "mixs:biotic_relationship"
+      ],
+      "description": "Description of relationship(s) between the subject organism and other organism(s) it is associated with. E.g., parasite on species X; mutualist with species Y. The target organism is the subject of the relationship, and the other organism(s) is the object",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[free living|parasitism|commensalism|symbiotic|mutualism]"
+    },
+    "specific_host": {
+      "name": "specific_host",
+      "aliases": [
+        "specific host"
+      ],
+      "mappings": [
+        "mixs:specific_host"
+      ],
+      "description": "If there is a host involved, please provide its taxid (or environmental if not actually isolated from the dead or alive host - i.e. a pathogen could be isolated from a swipe of a bench etc) and report whether it is a laboratory or natural host)",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_spec_range": {
+      "name": "host_spec_range",
+      "aliases": [
+        "host specificity or range"
+      ],
+      "mappings": [
+        "mixs:host_spec_range"
+      ],
+      "description": "The NCBI taxonomy identifier of the specific host if it is known",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "health_disease_stat": {
+      "name": "health_disease_stat",
+      "aliases": [
+        "health or disease status of specific host at time of collection"
+      ],
+      "mappings": [
+        "mixs:health_disease_stat"
+      ],
+      "description": "Health or disease status of specific host at time of collection",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[healthy|diseased|dead|disease\\-free|undetermined|recovering|resolving|pre\\-existing condition|pathological|life threatening|congenital]"
+    },
+    "trophic_level": {
+      "name": "trophic_level",
+      "aliases": [
+        "trophic level"
+      ],
+      "mappings": [
+        "mixs:trophic_level"
+      ],
+      "description": "Trophic levels are the feeding position in a food chain. Microbes can be a range of producers (e.g. chemolithotroph)",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[autotroph|carboxydotroph|chemoautotroph|chemoheterotroph|chemolithoautotroph|chemolithotroph|chemoorganoheterotroph|chemoorganotroph|chemosynthetic|chemotroph|copiotroph|diazotroph|facultative|autotroph|heterotroph|lithoautotroph|lithoheterotroph|lithotroph|methanotroph|methylotroph|mixotroph|obligate|chemoautolithotroph|oligotroph|organoheterotroph|organotroph|photoautotroph|photoheterotroph|photolithoautotroph|photolithotroph|photosynthetic|phototroph]"
+    },
+    "propagation": {
+      "name": "propagation",
+      "aliases": [
+        "propagation"
+      ],
+      "mappings": [
+        "mixs:propagation"
+      ],
+      "description": "This field is specific to different taxa. For phages: lytic/lysogenic, for plasmids: incompatibility group, for eukaryotes: sexual/asexual (Note: there is the strong opinion to name phage propagation obligately lytic or temperate, therefore we also give this choice",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "encoded_traits": {
+      "name": "encoded_traits",
+      "aliases": [
+        "encoded traits"
+      ],
+      "mappings": [
+        "mixs:encoded_traits"
+      ],
+      "description": "Should include key traits like antibiotic resistance or xenobiotic degradation phenotypes for plasmids, converting genes for phage",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "rel_to_oxygen": {
+      "name": "rel_to_oxygen",
+      "aliases": [
+        "relationship to oxygen"
+      ],
+      "mappings": [
+        "mixs:rel_to_oxygen"
+      ],
+      "description": "Is this organism an aerobe, anaerobe? Please note that aerobic and anaerobic are valid descriptors for microbial environments",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[aerobe|anaerobe|facultative|microaerophilic|microanaerobe|obligate aerobe|obligate anaerobe]"
+    },
+    "isol_growth_condt": {
+      "name": "isol_growth_condt",
+      "aliases": [
+        "isolation and growth condition"
+      ],
+      "mappings": [
+        "mixs:isol_growth_condt"
+      ],
+      "description": "Publication reference in the form of pubmed ID (pmid), digital object identifier (doi) or url for isolation and growth condition specifications of the organism/material",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_collect_device": {
+      "name": "samp_collect_device",
+      "aliases": [
+        "sample collection device or method"
+      ],
+      "mappings": [
+        "mixs:samp_collect_device"
+      ],
+      "description": "The method or device employed for collecting the sample",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_mat_process": {
+      "name": "samp_mat_process",
+      "aliases": [
+        "sample material processing"
+      ],
+      "mappings": [
+        "mixs:samp_mat_process"
+      ],
+      "description": "Any processing applied to the sample during or after retrieving the sample from environment. This field accepts OBI, for a browser of OBI (v 2018-02-12) terms please see http://purl.bioontology.org/ontology/OBI",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value"
+    },
+    "size_frac": {
+      "name": "size_frac",
+      "aliases": [
+        "size fraction selected"
+      ],
+      "mappings": [
+        "mixs:size_frac"
+      ],
+      "description": "Filtering pore size used in sample preparation",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float}-{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]\\-\\d+[.\\d+] \\S+"
+    },
+    "samp_size": {
+      "name": "samp_size",
+      "aliases": [
+        "amount or size of sample collected"
+      ],
+      "mappings": [
+        "mixs:samp_size"
+      ],
+      "description": "Amount or size of sample (volume, mass or area) that was collected",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "source_uvig": {
+      "name": "source_uvig",
+      "aliases": [
+        "source of UViGs"
+      ],
+      "mappings": [
+        "mixs:source_uvig"
+      ],
+      "description": "Type of dataset from which the UViG was obtained",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[metagenome (not viral targeted)|viral fraction metagenome (virome)|sequence\\-targeted metagenome|metatranscriptome (not viral targeted)|viral fraction RNA metagenome (RNA virome)|sequence\\-targeted RNA metagenome|microbial single amplified genome (SAG)|viral single amplified genome (vSAG)|isolate microbial genome|other]"
+    },
+    "virus_enrich_appr": {
+      "name": "virus_enrich_appr",
+      "aliases": [
+        "virus enrichment approach"
+      ],
+      "mappings": [
+        "mixs:virus_enrich_appr"
+      ],
+      "description": "List of approaches used to enrich the sample for viruses, if any",
+      "in_subset": [
+        "nucleic acid sequence source"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[filtration|ultrafiltration|centrifugation|ultracentrifugation|PEG Precipitation|FeCl Precipitation|CsCl density gradient|DNAse|RNAse|targeted sequence capture|other|none]"
+    },
+    "nucl_acid_ext": {
+      "name": "nucl_acid_ext",
+      "aliases": [
+        "nucleic acid extraction"
+      ],
+      "mappings": [
+        "mixs:nucl_acid_ext"
+      ],
+      "description": "A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the material separation to recover the nucleic acid fraction from a sample",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "nucl_acid_amp": {
+      "name": "nucl_acid_amp",
+      "aliases": [
+        "nucleic acid amplification"
+      ],
+      "mappings": [
+        "mixs:nucl_acid_amp"
+      ],
+      "description": "A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the enzymatic amplification (PCR, TMA, NASBA) of specific nucleic acids",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "lib_size": {
+      "name": "lib_size",
+      "aliases": [
+        "library size"
+      ],
+      "mappings": [
+        "mixs:lib_size"
+      ],
+      "description": "Total number of clones in the library prepared for the project",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "lib_reads_seqd": {
+      "name": "lib_reads_seqd",
+      "aliases": [
+        "library reads sequenced"
+      ],
+      "mappings": [
+        "mixs:lib_reads_seqd"
+      ],
+      "description": "Total number of clones sequenced from the library",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "lib_layout": {
+      "name": "lib_layout",
+      "aliases": [
+        "library layout"
+      ],
+      "mappings": [
+        "mixs:lib_layout"
+      ],
+      "description": "Specify whether to expect single, paired, or other configuration of reads",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[paired|single|vector|other]"
+    },
+    "lib_vector": {
+      "name": "lib_vector",
+      "aliases": [
+        "library vector"
+      ],
+      "mappings": [
+        "mixs:lib_vector"
+      ],
+      "description": "Cloning vector type(s) used in construction of libraries",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "lib_screen": {
+      "name": "lib_screen",
+      "aliases": [
+        "library screening strategy"
+      ],
+      "mappings": [
+        "mixs:lib_screen"
+      ],
+      "description": "Specific enrichment or screening methods applied before and/or after creating libraries",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "target_gene": {
+      "name": "target_gene",
+      "aliases": [
+        "target gene"
+      ],
+      "mappings": [
+        "mixs:target_gene"
+      ],
+      "description": "Targeted gene or locus name for marker gene studies",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "target_subfragment": {
+      "name": "target_subfragment",
+      "aliases": [
+        "target subfragment"
+      ],
+      "mappings": [
+        "mixs:target_subfragment"
+      ],
+      "description": "Name of subfragment of a gene or locus. Important to e.g. identify special regions on marker genes like V6 on 16S rRNA",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pcr_primers": {
+      "name": "pcr_primers",
+      "aliases": [
+        "pcr primers"
+      ],
+      "mappings": [
+        "mixs:pcr_primers"
+      ],
+      "description": "PCR primers that were used to amplify the sequence of the targeted gene, locus or subfragment. This field should contain all the primers used for a single PCR reaction if multiple forward or reverse primers are present in a single PCR reaction. The primer sequence should be reported in uppercase letters",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "mid": {
+      "name": "mid",
+      "aliases": [
+        "multiplex identifiers"
+      ],
+      "mappings": [
+        "mixs:mid"
+      ],
+      "description": "Molecular barcodes, called Multiplex Identifiers (MIDs), that are used to specifically tag unique samples in a sequencing run. Sequence should be reported in uppercase letters",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "adapters": {
+      "name": "adapters",
+      "aliases": [
+        "adapters"
+      ],
+      "mappings": [
+        "mixs:adapters"
+      ],
+      "description": "Adapters provide priming sequences for both amplification and sequencing of the sample-library fragments. Both adapters should be reported; in uppercase letters",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pcr_cond": {
+      "name": "pcr_cond",
+      "aliases": [
+        "pcr conditions"
+      ],
+      "mappings": [
+        "mixs:pcr_cond"
+      ],
+      "description": "Description of reaction conditions and components of PCR in the form of  'initial denaturation:94degC_1.5min; annealing=...'",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles"
+    },
+    "seq_meth": {
+      "name": "seq_meth",
+      "aliases": [
+        "sequencing method"
+      ],
+      "mappings": [
+        "mixs:seq_meth"
+      ],
+      "description": "Sequencing method used; e.g. Sanger, pyrosequencing, ABI-solid",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[MinION|GridION|PromethION|454 GS|454 GS 20|454 GS FLX|454 GS FLX+|454 GS FLX Titanium|454 GS Junior|Illumina Genome Analyzer|Illumina Genome Analyzer II|Illumina Genome Analyzer IIx|Illumina HiSeq 4000|Illumina HiSeq 3000|Illumina HiSeq 2500|Illumina HiSeq 2000|Illumina HiSeq 1500|Illumina HiSeq 1000|Illumina HiScanSQ|Illumina MiSeq|Illumina HiSeq X Five|Illumina HiSeq X Ten|Illumina NextSeq 500|Illumina NextSeq 550|AB SOLiD System|AB SOLiD System 2.0|AB SOLiD System 3.0|AB SOLiD 3 Plus System|AB SOLiD 4 System|AB SOLiD 4hq System|AB SOLiD PI System|AB 5500 Genetic Analyzer|AB 5500xl Genetic Analyzer|AB 5500xl\\-W Genetic Analysis System|Ion Torrent PGM|Ion Torrent Proton|Ion Torrent S5|Ion Torrent S5 XL|PacBio RS|PacBio RS II|Sequel|AB 3730xL Genetic Analyzer|AB 3730 Genetic Analyzer|AB 3500xL Genetic Analyzer|AB 3500 Genetic Analyzer|AB 3130xL Genetic Analyzer|AB 3130 Genetic Analyzer|AB 310 Genetic Analyzer|BGISEQ\\-500]"
+    },
+    "seq_quality_check": {
+      "name": "seq_quality_check",
+      "aliases": [
+        "sequence quality check"
+      ],
+      "mappings": [
+        "mixs:seq_quality_check"
+      ],
+      "description": "Indicate if the sequence has been called by automatic systems (none) or undergone a manual editing procedure (e.g. by inspecting the raw data or chromatograms). Applied only for sequences that are not submitted to SRA,ENA or DRA",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[none|manually edited]"
+    },
+    "chimera_check": {
+      "name": "chimera_check",
+      "aliases": [
+        "chimera check"
+      ],
+      "mappings": [
+        "mixs:chimera_check"
+      ],
+      "description": "A chimeric sequence, or chimera for short, is a sequence comprised of two or more phylogenetically distinct parent sequences. Chimeras are usually PCR artifacts thought to occur when a prematurely terminated amplicon reanneals to a foreign DNA strand and is copied to completion in the following PCR cycles. The point at which the chimeric sequence changes from one parent to the next is called the breakpoint or conversion point",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "tax_ident": {
+      "name": "tax_ident",
+      "aliases": [
+        "taxonomic identity marker"
+      ],
+      "mappings": [
+        "mixs:tax_ident"
+      ],
+      "description": "The phylogenetic marker(s) used to assign an organism name to the SAG or MAG",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[16S rRNA gene|multi\\-marker approach|other]"
+    },
+    "assembly_qual": {
+      "name": "assembly_qual",
+      "aliases": [
+        "assembly quality"
+      ],
+      "mappings": [
+        "mixs:assembly_qual"
+      ],
+      "description": "The assembly quality category is based on sets of criteria outlined for each assembly quality category. For MISAG/MIMAG; Finished: Single, validated, contiguous sequence per replicon without gaps or ambiguities with a consensus error rate equivalent to Q50 or better. High Quality Draft:Multiple fragments where gaps span repetitive regions. Presence of the 23S, 16S and 5S rRNA genes and at least 18 tRNAs. Medium Quality Draft:Many fragments with little to no review of assembly other than reporting of standard assembly statistics. Low Quality Draft:Many fragments with little to no review of assembly other than reporting of standard assembly statistics. Assembly statistics include, but are not limited to total assembly size, number of contigs, contig N50/L50, and maximum contig length. For MIUVIG; Finished: Single, validated, contiguous sequence per replicon without gaps or ambiguities, with extensive manual review and editing to annotate putative gene functions and transcriptional units. High-quality draft genome: One or multiple fragments, totaling 3 90% of the expected genome or replicon sequence or predicted complete. Genome fragment(s): One or multiple fragments, totalling < 90% of the expected genome or replicon sequence, or for which no genome size could be estimated",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Finished genome|High\\-quality draft genome|Medium\\-quality draft genome|Low\\-quality draft genome|Genome fragment(s)]"
+    },
+    "assembly_name": {
+      "name": "assembly_name",
+      "aliases": [
+        "assembly name"
+      ],
+      "mappings": [
+        "mixs:assembly_name"
+      ],
+      "description": "Name/version of the assembly provided by the submitter that is used in the genome browsers and in the community",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "assembly_software": {
+      "name": "assembly_software",
+      "aliases": [
+        "assembly software"
+      ],
+      "mappings": [
+        "mixs:assembly_software"
+      ],
+      "description": "Tool(s) used for assembly, including version number and parameters",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "annot": {
+      "name": "annot",
+      "aliases": [
+        "annotation"
+      ],
+      "mappings": [
+        "mixs:annot"
+      ],
+      "description": "Tool used for annotation, or for cases where annotation was provided by a community jamboree or model organism database rather than by a specific submitter",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "number_contig": {
+      "name": "number_contig",
+      "aliases": [
+        "number of contigs"
+      ],
+      "mappings": [
+        "mixs:number_contig"
+      ],
+      "description": "Total number of contigs in the cleaned/submitted assembly that makes up a given genome, SAG, MAG, or UViG",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "feat_pred": {
+      "name": "feat_pred",
+      "aliases": [
+        "feature prediction"
+      ],
+      "mappings": [
+        "mixs:feat_pred"
+      ],
+      "description": "Method used to predict UViGs features such as ORFs, integration site, etc.",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ref_db": {
+      "name": "ref_db",
+      "aliases": [
+        "reference database(s)"
+      ],
+      "mappings": [
+        "mixs:ref_db"
+      ],
+      "description": "List of database(s) used for ORF annotation, along with version number and reference to website or publication",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "sim_search_meth": {
+      "name": "sim_search_meth",
+      "aliases": [
+        "similarity search method"
+      ],
+      "mappings": [
+        "mixs:sim_search_meth"
+      ],
+      "description": "Tool used to compare ORFs with database, along with version and cutoffs used",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "tax_class": {
+      "name": "tax_class",
+      "aliases": [
+        "taxonomic classification"
+      ],
+      "mappings": [
+        "mixs:tax_class"
+      ],
+      "description": "Method used for taxonomic classification, along with reference database used, classification rank, and thresholds used to classify new genomes",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "_16s_recover": {
+      "name": "_16s_recover",
+      "aliases": [
+        "16S recovered"
+      ],
+      "mappings": [
+        "mixs:_16s_recover"
+      ],
+      "description": "Can a 16S gene be recovered from the submitted SAG or MAG?",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "_16s_recover_software": {
+      "name": "_16s_recover_software",
+      "aliases": [
+        "16S recovery software"
+      ],
+      "mappings": [
+        "mixs:_16s_recover_software"
+      ],
+      "description": "Tools used for 16S rRNA gene extraction",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "trnas": {
+      "name": "trnas",
+      "aliases": [
+        "number of standard tRNAs extracted"
+      ],
+      "mappings": [
+        "mixs:trnas"
+      ],
+      "description": "The total number of tRNAs identified from the SAG or MAG",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "trna_ext_software": {
+      "name": "trna_ext_software",
+      "aliases": [
+        "tRNA extraction software"
+      ],
+      "mappings": [
+        "mixs:trna_ext_software"
+      ],
+      "description": "Tools used for tRNA identification",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "compl_score": {
+      "name": "compl_score",
+      "aliases": [
+        "completeness score"
+      ],
+      "mappings": [
+        "mixs:compl_score"
+      ],
+      "description": "Completeness score is typically based on either the fraction of markers found as compared to a database or the percent of a genome found as compared to a closely related reference genome. High Quality Draft: >90%, Medium Quality Draft: >50%, and Low Quality Draft: < 50% should have the indicated completeness scores",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "compl_software": {
+      "name": "compl_software",
+      "aliases": [
+        "completeness software"
+      ],
+      "mappings": [
+        "mixs:compl_software"
+      ],
+      "description": "Tools used for completion estimate, i.e. checkm, anvi'o, busco",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "compl_appr": {
+      "name": "compl_appr",
+      "aliases": [
+        "completeness approach"
+      ],
+      "mappings": [
+        "mixs:compl_appr"
+      ],
+      "description": "The approach used to determine the completeness of a given SAG or MAG, which would typically make use of a set of conserved marker genes or a closely related reference genome. For UViG completeness, include reference genome or group used, and contig feature suggesting a complete genome",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[marker gene|reference based|other]"
+    },
+    "contam_score": {
+      "name": "contam_score",
+      "aliases": [
+        "contamination score"
+      ],
+      "mappings": [
+        "mixs:contam_score"
+      ],
+      "description": "The contamination score is based on the fraction of single-copy genes that are observed more than once in a query genome. The following scores are acceptable for; High Quality Draft: < 5%, Medium Quality Draft: < 10%, Low Quality Draft: < 10%. Contamination must be below 5% for a SAG or MAG to be deposited into any of the public databases",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "\\d+[.\\d+] percentage"
+    },
+    "contam_screen_input": {
+      "name": "contam_screen_input",
+      "aliases": [
+        "contamination screening input"
+      ],
+      "mappings": [
+        "mixs:contam_screen_input"
+      ],
+      "description": "The type of sequence data used as input",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[reads| contigs]"
+    },
+    "contam_screen_param": {
+      "name": "contam_screen_param",
+      "aliases": [
+        "contamination screening parameters"
+      ],
+      "mappings": [
+        "mixs:contam_screen_param"
+      ],
+      "description": "Specific parameters used in the decontamination sofware, such as reference database, coverage, and kmers. Combinations of these parameters may also be used, i.e. kmer and coverage, or reference database and kmer",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "decontam_software": {
+      "name": "decontam_software",
+      "aliases": [
+        "decontamination software"
+      ],
+      "mappings": [
+        "mixs:decontam_software"
+      ],
+      "description": "Tool(s) used in contamination screening",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[checkm\\/refinem|anvi\\'o|prodege|bbtools:decontaminate.sh|acdc|combination]"
+    },
+    "sort_tech": {
+      "name": "sort_tech",
+      "aliases": [
+        "sorting technology"
+      ],
+      "mappings": [
+        "mixs:sort_tech"
+      ],
+      "description": "Method used to sort/isolate cells or particles of interest",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[flow cytometric cell sorting|microfluidics|lazer\\-tweezing|optical manipulation|micromanipulation|other]"
+    },
+    "single_cell_lysis_appr": {
+      "name": "single_cell_lysis_appr",
+      "aliases": [
+        "single cell or viral particle lysis approach"
+      ],
+      "mappings": [
+        "mixs:single_cell_lysis_appr"
+      ],
+      "description": "Method used to free DNA from interior of the cell(s) or particle(s)",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[chemical|enzymatic|physical|combination]"
+    },
+    "single_cell_lysis_prot": {
+      "name": "single_cell_lysis_prot",
+      "aliases": [
+        "single cell or viral particle lysis kit protocol"
+      ],
+      "mappings": [
+        "mixs:single_cell_lysis_prot"
+      ],
+      "description": "Name of the kit or standard protocol used for cell(s) or particle(s) lysis",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "wga_amp_appr": {
+      "name": "wga_amp_appr",
+      "aliases": [
+        "WGA amplification approach"
+      ],
+      "mappings": [
+        "mixs:wga_amp_appr"
+      ],
+      "description": "Method used to amplify genomic DNA in preparation for sequencing",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[pcr based|mda based]"
+    },
+    "wga_amp_kit": {
+      "name": "wga_amp_kit",
+      "aliases": [
+        "WGA amplification kit"
+      ],
+      "mappings": [
+        "mixs:wga_amp_kit"
+      ],
+      "description": "Kit used to amplify genomic DNA in preparation for sequencing",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "bin_param": {
+      "name": "bin_param",
+      "aliases": [
+        "binning parameters"
+      ],
+      "mappings": [
+        "mixs:bin_param"
+      ],
+      "description": "The parameters that have been applied during the extraction of genomes from metagenomic datasets",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[homology search|kmer|coverage|codon usage|combination]"
+    },
+    "bin_software": {
+      "name": "bin_software",
+      "aliases": [
+        "binning software"
+      ],
+      "mappings": [
+        "mixs:bin_software"
+      ],
+      "description": "Tool(s) used for the extraction of genomes from metagenomic datasets",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[metabat|maxbin|concoct|groupm|esom|metawatt|combination|other]"
+    },
+    "reassembly_bin": {
+      "name": "reassembly_bin",
+      "aliases": [
+        "reassembly post binning"
+      ],
+      "mappings": [
+        "mixs:reassembly_bin"
+      ],
+      "description": "Has an assembly been performed on a genome bin extracted from a metagenomic assembly?",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "mag_cov_software": {
+      "name": "mag_cov_software",
+      "aliases": [
+        "MAG coverage software"
+      ],
+      "mappings": [
+        "mixs:mag_cov_software"
+      ],
+      "description": "Tool(s) used to determine the genome coverage if coverage is used as a binning parameter in the extraction of genomes from metagenomic datasets",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[bwa|bbmap|bowtie|other]"
+    },
+    "vir_ident_software": {
+      "name": "vir_ident_software",
+      "aliases": [
+        "viral identification software"
+      ],
+      "mappings": [
+        "mixs:vir_ident_software"
+      ],
+      "description": "Tool(s) used for the identification of UViG as a viral genome, software or protocol name  including version number, parameters, and cutoffs used",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pred_genome_type": {
+      "name": "pred_genome_type",
+      "aliases": [
+        "predicted genome type"
+      ],
+      "mappings": [
+        "mixs:pred_genome_type"
+      ],
+      "description": "Type of genome predicted for the UViG",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[DNA|dsDNA|ssDNA|RNA|dsRNA|ssRNA|ssRNA (+)|ssRNA (\\-)|mixed|uncharacterized]"
+    },
+    "pred_genome_struc": {
+      "name": "pred_genome_struc",
+      "aliases": [
+        "predicted genome structure"
+      ],
+      "mappings": [
+        "mixs:pred_genome_struc"
+      ],
+      "description": "Expected structure of the viral genome",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[segmented|non\\-segmented|undetermined]"
+    },
+    "detec_type": {
+      "name": "detec_type",
+      "aliases": [
+        "detection type"
+      ],
+      "mappings": [
+        "mixs:detec_type"
+      ],
+      "description": "Type of UViG detection",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[independent sequence (UViG)|provirus (UpViG)]"
+    },
+    "votu_class_appr": {
+      "name": "votu_class_appr",
+      "aliases": [
+        "vOTU classification approach"
+      ],
+      "mappings": [
+        "mixs:votu_class_appr"
+      ],
+      "description": "Cutoffs and approach used when clustering new UViGs in Rspecies-levelS vOTUs. Note that results from standard 95% ANI / 85% AF clustering should be provided alongside vOTUS defined from another set of thresholds, even if the latter are the ones primarily used during the analysis",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "votu_seq_comp_appr": {
+      "name": "votu_seq_comp_appr",
+      "aliases": [
+        "vOTU sequence comparison approach"
+      ],
+      "mappings": [
+        "mixs:votu_seq_comp_appr"
+      ],
+      "description": "Tool and thresholds used to compare sequences when computing 'species-level' vOTUs",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "votu_db": {
+      "name": "votu_db",
+      "aliases": [
+        "vOTU database"
+      ],
+      "mappings": [
+        "mixs:votu_db"
+      ],
+      "description": "Reference database (i.e. sequences not generated as part of the current study) used to cluster new genomes in 'species-level' vOTUs, if any",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_pred_appr": {
+      "name": "host_pred_appr",
+      "aliases": [
+        "host prediction approach"
+      ],
+      "mappings": [
+        "mixs:host_pred_appr"
+      ],
+      "description": "Tool or approach used for host prediction",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[provirus|host sequence similarity|CRISPR spacer match|kmer similarity|co\\-occurrence|combination|other]"
+    },
+    "host_pred_est_acc": {
+      "name": "host_pred_est_acc",
+      "aliases": [
+        "host prediction estimated accuracy"
+      ],
+      "mappings": [
+        "mixs:host_pred_est_acc"
+      ],
+      "description": "For each tool or approach used for host prediction, estimated false discovery rates should be included, either computed de novo or from the literature",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "mixs_url": {
+      "name": "mixs_url",
+      "aliases": [
+        "relevant electronic resources"
+      ],
+      "mappings": [
+        "mixs:mixs_url"
+      ],
+      "description": "",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "sop": {
+      "name": "sop",
+      "aliases": [
+        "relevant standard operating procedures"
+      ],
+      "mappings": [
+        "mixs:sop"
+      ],
+      "description": "Standard operating procedures used in assembly and/or annotation of genomes, metagenomes or environmental sequences",
+      "in_subset": [
+        "sequencing"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "barometric_press": {
+      "name": "barometric_press",
+      "aliases": [
+        "barometric pressure"
+      ],
+      "mappings": [
+        "mixs:barometric_press"
+      ],
+      "description": "Force per unit area exerted against a surface by the weight of air above that surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "carb_dioxide": {
+      "name": "carb_dioxide",
+      "aliases": [
+        "carbon dioxide"
+      ],
+      "mappings": [
+        "mixs:carb_dioxide"
+      ],
+      "description": "Carbon dioxide (gas) amount or concentration at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "carb_monoxide": {
+      "name": "carb_monoxide",
+      "aliases": [
+        "carbon monoxide"
+      ],
+      "mappings": [
+        "mixs:carb_monoxide"
+      ],
+      "description": "Carbon monoxide (gas) amount or concentration at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "chem_administration": {
+      "name": "chem_administration",
+      "aliases": [
+        "chemical administration"
+      ],
+      "mappings": [
+        "mixs:chem_administration"
+      ],
+      "description": "List of chemical compounds administered to the host or site where sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can include multiple compounds. For chemical entities of biological interest ontology (chebi) (v 163), http://purl.bioontology.org/ontology/chebi",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value"
+    },
+    "humidity": {
+      "name": "humidity",
+      "aliases": [
+        "humidity"
+      ],
+      "mappings": [
+        "mixs:humidity"
+      ],
+      "description": "Amount of water vapour in the air, at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "methane": {
+      "name": "methane",
+      "aliases": [
+        "methane"
+      ],
+      "mappings": [
+        "mixs:methane"
+      ],
+      "description": "Methane (gas) amount or concentration at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "misc_param": {
+      "name": "misc_param",
+      "aliases": [
+        "miscellaneous parameter"
+      ],
+      "mappings": [
+        "mixs:misc_param"
+      ],
+      "description": "Any other measurement performed or parameter collected, that is not listed here",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "organism_count": {
+      "name": "organism_count",
+      "aliases": [
+        "organism count"
+      ],
+      "mappings": [
+        "mixs:organism_count"
+      ],
+      "description": "Total cell count of any organism (or group of organisms) per gram, volume or area of sample, should include name of organism followed by count. The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should also be provided. (example: total prokaryotes; 3.5e7 cells per ml; qpcr)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};[qPCR|ATP|MPN|other]",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "oxygen": {
+      "name": "oxygen",
+      "aliases": [
+        "oxygen"
+      ],
+      "mappings": [
+        "mixs:oxygen"
+      ],
+      "description": "Oxygen (gas) amount or concentration at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "oxy_stat_samp": {
+      "name": "oxy_stat_samp",
+      "aliases": [
+        "oxygenation status of sample"
+      ],
+      "mappings": [
+        "mixs:oxy_stat_samp"
+      ],
+      "description": "Oxygenation status of sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[aerobic|anaerobic|other]"
+    },
+    "perturbation": {
+      "name": "perturbation",
+      "aliases": [
+        "perturbation"
+      ],
+      "mappings": [
+        "mixs:perturbation"
+      ],
+      "description": "Type of perturbation, e.g. chemical administration, physical disturbance, etc., coupled with perturbation regimen including how many times the perturbation was repeated, how long each perturbation lasted, and the start and end time of the entire perturbation period; can include multiple perturbation types",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pollutants": {
+      "name": "pollutants",
+      "aliases": [
+        "pollutants"
+      ],
+      "mappings": [
+        "mixs:pollutants"
+      ],
+      "description": "Pollutant types and, amount or concentrations measured at the time of sampling; can report multiple pollutants by entering numeric values preceded by name of pollutant",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "resp_part_matter": {
+      "name": "resp_part_matter",
+      "aliases": [
+        "respirable particulate matter"
+      ],
+      "mappings": [
+        "mixs:resp_part_matter"
+      ],
+      "description": "Concentration of substances that remain suspended in the air, and comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can report multiple PM's by entering numeric values preceded by name of PM",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "samp_salinity": {
+      "name": "samp_salinity",
+      "aliases": [
+        "sample salinity"
+      ],
+      "mappings": [
+        "mixs:samp_salinity"
+      ],
+      "description": "Salinity is the total concentration of all dissolved salts in a liquid or solid (in the form of an extract obtained by centrifugation) sample. While salinity can be measured by a complete chemical analysis, this method is difficult and time consuming. More often, it is instead derived from the conductivity measurement. This is known as practical salinity. These derivations compare the specific conductance of the sample to a salinity standard such as seawater",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "samp_store_dur": {
+      "name": "samp_store_dur",
+      "aliases": [
+        "sample storage duration"
+      ],
+      "mappings": [
+        "mixs:samp_store_dur"
+      ],
+      "description": "Duration for which the sample was stored",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_store_loc": {
+      "name": "samp_store_loc",
+      "aliases": [
+        "sample storage location"
+      ],
+      "mappings": [
+        "mixs:samp_store_loc"
+      ],
+      "description": "Location at which sample was stored, usually name of a specific freezer/room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_store_temp": {
+      "name": "samp_store_temp",
+      "aliases": [
+        "sample storage temperature"
+      ],
+      "mappings": [
+        "mixs:samp_store_temp"
+      ],
+      "description": "Temperature at which sample was stored, e.g. -80 degree Celsius",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "samp_vol_we_dna_ext": {
+      "name": "samp_vol_we_dna_ext",
+      "aliases": [
+        "sample volume or weight for DNA extraction"
+      ],
+      "mappings": [
+        "mixs:samp_vol_we_dna_ext"
+      ],
+      "description": "Volume (ml), weight (g) of processed sample, or surface area swabbed from sample for DNA extraction",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "solar_irradiance": {
+      "name": "solar_irradiance",
+      "aliases": [
+        "solar irradiance"
+      ],
+      "mappings": [
+        "mixs:solar_irradiance"
+      ],
+      "description": "The amount of solar energy that arrives at a specific area of a surface during a specific time interval",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "temp": {
+      "name": "temp",
+      "aliases": [
+        "temperature"
+      ],
+      "mappings": [
+        "mixs:temp"
+      ],
+      "description": "Temperature of the sample at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "ventilation_rate": {
+      "name": "ventilation_rate",
+      "aliases": [
+        "ventilation rate"
+      ],
+      "mappings": [
+        "mixs:ventilation_rate"
+      ],
+      "description": "Ventilation rate of the system in the sampled premises",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "ventilation_type": {
+      "name": "ventilation_type",
+      "aliases": [
+        "ventilation type"
+      ],
+      "mappings": [
+        "mixs:ventilation_type"
+      ],
+      "description": "Ventilation system used in the sampled premises",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "volatile_org_comp": {
+      "name": "volatile_org_comp",
+      "aliases": [
+        "volatile organic compounds"
+      ],
+      "mappings": [
+        "mixs:volatile_org_comp"
+      ],
+      "description": "Concentration of carbon-based chemicals that easily evaporate at room temperature; can report multiple volatile organic compounds by entering numeric values preceded by name of compound",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "wind_direction": {
+      "name": "wind_direction",
+      "aliases": [
+        "wind direction"
+      ],
+      "mappings": [
+        "mixs:wind_direction"
+      ],
+      "description": "Wind direction is the direction from which a wind originates",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "wind_speed": {
+      "name": "wind_speed",
+      "aliases": [
+        "wind speed"
+      ],
+      "mappings": [
+        "mixs:wind_speed"
+      ],
+      "description": "Speed of wind measured at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "surf_material": {
+      "name": "surf_material",
+      "aliases": [
+        "surface material"
+      ],
+      "mappings": [
+        "mixs:surf_material"
+      ],
+      "description": "Surface materials at the point of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[concrete|wood|stone|tile|plastic|glass|vinyl|metal|carpet|stainless steel|paint|cinder blocks|hay bales|stucco|adobe]"
+    },
+    "surf_air_cont": {
+      "name": "surf_air_cont",
+      "aliases": [
+        "surface-air contaminant"
+      ],
+      "mappings": [
+        "mixs:surf_air_cont"
+      ],
+      "description": "Contaminant identified on surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[dust|organic matter|particulate matter|volatile organic compounds|biological contaminants|radon|nutrients|biocides]"
+    },
+    "rel_air_humidity": {
+      "name": "rel_air_humidity",
+      "aliases": [
+        "relative air humidity"
+      ],
+      "mappings": [
+        "mixs:rel_air_humidity"
+      ],
+      "description": "Partial vapor and air pressure, density of the vapor and air, or by the actual mass of the vapor and air",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "abs_air_humidity": {
+      "name": "abs_air_humidity",
+      "aliases": [
+        "absolute air humidity"
+      ],
+      "mappings": [
+        "mixs:abs_air_humidity"
+      ],
+      "description": "Actual mass of water vapor - mh20 - present in the air water vapor mixture",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "surf_humidity": {
+      "name": "surf_humidity",
+      "aliases": [
+        "surface humidity"
+      ],
+      "mappings": [
+        "mixs:surf_humidity"
+      ],
+      "description": "Surfaces: water activity as a function of air and material moisture",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "air_temp": {
+      "name": "air_temp",
+      "aliases": [
+        "air temperature"
+      ],
+      "mappings": [
+        "mixs:air_temp"
+      ],
+      "description": "Temperature of the air at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "surf_temp": {
+      "name": "surf_temp",
+      "aliases": [
+        "surface temperature"
+      ],
+      "mappings": [
+        "mixs:surf_temp"
+      ],
+      "description": "Temperature of the surface at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "surf_moisture_ph": {
+      "name": "surf_moisture_ph",
+      "aliases": [
+        "surface moisture pH"
+      ],
+      "mappings": [
+        "mixs:surf_moisture_ph"
+      ],
+      "description": "ph measurement of surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "build_occup_type": {
+      "name": "build_occup_type",
+      "aliases": [
+        "building occupancy type"
+      ],
+      "mappings": [
+        "mixs:build_occup_type"
+      ],
+      "description": "The primary function for which a building or discrete part of a building is intended to be used",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[office|market|restaurant|residence|school|residential|commercial|low rise|high rise|wood framed|office|health care|school|airport|sports complex]"
+    },
+    "surf_moisture": {
+      "name": "surf_moisture",
+      "aliases": [
+        "surface moisture"
+      ],
+      "mappings": [
+        "mixs:surf_moisture"
+      ],
+      "description": "Water held on a surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "dew_point": {
+      "name": "dew_point",
+      "aliases": [
+        "dew point"
+      ],
+      "mappings": [
+        "mixs:dew_point"
+      ],
+      "description": "The temperature to which a given parcel of humid air must be cooled, at constant barometric pressure, for water vapor to condense into water.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "indoor_space": {
+      "name": "indoor_space",
+      "aliases": [
+        "indoor space"
+      ],
+      "mappings": [
+        "mixs:indoor_space"
+      ],
+      "description": "A distinguishable space within a structure, the purpose for which discrete areas of a building is used",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[bedroom|office|bathroom|foyer|kitchen|locker room|hallway|elevator]"
+    },
+    "indoor_surf": {
+      "name": "indoor_surf",
+      "aliases": [
+        "indoor surface"
+      ],
+      "mappings": [
+        "mixs:indoor_surf"
+      ],
+      "description": "Type of indoor surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[counter top|window|wall|cabinet|ceiling|door|shelving|vent cover]"
+    },
+    "filter_type": {
+      "name": "filter_type",
+      "aliases": [
+        "filter type"
+      ],
+      "mappings": [
+        "mixs:filter_type"
+      ],
+      "description": "A device which removes solid particulates or airborne molecular contaminants",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[particulate air filter|chemical air filter|low\\-MERV pleated media|HEPA|electrostatic|gas\\-phase or ultraviolet air treatments]"
+    },
+    "heat_cool_type": {
+      "name": "heat_cool_type",
+      "aliases": [
+        "heating and cooling system type"
+      ],
+      "mappings": [
+        "mixs:heat_cool_type"
+      ],
+      "description": "Methods of conditioning or heating a room or building",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[radiant system|heat pump|forced air system|steam forced heat|wood stove]"
+    },
+    "substructure_type": {
+      "name": "substructure_type",
+      "aliases": [
+        "substructure type"
+      ],
+      "mappings": [
+        "mixs:substructure_type"
+      ],
+      "description": "The substructure or under building is that largely hidden section of the building which is built off the foundations to the ground floor level",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[crawlspace|slab on grade|basement]"
+    },
+    "building_setting": {
+      "name": "building_setting",
+      "aliases": [
+        "building setting"
+      ],
+      "mappings": [
+        "mixs:building_setting"
+      ],
+      "description": "A location (geography) where a building is set",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[urban|suburban|exurban|rural]"
+    },
+    "light_type": {
+      "name": "light_type",
+      "aliases": [
+        "light type"
+      ],
+      "mappings": [
+        "mixs:light_type"
+      ],
+      "description": "Application of light to achieve some practical or aesthetic effect. Lighting includes the use of both artificial light sources such as lamps and light fixtures, as well as natural illumination by capturing daylight. Can also include absence of light",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[natural light|electric light|desk lamp|flourescent lights|natural light|none]"
+    },
+    "samp_sort_meth": {
+      "name": "samp_sort_meth",
+      "aliases": [
+        "sample size sorting method"
+      ],
+      "mappings": [
+        "mixs:samp_sort_meth"
+      ],
+      "description": "Method by which samples are sorted; open face filter collecting total suspended particles, prefilter to remove particles larger than X micrometers in diameter, where common values of X would be 10 and 2.5 full size sorting in a cascade impactor.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "space_typ_state": {
+      "name": "space_typ_state",
+      "aliases": [
+        "space typical state"
+      ],
+      "mappings": [
+        "mixs:space_typ_state"
+      ],
+      "description": "Customary or normal state of the space",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[typically occupied|typically unoccupied]"
+    },
+    "typ_occup_density": {
+      "name": "typ_occup_density",
+      "aliases": [
+        "typical occupant density"
+      ],
+      "mappings": [
+        "mixs:typ_occup_density"
+      ],
+      "description": "Customary or normal density of occupants",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "occup_samp": {
+      "name": "occup_samp",
+      "aliases": [
+        "occupancy at sampling"
+      ],
+      "mappings": [
+        "mixs:occup_samp"
+      ],
+      "description": "Number of occupants present at time of sample within the given space",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "occup_density_samp": {
+      "name": "occup_density_samp",
+      "aliases": [
+        "occupant density at sampling"
+      ],
+      "mappings": [
+        "mixs:occup_density_samp"
+      ],
+      "description": "Average number of occupants at time of sampling per square footage",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "address": {
+      "name": "address",
+      "aliases": [
+        "address"
+      ],
+      "mappings": [
+        "mixs:address"
+      ],
+      "description": "The street name and building number where the sampling occurred.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "adj_room": {
+      "name": "adj_room",
+      "aliases": [
+        "adjacent rooms"
+      ],
+      "mappings": [
+        "mixs:adj_room"
+      ],
+      "description": "List of rooms (room number, room name) immediately adjacent to the sampling room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "aero_struc": {
+      "name": "aero_struc",
+      "aliases": [
+        "aerospace structure"
+      ],
+      "mappings": [
+        "mixs:aero_struc"
+      ],
+      "description": "Aerospace structures typically consist of thin plates with stiffeners for the external surfaces, bulkheads and frames to support the shape and fasteners such as welds, rivets, screws and bolts to hold the components together",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[plane|glider]"
+    },
+    "amount_light": {
+      "name": "amount_light",
+      "aliases": [
+        "amount of light"
+      ],
+      "mappings": [
+        "mixs:amount_light"
+      ],
+      "description": "The unit of illuminance and luminous emittance, measuring luminous flux per unit area",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "arch_struc": {
+      "name": "arch_struc",
+      "aliases": [
+        "architectural structure"
+      ],
+      "mappings": [
+        "mixs:arch_struc"
+      ],
+      "description": "An architectural structure is a human-made, free-standing, immobile outdoor construction",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[building|shed|home]"
+    },
+    "avg_occup": {
+      "name": "avg_occup",
+      "aliases": [
+        "average daily occupancy"
+      ],
+      "mappings": [
+        "mixs:avg_occup"
+      ],
+      "description": "Daily average  occupancy of room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "avg_dew_point": {
+      "name": "avg_dew_point",
+      "aliases": [
+        "average dew point"
+      ],
+      "mappings": [
+        "mixs:avg_dew_point"
+      ],
+      "description": "The average of dew point measures taken at the beginning of every hour over a 24 hour period on the sampling day",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "avg_temp": {
+      "name": "avg_temp",
+      "aliases": [
+        "average temperature"
+      ],
+      "mappings": [
+        "mixs:avg_temp"
+      ],
+      "description": "The average of temperatures taken at the beginning of every hour over a 24 hour period on the sampling day",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "bathroom_count": {
+      "name": "bathroom_count",
+      "aliases": [
+        "bathroom count"
+      ],
+      "mappings": [
+        "mixs:bathroom_count"
+      ],
+      "description": "The number of bathrooms in the building",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "bedroom_count": {
+      "name": "bedroom_count",
+      "aliases": [
+        "bedroom count"
+      ],
+      "mappings": [
+        "mixs:bedroom_count"
+      ],
+      "description": "The number of bedrooms in the building",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "built_struc_age": {
+      "name": "built_struc_age",
+      "aliases": [
+        "built structure age"
+      ],
+      "mappings": [
+        "mixs:built_struc_age"
+      ],
+      "description": "The age of the built structure since construction",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "built_struc_set": {
+      "name": "built_struc_set",
+      "aliases": [
+        "built structure setting"
+      ],
+      "mappings": [
+        "mixs:built_struc_set"
+      ],
+      "description": "The characterization of the location of the built structure as high or low human density",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[urban|rural]"
+    },
+    "built_struc_type": {
+      "name": "built_struc_type",
+      "aliases": [
+        "built structure type"
+      ],
+      "mappings": [
+        "mixs:built_struc_type"
+      ],
+      "description": "A physical structure that is a body or assemblage of bodies in space to form a system capable of supporting loads",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ceil_area": {
+      "name": "ceil_area",
+      "aliases": [
+        "ceiling area"
+      ],
+      "mappings": [
+        "mixs:ceil_area"
+      ],
+      "description": "The area of the ceiling space within the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "ceil_cond": {
+      "name": "ceil_cond",
+      "aliases": [
+        "ceiling condition"
+      ],
+      "mappings": [
+        "mixs:ceil_cond"
+      ],
+      "description": "The physical condition of the ceiling at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[new|visible wear|needs repair|damaged|rupture]"
+    },
+    "ceil_finish_mat": {
+      "name": "ceil_finish_mat",
+      "aliases": [
+        "ceiling finish material"
+      ],
+      "mappings": [
+        "mixs:ceil_finish_mat"
+      ],
+      "description": "The type of material used to finish a ceiling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[drywall|mineral fibre|tiles|PVC|plasterboard|metal|fiberglass|stucco|mineral wool\\/calcium silicate|wood]"
+    },
+    "ceil_water_mold": {
+      "name": "ceil_water_mold",
+      "aliases": [
+        "ceiling signs of water/mold"
+      ],
+      "mappings": [
+        "mixs:ceil_water_mold"
+      ],
+      "description": "Signs of the presence of mold or mildew on the ceiling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[presence of mold visible|no presence of mold visible]"
+    },
+    "ceil_struc": {
+      "name": "ceil_struc",
+      "aliases": [
+        "ceiling structure"
+      ],
+      "mappings": [
+        "mixs:ceil_struc"
+      ],
+      "description": "The construction format of the ceiling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[wood frame|concrete]"
+    },
+    "ceil_texture": {
+      "name": "ceil_texture",
+      "aliases": [
+        "ceiling texture"
+      ],
+      "mappings": [
+        "mixs:ceil_texture"
+      ],
+      "description": "The feel, appearance, or consistency of a ceiling surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[crows feet|crows\\-foot stomp|double skip|hawk and trowel|knockdown|popcorn|orange peel|rosebud stomp|Santa\\-Fe texture|skip trowel|smooth|stomp knockdown|swirl]"
+    },
+    "ceil_thermal_mass": {
+      "name": "ceil_thermal_mass",
+      "aliases": [
+        "ceiling thermal mass"
+      ],
+      "mappings": [
+        "mixs:ceil_thermal_mass"
+      ],
+      "description": "The ability of the ceiling to provide inertia against temperature fluctuations. Generally this means concrete that is exposed. A metal deck that supports a concrete slab will act thermally as long as it is exposed to room air flow",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "ceil_type": {
+      "name": "ceil_type",
+      "aliases": [
+        "ceiling type"
+      ],
+      "mappings": [
+        "mixs:ceil_type"
+      ],
+      "description": "The type of ceiling according to the ceiling's appearance or construction",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[cathedral|dropped|concave|barrel\\-shaped|coffered|cove|stretched]"
+    },
+    "cool_syst_id": {
+      "name": "cool_syst_id",
+      "aliases": [
+        "cooling system identifier"
+      ],
+      "mappings": [
+        "mixs:cool_syst_id"
+      ],
+      "description": "The cooling system identifier",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "date_last_rain": {
+      "name": "date_last_rain",
+      "aliases": [
+        "date last rain"
+      ],
+      "mappings": [
+        "mixs:date_last_rain"
+      ],
+      "description": "The date of the last time it rained",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "build_docs": {
+      "name": "build_docs",
+      "aliases": [
+        "design, construction, and operation documents"
+      ],
+      "mappings": [
+        "mixs:build_docs"
+      ],
+      "description": "The building design, construction and operation documents",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[building information model|commissioning report|complaint logs|contract administration|cost estimate|janitorial schedules or logs|maintenance plans|schedule|sections|shop drawings|submittals|ventilation system|windows] "
+    },
+    "door_size": {
+      "name": "door_size",
+      "aliases": [
+        "door area or size"
+      ],
+      "mappings": [
+        "mixs:door_size"
+      ],
+      "description": "The size of the door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "door_cond": {
+      "name": "door_cond",
+      "aliases": [
+        "door condition"
+      ],
+      "mappings": [
+        "mixs:door_cond"
+      ],
+      "description": "The phsical condition of the door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[damaged|needs repair|new|rupture|visible wear]"
+    },
+    "door_direct": {
+      "name": "door_direct",
+      "aliases": [
+        "door direction of opening"
+      ],
+      "mappings": [
+        "mixs:door_direct"
+      ],
+      "description": "The direction the door opens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[inward|outward|sideways]"
+    },
+    "door_loc": {
+      "name": "door_loc",
+      "aliases": [
+        "door location"
+      ],
+      "mappings": [
+        "mixs:door_loc"
+      ],
+      "description": "The relative location of the door in the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north|south|east|west]"
+    },
+    "door_mat": {
+      "name": "door_mat",
+      "aliases": [
+        "door material"
+      ],
+      "mappings": [
+        "mixs:door_mat"
+      ],
+      "description": "The material the door is composed of",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[aluminum|cellular PVC|engineered plastic|fiberboard|fiberglass|metal|thermoplastic alloy|vinyl|wood|wood\\/plastic composite]"
+    },
+    "door_move": {
+      "name": "door_move",
+      "aliases": [
+        "door movement"
+      ],
+      "mappings": [
+        "mixs:door_move"
+      ],
+      "description": "The type of movement of the door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[collapsible|folding|revolving|rolling shutter|sliding|swinging] "
+    },
+    "door_water_mold": {
+      "name": "door_water_mold",
+      "aliases": [
+        "door signs of water/mold"
+      ],
+      "mappings": [
+        "mixs:door_water_mold"
+      ],
+      "description": "Signs of the presence of mold or mildew on a door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[presence of mold visible|no presence of mold visible]"
+    },
+    "door_type": {
+      "name": "door_type",
+      "aliases": [
+        "door type"
+      ],
+      "mappings": [
+        "mixs:door_type"
+      ],
+      "description": "The type of door material",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[composite|metal|wooden]"
+    },
+    "door_comp_type": {
+      "name": "door_comp_type",
+      "aliases": [
+        "door type, composite"
+      ],
+      "mappings": [
+        "mixs:door_comp_type"
+      ],
+      "description": "The composite type of the door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[metal covered|revolving|sliding|telescopic]"
+    },
+    "door_type_metal": {
+      "name": "door_type_metal",
+      "aliases": [
+        "door type, metal"
+      ],
+      "mappings": [
+        "mixs:door_type_metal"
+      ],
+      "description": "The type of metal door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[collapsible|corrugated steel|hollow|rolling shutters|steel plate]"
+    },
+    "door_type_wood": {
+      "name": "door_type_wood",
+      "aliases": [
+        "door type, wood"
+      ],
+      "mappings": [
+        "mixs:door_type_wood"
+      ],
+      "description": "The type of wood door",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[bettened and ledged|battened|ledged and braced|battened|ledged and framed|battened|ledged, braced and frame|framed and paneled|glashed or sash|flush|louvered|wire gauged]"
+    },
+    "drawings": {
+      "name": "drawings",
+      "aliases": [
+        "drawings"
+      ],
+      "mappings": [
+        "mixs:drawings"
+      ],
+      "description": "The buildings architectural drawings; if design is chosen, indicate phase-conceptual, schematic, design development, and construction documents",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[operation|as built|construction|bid|design|building navigation map|diagram|sketch]"
+    },
+    "elevator": {
+      "name": "elevator",
+      "aliases": [
+        "elevator count"
+      ],
+      "mappings": [
+        "mixs:elevator"
+      ],
+      "description": "The number of elevators within the built structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "escalator": {
+      "name": "escalator",
+      "aliases": [
+        "escalator count"
+      ],
+      "mappings": [
+        "mixs:escalator"
+      ],
+      "description": "The number of escalators within the built structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "exp_duct": {
+      "name": "exp_duct",
+      "aliases": [
+        "exposed ductwork"
+      ],
+      "mappings": [
+        "mixs:exp_duct"
+      ],
+      "description": "The amount of exposed ductwork in the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "exp_pipe": {
+      "name": "exp_pipe",
+      "aliases": [
+        "exposed pipes"
+      ],
+      "mappings": [
+        "mixs:exp_pipe"
+      ],
+      "description": "The number of exposed pipes in the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "ext_door": {
+      "name": "ext_door",
+      "aliases": [
+        "exterior door count"
+      ],
+      "mappings": [
+        "mixs:ext_door"
+      ],
+      "description": "The number of exterior doors in the built structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "fireplace_type": {
+      "name": "fireplace_type",
+      "aliases": [
+        "fireplace type"
+      ],
+      "mappings": [
+        "mixs:fireplace_type"
+      ],
+      "description": "A firebox with chimney",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[gas burning|wood burning]"
+    },
+    "floor_age": {
+      "name": "floor_age",
+      "aliases": [
+        "floor age"
+      ],
+      "mappings": [
+        "mixs:floor_age"
+      ],
+      "description": "The time period since installment of the carpet or flooring",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "floor_area": {
+      "name": "floor_area",
+      "aliases": [
+        "floor area"
+      ],
+      "mappings": [
+        "mixs:floor_area"
+      ],
+      "description": "The area of the floor space within the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "floor_cond": {
+      "name": "floor_cond",
+      "aliases": [
+        "floor condition"
+      ],
+      "mappings": [
+        "mixs:floor_cond"
+      ],
+      "description": "The physical condition of the floor at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[new|visible wear|needs repair|damaged|rupture]"
+    },
+    "floor_count": {
+      "name": "floor_count",
+      "aliases": [
+        "floor count"
+      ],
+      "mappings": [
+        "mixs:floor_count"
+      ],
+      "description": "The number of floors in the building, including basements and mechanical penthouse",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "floor_finish_mat": {
+      "name": "floor_finish_mat",
+      "aliases": [
+        "floor finish material"
+      ],
+      "mappings": [
+        "mixs:floor_finish_mat"
+      ],
+      "description": "The floor covering type; the finished surface that is walked on",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[tile|wood strip or parquet|carpet|rug|laminate wood|lineoleum|vinyl composition tile|sheet vinyl|stone|bamboo|cork|terrazo|concrete|none;specify unfinished|sealed|clear finish|paint]"
+    },
+    "floor_water_mold": {
+      "name": "floor_water_mold",
+      "aliases": [
+        "floor signs of water/mold"
+      ],
+      "mappings": [
+        "mixs:floor_water_mold"
+      ],
+      "description": "Signs of the presence of mold or mildew in a room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[mold odor|wet floor|water stains|wall discoloration|floor discoloration|ceiling discoloration|peeling paint or wallpaper|bulging walls|condensation]"
+    },
+    "floor_struc": {
+      "name": "floor_struc",
+      "aliases": [
+        "floor structure"
+      ],
+      "mappings": [
+        "mixs:floor_struc"
+      ],
+      "description": "Refers to the structural elements and subfloor upon which the finish flooring is installed",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[balcony|floating floor|glass floor|raised floor|sprung floor|wood\\-framed|concrete]"
+    },
+    "floor_thermal_mass": {
+      "name": "floor_thermal_mass",
+      "aliases": [
+        "floor thermal mass"
+      ],
+      "mappings": [
+        "mixs:floor_thermal_mass"
+      ],
+      "description": "The ability of the floor to provide inertia against temperature fluctuations",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "freq_clean": {
+      "name": "freq_clean",
+      "aliases": [
+        "frequency of cleaning"
+      ],
+      "mappings": [
+        "mixs:freq_clean"
+      ],
+      "description": "The number of times the building is cleaned per week",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "freq_cook": {
+      "name": "freq_cook",
+      "aliases": [
+        "frequency of cooking"
+      ],
+      "mappings": [
+        "mixs:freq_cook"
+      ],
+      "description": "The number of times a meal is cooked per week",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "furniture": {
+      "name": "furniture",
+      "aliases": [
+        "furniture"
+      ],
+      "mappings": [
+        "mixs:furniture"
+      ],
+      "description": "The types of furniture present in the sampled room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[cabinet|chair|desks]"
+    },
+    "gender_restroom": {
+      "name": "gender_restroom",
+      "aliases": [
+        "gender of restroom"
+      ],
+      "mappings": [
+        "mixs:gender_restroom"
+      ],
+      "description": "The gender type of the restroom",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[male|female]"
+    },
+    "hall_count": {
+      "name": "hall_count",
+      "aliases": [
+        "hallway/corridor count"
+      ],
+      "mappings": [
+        "mixs:hall_count"
+      ],
+      "description": "The total count of hallways and cooridors in the built structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "handidness": {
+      "name": "handidness",
+      "aliases": [
+        "handidness"
+      ],
+      "mappings": [
+        "mixs:handidness"
+      ],
+      "description": "The handidness of the individual sampled",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[ambidexterity|left handedness|mixed\\-handedness|right handedness]"
+    },
+    "heat_deliv_loc": {
+      "name": "heat_deliv_loc",
+      "aliases": [
+        "heating delivery locations"
+      ],
+      "mappings": [
+        "mixs:heat_deliv_loc"
+      ],
+      "description": "The location of heat delivery within the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north|south|east|west]"
+    },
+    "heat_system_deliv_meth": {
+      "name": "heat_system_deliv_meth",
+      "aliases": [
+        "heating system delivery method"
+      ],
+      "mappings": [
+        "mixs:heat_system_deliv_meth"
+      ],
+      "description": "The method by which the heat is delivered through the system",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[conductive|radiant]"
+    },
+    "heat_system_id": {
+      "name": "heat_system_id",
+      "aliases": [
+        "heating system identifier"
+      ],
+      "mappings": [
+        "mixs:heat_system_id"
+      ],
+      "description": "The heating system identifier",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "height_carper_fiber": {
+      "name": "height_carper_fiber",
+      "aliases": [
+        "height carpet fiber mat"
+      ],
+      "mappings": [
+        "mixs:height_carper_fiber"
+      ],
+      "description": "The average carpet fiber height in the indoor environment",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "inside_lux": {
+      "name": "inside_lux",
+      "aliases": [
+        "inside lux light"
+      ],
+      "mappings": [
+        "mixs:inside_lux"
+      ],
+      "description": "The recorded value at sampling time (power density)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "int_wall_cond": {
+      "name": "int_wall_cond",
+      "aliases": [
+        "interior wall condition"
+      ],
+      "mappings": [
+        "mixs:int_wall_cond"
+      ],
+      "description": "The physical condition of the wall at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[new|visible wear|needs repair|damaged|rupture]"
+    },
+    "last_clean": {
+      "name": "last_clean",
+      "aliases": [
+        "last time swept/mopped/vacuumed"
+      ],
+      "mappings": [
+        "mixs:last_clean"
+      ],
+      "description": "The last time the floor was cleaned (swept, mopped, vacuumed)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "max_occup": {
+      "name": "max_occup",
+      "aliases": [
+        "maximum occupancy"
+      ],
+      "mappings": [
+        "mixs:max_occup"
+      ],
+      "description": "The maximum amount of people allowed in the indoor environment",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "mech_struc": {
+      "name": "mech_struc",
+      "aliases": [
+        "mechanical structure"
+      ],
+      "mappings": [
+        "mixs:mech_struc"
+      ],
+      "description": "mechanical structure: a moving structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[subway|coach|carriage|elevator|escalator|boat|train|car|bus]"
+    },
+    "number_plants": {
+      "name": "number_plants",
+      "aliases": [
+        "number of houseplants"
+      ],
+      "mappings": [
+        "mixs:number_plants"
+      ],
+      "description": "The number of plant(s) in the sampling space",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "number_pets": {
+      "name": "number_pets",
+      "aliases": [
+        "number of pets"
+      ],
+      "mappings": [
+        "mixs:number_pets"
+      ],
+      "description": "The number of pets residing in the sampled space",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "number_resident": {
+      "name": "number_resident",
+      "aliases": [
+        "number of residents"
+      ],
+      "mappings": [
+        "mixs:number_resident"
+      ],
+      "description": "The number of individuals currently occupying in the sampling location",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "occup_document": {
+      "name": "occup_document",
+      "aliases": [
+        "occupancy documentation"
+      ],
+      "mappings": [
+        "mixs:occup_document"
+      ],
+      "description": "The type of documentation of occupancy",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[automated count|estimate|manual count|videos]"
+    },
+    "ext_wall_orient": {
+      "name": "ext_wall_orient",
+      "aliases": [
+        "orientations of exterior wall"
+      ],
+      "mappings": [
+        "mixs:ext_wall_orient"
+      ],
+      "description": "The orientation of the exterior wall",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north|south|east|west|northeast|southeast|southwest|northwest]"
+    },
+    "ext_window_orient": {
+      "name": "ext_window_orient",
+      "aliases": [
+        "orientations of exterior window"
+      ],
+      "mappings": [
+        "mixs:ext_window_orient"
+      ],
+      "description": "The compass direction the exterior window of the room is facing",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north|south|east|west|northeast|southeast|southwest|northwest]"
+    },
+    "rel_humidity_out": {
+      "name": "rel_humidity_out",
+      "aliases": [
+        "outside relative humidity"
+      ],
+      "mappings": [
+        "mixs:rel_humidity_out"
+      ],
+      "description": "The recorded outside relative humidity value at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "pres_animal": {
+      "name": "pres_animal",
+      "aliases": [
+        "presence of pets, animals, or insects"
+      ],
+      "mappings": [
+        "mixs:pres_animal"
+      ],
+      "description": "The number and type of animals present in the sampling space",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "quad_pos": {
+      "name": "quad_pos",
+      "aliases": [
+        "quadrant position"
+      ],
+      "mappings": [
+        "mixs:quad_pos"
+      ],
+      "description": "The quadrant position of the sampling room within the building",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[North side|West side|South side|East side]"
+    },
+    "rel_samp_loc": {
+      "name": "rel_samp_loc",
+      "aliases": [
+        "relative sampling location"
+      ],
+      "mappings": [
+        "mixs:rel_samp_loc"
+      ],
+      "description": "The sampling location within the train car",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[edge of car|center of car|under a seat]"
+    },
+    "room_air_exch_rate": {
+      "name": "room_air_exch_rate",
+      "aliases": [
+        "room air exchange rate"
+      ],
+      "mappings": [
+        "mixs:room_air_exch_rate"
+      ],
+      "description": "The rate at which outside air replaces indoor air in a given space",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "room_architec_element": {
+      "name": "room_architec_element",
+      "aliases": [
+        "room architectural elements"
+      ],
+      "mappings": [
+        "mixs:room_architec_element"
+      ],
+      "description": "The unique details and component parts that, together, form the architecture of a distinguisahable space within a built structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "room_condt": {
+      "name": "room_condt",
+      "aliases": [
+        "room condition"
+      ],
+      "mappings": [
+        "mixs:room_condt"
+      ],
+      "description": "The condition of the room at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[new|visible wear|needs repair|damaged|rupture|visible signs of mold\\/mildew]"
+    },
+    "room_count": {
+      "name": "room_count",
+      "aliases": [
+        "room count"
+      ],
+      "mappings": [
+        "mixs:room_count"
+      ],
+      "description": "The total count of rooms in the built structure including all room types",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "room_dim": {
+      "name": "room_dim",
+      "aliases": [
+        "room dimensions"
+      ],
+      "mappings": [
+        "mixs:room_dim"
+      ],
+      "description": "The length, width and height of sampling room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{integer} {unit} x {integer} {unit} x {integer} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "room_door_dist": {
+      "name": "room_door_dist",
+      "aliases": [
+        "room door distance"
+      ],
+      "mappings": [
+        "mixs:room_door_dist"
+      ],
+      "description": "Distance between doors (meters) in the hallway between the sampling room and adjacent rooms",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{integer} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "room_loc": {
+      "name": "room_loc",
+      "aliases": [
+        "room location in building"
+      ],
+      "mappings": [
+        "mixs:room_loc"
+      ],
+      "description": "The position of the room within the building",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[corner room|interior room|exterior wall]"
+    },
+    "room_moist_damage_hist": {
+      "name": "room_moist_damage_hist",
+      "aliases": [
+        "room moisture damage or mold history"
+      ],
+      "mappings": [
+        "mixs:room_moist_damage_hist"
+      ],
+      "description": "The history of moisture damage or mold in the past 12 months. Number of events of moisture damage or mold observed",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "room_net_area": {
+      "name": "room_net_area",
+      "aliases": [
+        "room net area"
+      ],
+      "mappings": [
+        "mixs:room_net_area"
+      ],
+      "description": "The net floor area of sampling room. Net area excludes wall thicknesses",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{integer} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "room_occup": {
+      "name": "room_occup",
+      "aliases": [
+        "room occupancy"
+      ],
+      "mappings": [
+        "mixs:room_occup"
+      ],
+      "description": "Count of room occupancy at time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "room_samp_pos": {
+      "name": "room_samp_pos",
+      "aliases": [
+        "room sampling position"
+      ],
+      "mappings": [
+        "mixs:room_samp_pos"
+      ],
+      "description": "The horizontal sampling position in the room relative to architectural elements",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north corner|south corner|west corner|east corner|northeast corner|northwest corner|southeast corner|southwest corner|center]"
+    },
+    "room_type": {
+      "name": "room_type",
+      "aliases": [
+        "room type"
+      ],
+      "mappings": [
+        "mixs:room_type"
+      ],
+      "description": "The main purpose or activity of the sampling room. A room is any distinguishable space within a structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[attic|bathroom|closet|conference room|elevator|examining room|hallway|kitchen|mail room|private office|open office|stairwell|,restroom|lobby|vestibule|mechanical or electrical room|data center|laboratory_wet|laboratory_dry|gymnasium|natatorium|auditorium|lockers|cafe|warehouse]"
+    },
+    "room_vol": {
+      "name": "room_vol",
+      "aliases": [
+        "room volume"
+      ],
+      "mappings": [
+        "mixs:room_vol"
+      ],
+      "description": "Volume of sampling room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{integer} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "room_window_count": {
+      "name": "room_window_count",
+      "aliases": [
+        "room window count"
+      ],
+      "mappings": [
+        "mixs:room_window_count"
+      ],
+      "description": "Number of windows in the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "room_connected": {
+      "name": "room_connected",
+      "aliases": [
+        "rooms connected by a doorway"
+      ],
+      "mappings": [
+        "mixs:room_connected"
+      ],
+      "description": "List of rooms connected to the sampling room by a doorway",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[attic|bathroom|closet|conference room|elevator|examining room|hallway|kitchen|mail room|office|stairwell]"
+    },
+    "room_hallway": {
+      "name": "room_hallway",
+      "aliases": [
+        "rooms that are on the same hallway"
+      ],
+      "mappings": [
+        "mixs:room_hallway"
+      ],
+      "description": "List of room(s) (room number, room name) located in the same hallway as sampling room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "room_door_share": {
+      "name": "room_door_share",
+      "aliases": [
+        "rooms that share a door with sampling room"
+      ],
+      "mappings": [
+        "mixs:room_door_share"
+      ],
+      "description": "List of room(s) (room number, room name) sharing a door with the sampling room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "room_wall_share": {
+      "name": "room_wall_share",
+      "aliases": [
+        "rooms that share a wall with sampling room"
+      ],
+      "mappings": [
+        "mixs:room_wall_share"
+      ],
+      "description": "List of room(s) (room number, room name) sharing a wall with the sampling room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_weather": {
+      "name": "samp_weather",
+      "aliases": [
+        "sampling day weather"
+      ],
+      "mappings": [
+        "mixs:samp_weather"
+      ],
+      "description": "The weather on the sampling day",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[clear sky|cloudy|foggy|hail|rain|snow|sleet|sunny|windy]"
+    },
+    "samp_floor": {
+      "name": "samp_floor",
+      "aliases": [
+        "sampling floor"
+      ],
+      "mappings": [
+        "mixs:samp_floor"
+      ],
+      "description": "The floor of the building, where the sampling room is located",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_room_id": {
+      "name": "samp_room_id",
+      "aliases": [
+        "sampling room ID or name"
+      ],
+      "mappings": [
+        "mixs:samp_room_id"
+      ],
+      "description": "Sampling room number. This ID should be consistent with the designations on the building floor plans",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_time_out": {
+      "name": "samp_time_out",
+      "aliases": [
+        "sampling time outside"
+      ],
+      "mappings": [
+        "mixs:samp_time_out"
+      ],
+      "description": "The recent and long term history of outside sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "season": {
+      "name": "season",
+      "aliases": [
+        "season"
+      ],
+      "mappings": [
+        "mixs:season"
+      ],
+      "description": "The season when sampling occurred",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Spring|Summer|Fall|Winter]"
+    },
+    "season_use": {
+      "name": "season_use",
+      "aliases": [
+        "seasonal use"
+      ],
+      "mappings": [
+        "mixs:season_use"
+      ],
+      "description": "The seasons the space is occupied",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Spring|Summer|Fall|Winter]"
+    },
+    "shading_device_cond": {
+      "name": "shading_device_cond",
+      "aliases": [
+        "shading device condition"
+      ],
+      "mappings": [
+        "mixs:shading_device_cond"
+      ],
+      "description": "The physical condition of the shading device at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[damaged|needs repair|new|rupture|visible wear]"
+    },
+    "shading_device_loc": {
+      "name": "shading_device_loc",
+      "aliases": [
+        "shading device location"
+      ],
+      "mappings": [
+        "mixs:shading_device_loc"
+      ],
+      "description": "The location of the shading device in relation to the built structure",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[exterior|interior]"
+    },
+    "shading_device_mat": {
+      "name": "shading_device_mat",
+      "aliases": [
+        "shading device material"
+      ],
+      "mappings": [
+        "mixs:shading_device_mat"
+      ],
+      "description": "The material the shading device is composed of",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "shading_device_water_mold": {
+      "name": "shading_device_water_mold",
+      "aliases": [
+        "shading device signs of water/mold"
+      ],
+      "mappings": [
+        "mixs:shading_device_water_mold"
+      ],
+      "description": "Signs of the presence of mold or mildew on the shading device",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[presence of mold visible|no presence of mold visible]"
+    },
+    "shading_device_type": {
+      "name": "shading_device_type",
+      "aliases": [
+        "shading device type"
+      ],
+      "mappings": [
+        "mixs:shading_device_type"
+      ],
+      "description": "The type of shading device",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[bahama shutters|exterior roll blind|gambrel awning|hood awning|porchroller awning|sarasota shutters|slatted aluminum|solid aluminum awning|sun screen|tree|trellis|venetian awning]"
+    },
+    "specific_humidity": {
+      "name": "specific_humidity",
+      "aliases": [
+        "specific humidity"
+      ],
+      "mappings": [
+        "mixs:specific_humidity"
+      ],
+      "description": "The mass of water vapour in a unit mass of moist air, usually expressed as grams of vapour per kilogram of air, or, in air conditioning, as grains per pound.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "specific": {
+      "name": "specific",
+      "aliases": [
+        "specifications"
+      ],
+      "mappings": [
+        "mixs:specific"
+      ],
+      "description": "The building specifications. If design is chosen, indicate phase: conceptual, schematic, design development, construction documents",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[operation|as built|construction|bid|design|photos]"
+    },
+    "temp_out": {
+      "name": "temp_out",
+      "aliases": [
+        "temperature outside house"
+      ],
+      "mappings": [
+        "mixs:temp_out"
+      ],
+      "description": "The recorded temperature value at sampling time outside",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "train_line": {
+      "name": "train_line",
+      "aliases": [
+        "train line"
+      ],
+      "mappings": [
+        "mixs:train_line"
+      ],
+      "description": "The subway line name",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[red|green|orange]"
+    },
+    "train_stat_loc": {
+      "name": "train_stat_loc",
+      "aliases": [
+        "train station collection location"
+      ],
+      "mappings": [
+        "mixs:train_stat_loc"
+      ],
+      "description": "The train station collection location",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[south station above ground|south station underground|south station amtrak|forest hills|riverside]"
+    },
+    "train_stop_loc": {
+      "name": "train_stop_loc",
+      "aliases": [
+        "train stop collection location"
+      ],
+      "mappings": [
+        "mixs:train_stop_loc"
+      ],
+      "description": "The train stop collection location",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[end|mid|downtown]"
+    },
+    "vis_media": {
+      "name": "vis_media",
+      "aliases": [
+        "visual media"
+      ],
+      "mappings": [
+        "mixs:vis_media"
+      ],
+      "description": "The building visual media",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[photos|videos|commonly of the building|site context (adjacent buildings, vegetation, terrain, streets)|interiors|equipment|3D scans]"
+    },
+    "wall_area": {
+      "name": "wall_area",
+      "aliases": [
+        "wall area"
+      ],
+      "mappings": [
+        "mixs:wall_area"
+      ],
+      "description": "The total area of the sampled room's walls",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "wall_const_type": {
+      "name": "wall_const_type",
+      "aliases": [
+        "wall construction type"
+      ],
+      "mappings": [
+        "mixs:wall_const_type"
+      ],
+      "description": "The building class of the wall defined by the composition of the building elements and fire-resistance rating.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[frame construction|joisted masonry|light noncombustible|masonry noncombustible|modified fire resistive|fire resistive]"
+    },
+    "wall_finish_mat": {
+      "name": "wall_finish_mat",
+      "aliases": [
+        "wall finish material"
+      ],
+      "mappings": [
+        "mixs:wall_finish_mat"
+      ],
+      "description": "The material utilized to finish the outer most layer of the wall ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[plaster|gypsum plaster|veneer plaster|gypsum board|tile|terrazzo|stone facing|acoustical treatment|wood|metal|masonry]"
+    },
+    "wall_height": {
+      "name": "wall_height",
+      "aliases": [
+        "wall height"
+      ],
+      "mappings": [
+        "mixs:wall_height"
+      ],
+      "description": "The average height of the walls in the sampled room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "wall_loc": {
+      "name": "wall_loc",
+      "aliases": [
+        "wall location"
+      ],
+      "mappings": [
+        "mixs:wall_loc"
+      ],
+      "description": "The relative location of the wall within the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north|south|east|west]"
+    },
+    "wall_water_mold": {
+      "name": "wall_water_mold",
+      "aliases": [
+        "wall signs of water/mold"
+      ],
+      "mappings": [
+        "mixs:wall_water_mold"
+      ],
+      "description": "Signs of the presence of mold or mildew on a wall",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[presence of mold visible|no presence of mold visible]"
+    },
+    "wall_surf_treatment": {
+      "name": "wall_surf_treatment",
+      "aliases": [
+        "wall surface treatment"
+      ],
+      "mappings": [
+        "mixs:wall_surf_treatment"
+      ],
+      "description": "The surface treatment of interior wall",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[painted|wall paper|no treatment|paneling|stucco|fabric]"
+    },
+    "wall_texture": {
+      "name": "wall_texture",
+      "aliases": [
+        "wall texture"
+      ],
+      "mappings": [
+        "mixs:wall_texture"
+      ],
+      "description": "The feel, appearance, or consistency of a wall surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[crows feet|crows\\-foot stomp|double skip|hawk and trowel|knockdown|popcorn|orange peel|rosebud stomp|Santa\\-Fe texture|skip trowel|smooth|stomp knockdown|swirl]"
+    },
+    "wall_thermal_mass": {
+      "name": "wall_thermal_mass",
+      "aliases": [
+        "wall thermal mass"
+      ],
+      "mappings": [
+        "mixs:wall_thermal_mass"
+      ],
+      "description": "The ability of the wall to provide inertia against temperature fluctuations. Generally this means concrete or concrete block that is either exposed or covered only with paint",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "water_feat_size": {
+      "name": "water_feat_size",
+      "aliases": [
+        "water feature size"
+      ],
+      "mappings": [
+        "mixs:water_feat_size"
+      ],
+      "description": "The size of the water feature",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "water_feat_type": {
+      "name": "water_feat_type",
+      "aliases": [
+        "water feature type"
+      ],
+      "mappings": [
+        "mixs:water_feat_type"
+      ],
+      "description": "The type of water feature present within the building being sampled",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[fountain|pool|standing feature|stream|waterfall]"
+    },
+    "weekday": {
+      "name": "weekday",
+      "aliases": [
+        "weekday"
+      ],
+      "mappings": [
+        "mixs:weekday"
+      ],
+      "description": "The day of the week when sampling occurred",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday]"
+    },
+    "window_size": {
+      "name": "window_size",
+      "aliases": [
+        "window area/size"
+      ],
+      "mappings": [
+        "mixs:window_size"
+      ],
+      "description": "The window's length and width",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit} x {float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+ x \\d+[.\\d+] \\S+"
+    },
+    "window_cond": {
+      "name": "window_cond",
+      "aliases": [
+        "window condition"
+      ],
+      "mappings": [
+        "mixs:window_cond"
+      ],
+      "description": "The physical condition of the window at the time of sampling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[damaged|needs repair|new|rupture|visible wear]"
+    },
+    "window_cover": {
+      "name": "window_cover",
+      "aliases": [
+        "window covering"
+      ],
+      "mappings": [
+        "mixs:window_cover"
+      ],
+      "description": "The type of window covering",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[blinds|curtains|none]"
+    },
+    "window_horiz_pos": {
+      "name": "window_horiz_pos",
+      "aliases": [
+        "window horizontal position"
+      ],
+      "mappings": [
+        "mixs:window_horiz_pos"
+      ],
+      "description": "The horizontal position of the window on the wall",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[left|middle|right]"
+    },
+    "window_loc": {
+      "name": "window_loc",
+      "aliases": [
+        "window location"
+      ],
+      "mappings": [
+        "mixs:window_loc"
+      ],
+      "description": "The relative location of the window within the room",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[north|south|east|west]"
+    },
+    "window_mat": {
+      "name": "window_mat",
+      "aliases": [
+        "window material"
+      ],
+      "mappings": [
+        "mixs:window_mat"
+      ],
+      "description": "The type of material used to finish a window",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[clad|fiberglass|metal|vinyl|wood]"
+    },
+    "window_open_freq": {
+      "name": "window_open_freq",
+      "aliases": [
+        "window open frequency"
+      ],
+      "mappings": [
+        "mixs:window_open_freq"
+      ],
+      "description": "The number of times windows are opened per week",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "window_water_mold": {
+      "name": "window_water_mold",
+      "aliases": [
+        "window signs of water/mold"
+      ],
+      "mappings": [
+        "mixs:window_water_mold"
+      ],
+      "description": "Signs of the presence of mold or mildew on the window.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[presence of mold visible|no presence of mold visible]"
+    },
+    "window_status": {
+      "name": "window_status",
+      "aliases": [
+        "window status"
+      ],
+      "mappings": [
+        "mixs:window_status"
+      ],
+      "description": "Defines whether the windows were open or closed during environmental testing",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[closed|open]"
+    },
+    "window_type": {
+      "name": "window_type",
+      "aliases": [
+        "window type"
+      ],
+      "mappings": [
+        "mixs:window_type"
+      ],
+      "description": "The type of windows",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[single\\-hung sash window|horizontal sash window|fixed window] "
+    },
+    "window_vert_pos": {
+      "name": "window_vert_pos",
+      "aliases": [
+        "window vertical position"
+      ],
+      "mappings": [
+        "mixs:window_vert_pos"
+      ],
+      "description": "The vertical position of the window on the wall",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[bottom|middle|top|low|middle|high]"
+    },
+    "ances_data": {
+      "name": "ances_data",
+      "aliases": [
+        "ancestral data"
+      ],
+      "mappings": [
+        "mixs:ances_data"
+      ],
+      "description": "Information about either pedigree or other ancestral information description (e.g. parental variety in case of mutant or selection), e.g. A/3*B (meaning [(A x B) x B] x B)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "biol_stat": {
+      "name": "biol_stat",
+      "aliases": [
+        "biological status"
+      ],
+      "mappings": [
+        "mixs:biol_stat"
+      ],
+      "description": "The level of genome modification",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[wild|natural|semi\\-natural|inbred line|breeder\\'s line|hybrid|clonal selection|mutant]"
+    },
+    "genetic_mod": {
+      "name": "genetic_mod",
+      "aliases": [
+        "genetic modification"
+      ],
+      "mappings": [
+        "mixs:genetic_mod"
+      ],
+      "description": "Genetic modifications of the genome of an organism, which may occur naturally by spontaneous mutation, or be introduced by some experimental means, e.g. specification of a transgene or the gene knocked-out or details of transient transfection",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_common_name": {
+      "name": "host_common_name",
+      "aliases": [
+        "host common name"
+      ],
+      "mappings": [
+        "mixs:host_common_name"
+      ],
+      "description": "Common name of the host, e.g. Human",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_capt_status": {
+      "name": "samp_capt_status",
+      "aliases": [
+        "sample capture status"
+      ],
+      "mappings": [
+        "mixs:samp_capt_status"
+      ],
+      "description": "Reason for the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[active surveillance in response to an outbreak|active surveillance not initiated by an outbreak|farm sample|market sample|other]"
+    },
+    "samp_dis_stage": {
+      "name": "samp_dis_stage",
+      "aliases": [
+        "sample disease stage"
+      ],
+      "mappings": [
+        "mixs:samp_dis_stage"
+      ],
+      "description": "Stage of the disease at the time of sample collection, e.g. inoculation, penetration, infection, growth and reproduction, dissemination of pathogen.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_taxid": {
+      "name": "host_taxid",
+      "aliases": [
+        "host taxid"
+      ],
+      "mappings": [
+        "mixs:host_taxid"
+      ],
+      "description": "NCBI taxon id of the host, e.g. 9606",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_subject_id": {
+      "name": "host_subject_id",
+      "aliases": [
+        "host subject id"
+      ],
+      "mappings": [
+        "mixs:host_subject_id"
+      ],
+      "description": "A unique identifier by which each subject can be referred to, de-identified, e.g. #131",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_age": {
+      "name": "host_age",
+      "aliases": [
+        "host age"
+      ],
+      "mappings": [
+        "mixs:host_age"
+      ],
+      "description": "Age of host at the time of sampling; relevant scale depends on species and study, e.g. Could be seconds for amoebae or centuries for trees",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_life_stage": {
+      "name": "host_life_stage",
+      "aliases": [
+        "host life stage"
+      ],
+      "mappings": [
+        "mixs:host_life_stage"
+      ],
+      "description": "Description of life stage of host",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_sex": {
+      "name": "host_sex",
+      "aliases": [
+        "host sex"
+      ],
+      "mappings": [
+        "mixs:host_sex"
+      ],
+      "description": "Physical sex of the host",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[male|female|neuter|hermaphrodite|not determined]"
+    },
+    "host_disease_stat": {
+      "name": "host_disease_stat",
+      "aliases": [
+        "host disease status"
+      ],
+      "mappings": [
+        "mixs:host_disease_stat"
+      ],
+      "description": "List of diseases with which the host has been diagnosed; can include multiple diagnoses. The value of the field depends on host; for humans the terms should be chosen from do (disease ontology) at http://www.disease-ontology.org, other hosts are free text",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value"
+    },
+    "host_body_habitat": {
+      "name": "host_body_habitat",
+      "aliases": [
+        "host body habitat"
+      ],
+      "mappings": [
+        "mixs:host_body_habitat"
+      ],
+      "description": "Original body habitat where the sample was obtained from",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_body_site": {
+      "name": "host_body_site",
+      "aliases": [
+        "host body site"
+      ],
+      "mappings": [
+        "mixs:host_body_site"
+      ],
+      "description": "Name of body site where the sample was obtained from, such as a specific organ or tissue (tongue, lung etc...). For foundational model of anatomy ontology (fma) (v 4.11.0) or Uber-anatomy ontology (UBERON) (v releases/2014-06-15) terms, please see http://purl.bioontology.org/ontology/FMA or http://purl.bioontology.org/ontology/UBERON",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "host_body_product": {
+      "name": "host_body_product",
+      "aliases": [
+        "host body product"
+      ],
+      "mappings": [
+        "mixs:host_body_product"
+      ],
+      "description": "Substance produced by the body, e.g. Stool, mucus, where the sample was obtained from. For foundational model of anatomy ontology (fma) or Uber-anatomy ontology (UBERON) terms, please see https://www.ebi.ac.uk/ols/ontologies/fma or https://www.ebi.ac.uk/ols/ontologies/uberon",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "host_tot_mass": {
+      "name": "host_tot_mass",
+      "aliases": [
+        "host total mass"
+      ],
+      "mappings": [
+        "mixs:host_tot_mass"
+      ],
+      "description": "Total mass of the host at collection, the unit depends on host",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_height": {
+      "name": "host_height",
+      "aliases": [
+        "host height"
+      ],
+      "mappings": [
+        "mixs:host_height"
+      ],
+      "description": "The height of subject",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_length": {
+      "name": "host_length",
+      "aliases": [
+        "host length"
+      ],
+      "mappings": [
+        "mixs:host_length"
+      ],
+      "description": "The length of subject",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_diet": {
+      "name": "host_diet",
+      "aliases": [
+        "host diet"
+      ],
+      "mappings": [
+        "mixs:host_diet"
+      ],
+      "description": "Type of diet depending on the host, for animals omnivore, herbivore etc., for humans high-fat, meditteranean etc.; can include multiple diet types",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_last_meal": {
+      "name": "host_last_meal",
+      "aliases": [
+        "host last meal"
+      ],
+      "mappings": [
+        "mixs:host_last_meal"
+      ],
+      "description": "Content of last meal and time since feeding; can include multiple values",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_growth_cond": {
+      "name": "host_growth_cond",
+      "aliases": [
+        "host growth conditions"
+      ],
+      "mappings": [
+        "mixs:host_growth_cond"
+      ],
+      "description": "Literature reference giving growth conditions of the host",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_substrate": {
+      "name": "host_substrate",
+      "aliases": [
+        "host substrate"
+      ],
+      "mappings": [
+        "mixs:host_substrate"
+      ],
+      "description": "The growth substrate of the host ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_family_relationship": {
+      "name": "host_family_relationship",
+      "aliases": [
+        "host family relationship"
+      ],
+      "mappings": [
+        "mixs:host_family_relationship"
+      ],
+      "description": "Relationships to other hosts in the same study; can include multiple relationships",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_infra_specific_name": {
+      "name": "host_infra_specific_name",
+      "aliases": [
+        "host infra-specific name"
+      ],
+      "mappings": [
+        "mixs:host_infra_specific_name"
+      ],
+      "description": "Taxonomic information about the host below subspecies level",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_infra_specific_rank": {
+      "name": "host_infra_specific_rank",
+      "aliases": [
+        "host infra-specific rank"
+      ],
+      "mappings": [
+        "mixs:host_infra_specific_rank"
+      ],
+      "description": "Taxonomic rank information about the host below subspecies level, such as variety, form, rank etc.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_genotype": {
+      "name": "host_genotype",
+      "aliases": [
+        "host genotype"
+      ],
+      "mappings": [
+        "mixs:host_genotype"
+      ],
+      "description": "Observed genotype",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_phenotype": {
+      "name": "host_phenotype",
+      "aliases": [
+        "host phenotype"
+      ],
+      "mappings": [
+        "mixs:host_phenotype"
+      ],
+      "description": "Phenotype of human or other host. For phenotypic quality ontology (pato) (v 2018-03-27) terms, please see http://purl.bioontology.org/ontology/pato. For Human Phenotype Ontology (HP) (v 2018-06-13) please see http://purl.bioontology.org/ontology/HP",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "host_body_temp": {
+      "name": "host_body_temp",
+      "aliases": [
+        "host body temperature"
+      ],
+      "mappings": [
+        "mixs:host_body_temp"
+      ],
+      "description": "Core body temperature of the host when sample was collected",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_dry_mass": {
+      "name": "host_dry_mass",
+      "aliases": [
+        "host dry mass"
+      ],
+      "mappings": [
+        "mixs:host_dry_mass"
+      ],
+      "description": "Measurement of dry mass",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_blood_press_diast": {
+      "name": "host_blood_press_diast",
+      "aliases": [
+        "host blood pressure diastolic"
+      ],
+      "mappings": [
+        "mixs:host_blood_press_diast"
+      ],
+      "description": "Resting diastolic blood pressure, measured as mm mercury",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_blood_press_syst": {
+      "name": "host_blood_press_syst",
+      "aliases": [
+        "host blood pressure systolic"
+      ],
+      "mappings": [
+        "mixs:host_blood_press_syst"
+      ],
+      "description": "Resting systolic blood pressure, measured as mm mercury",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "host_color": {
+      "name": "host_color",
+      "aliases": [
+        "host color"
+      ],
+      "mappings": [
+        "mixs:host_color"
+      ],
+      "description": "The color of host",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_shape": {
+      "name": "host_shape",
+      "aliases": [
+        "host shape"
+      ],
+      "mappings": [
+        "mixs:host_shape"
+      ],
+      "description": "Morphological shape of host ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "gravidity": {
+      "name": "gravidity",
+      "aliases": [
+        "gravidity"
+      ],
+      "mappings": [
+        "mixs:gravidity"
+      ],
+      "description": "Whether or not subject is gravid, and if yes date due or date post-conception, specifying which is used",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ihmc_medication_code": {
+      "name": "ihmc_medication_code",
+      "aliases": [
+        "IHMC medication code"
+      ],
+      "mappings": [
+        "mixs:ihmc_medication_code"
+      ],
+      "description": "Can include multiple medication codes",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "smoker": {
+      "name": "smoker",
+      "aliases": [
+        "smoker"
+      ],
+      "mappings": [
+        "mixs:smoker"
+      ],
+      "description": "Specification of smoking status",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "host_hiv_stat": {
+      "name": "host_hiv_stat",
+      "aliases": [
+        "host HIV status"
+      ],
+      "mappings": [
+        "mixs:host_hiv_stat"
+      ],
+      "description": "HIV status of subject, if yes HAART initiation status should also be indicated as [YES or NO]",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[true|false];[true|false]"
+    },
+    "drug_usage": {
+      "name": "drug_usage",
+      "aliases": [
+        "drug usage"
+      ],
+      "mappings": [
+        "mixs:drug_usage"
+      ],
+      "description": "Any drug used by subject and the frequency of usage; can include multiple drugs used",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_body_mass_index": {
+      "name": "host_body_mass_index",
+      "aliases": [
+        "host body-mass index"
+      ],
+      "mappings": [
+        "mixs:host_body_mass_index"
+      ],
+      "description": "Body mass index, calculated as weight/(height)squared",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diet_last_six_month": {
+      "name": "diet_last_six_month",
+      "aliases": [
+        "major diet change in last six months"
+      ],
+      "mappings": [
+        "mixs:diet_last_six_month"
+      ],
+      "description": "Specification of major diet changes in the last six months, if yes the change should be specified",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "weight_loss_3_month": {
+      "name": "weight_loss_3_month",
+      "aliases": [
+        "weight loss in last three months"
+      ],
+      "mappings": [
+        "mixs:weight_loss_3_month"
+      ],
+      "description": "Specification of weight loss in the last three months, if yes should be further specified to include amount of weight loss",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{boolean};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "[true|false];\\d+[.\\d+] \\S+"
+    },
+    "ihmc_ethnicity": {
+      "name": "ihmc_ethnicity",
+      "aliases": [
+        "IHMC ethnicity"
+      ],
+      "mappings": [
+        "mixs:ihmc_ethnicity"
+      ],
+      "description": "Ethnicity of the subject",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_occupation": {
+      "name": "host_occupation",
+      "aliases": [
+        "host occupation"
+      ],
+      "mappings": [
+        "mixs:host_occupation"
+      ],
+      "description": "Most frequent job performed by subject",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pet_farm_animal": {
+      "name": "pet_farm_animal",
+      "aliases": [
+        "presence of pets or farm animals"
+      ],
+      "mappings": [
+        "mixs:pet_farm_animal"
+      ],
+      "description": "Specification of presence of pets or farm animals in the environment of subject, if yes the animals should be specified; can include multiple animals present",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "travel_out_six_month": {
+      "name": "travel_out_six_month",
+      "aliases": [
+        "travel outside the country in last six months"
+      ],
+      "mappings": [
+        "mixs:travel_out_six_month"
+      ],
+      "description": "Specification of the countries travelled in the last six months; can include multiple travels",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "twin_sibling": {
+      "name": "twin_sibling",
+      "aliases": [
+        "twin sibling presence"
+      ],
+      "mappings": [
+        "mixs:twin_sibling"
+      ],
+      "description": "Specification of twin sibling presence",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "medic_hist_perform": {
+      "name": "medic_hist_perform",
+      "aliases": [
+        "medical history performed"
+      ],
+      "mappings": [
+        "mixs:medic_hist_perform"
+      ],
+      "description": "Whether full medical history was collected",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "study_complt_stat": {
+      "name": "study_complt_stat",
+      "aliases": [
+        "study completion status"
+      ],
+      "mappings": [
+        "mixs:study_complt_stat"
+      ],
+      "description": "Specification of study completion status, if no the reason should be specified",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[true|false];[adverse event|non\\-compliance|lost to follow up|other\\-specify]"
+    },
+    "pulmonary_disord": {
+      "name": "pulmonary_disord",
+      "aliases": [
+        "lung/pulmonary disorder"
+      ],
+      "mappings": [
+        "mixs:pulmonary_disord"
+      ],
+      "description": "History of pulmonary disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "nose_throat_disord": {
+      "name": "nose_throat_disord",
+      "aliases": [
+        "lung/nose-throat disorder"
+      ],
+      "mappings": [
+        "mixs:nose_throat_disord"
+      ],
+      "description": "History of nose-throat disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "blood_blood_disord": {
+      "name": "blood_blood_disord",
+      "aliases": [
+        "blood/blood disorder"
+      ],
+      "mappings": [
+        "mixs:blood_blood_disord"
+      ],
+      "description": "History of blood disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "host_pulse": {
+      "name": "host_pulse",
+      "aliases": [
+        "host pulse"
+      ],
+      "mappings": [
+        "mixs:host_pulse"
+      ],
+      "description": "Resting pulse, measured as beats per minute",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "gestation_state": {
+      "name": "gestation_state",
+      "aliases": [
+        "amniotic fluid/gestation state"
+      ],
+      "mappings": [
+        "mixs:gestation_state"
+      ],
+      "description": "Specification of the gestation state",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "maternal_health_stat": {
+      "name": "maternal_health_stat",
+      "aliases": [
+        "amniotic fluid/maternal health status"
+      ],
+      "mappings": [
+        "mixs:maternal_health_stat"
+      ],
+      "description": "Specification of the maternal health status",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "foetal_health_stat": {
+      "name": "foetal_health_stat",
+      "aliases": [
+        "amniotic fluid/foetal health status"
+      ],
+      "mappings": [
+        "mixs:foetal_health_stat"
+      ],
+      "description": "Specification of foetal health status, should also include abortion",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "amniotic_fluid_color": {
+      "name": "amniotic_fluid_color",
+      "aliases": [
+        "amniotic fluid/color"
+      ],
+      "mappings": [
+        "mixs:amniotic_fluid_color"
+      ],
+      "description": "Specification of the color of the amniotic fluid sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "kidney_disord": {
+      "name": "kidney_disord",
+      "aliases": [
+        "urine/kidney disorder"
+      ],
+      "mappings": [
+        "mixs:kidney_disord"
+      ],
+      "description": "History of kidney disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "urogenit_tract_disor": {
+      "name": "urogenit_tract_disor",
+      "aliases": [
+        "urine/urogenital tract disorder"
+      ],
+      "mappings": [
+        "mixs:urogenit_tract_disor"
+      ],
+      "description": "History of urogenitaltract disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "urine_collect_meth": {
+      "name": "urine_collect_meth",
+      "aliases": [
+        "urine/collection method"
+      ],
+      "mappings": [
+        "mixs:urine_collect_meth"
+      ],
+      "description": "Specification of urine collection method",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[clean catch|catheter]"
+    },
+    "gastrointest_disord": {
+      "name": "gastrointest_disord",
+      "aliases": [
+        "gastrointestinal tract disorder"
+      ],
+      "mappings": [
+        "mixs:gastrointest_disord"
+      ],
+      "description": "History of gastrointestinal tract disorders; can include multiple disorders ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "liver_disord": {
+      "name": "liver_disord",
+      "aliases": [
+        "liver disorder"
+      ],
+      "mappings": [
+        "mixs:liver_disord"
+      ],
+      "description": "History of liver disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "special_diet": {
+      "name": "special_diet",
+      "aliases": [
+        "special diet"
+      ],
+      "mappings": [
+        "mixs:special_diet"
+      ],
+      "description": "Specification of special diet; can include multiple special diets",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[low carb|reduced calorie|vegetarian|other(to be specified)]"
+    },
+    "nose_mouth_teeth_throat_disord": {
+      "name": "nose_mouth_teeth_throat_disord",
+      "aliases": [
+        "nose/mouth/teeth/throat disorder"
+      ],
+      "mappings": [
+        "mixs:nose_mouth_teeth_throat_disord"
+      ],
+      "description": "History of nose/mouth/teeth/throat disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "time_last_toothbrush": {
+      "name": "time_last_toothbrush",
+      "aliases": [
+        "time since last toothbrushing"
+      ],
+      "mappings": [
+        "mixs:time_last_toothbrush"
+      ],
+      "description": "Specification of the time since last toothbrushing",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "dermatology_disord": {
+      "name": "dermatology_disord",
+      "aliases": [
+        "dermatology disorder"
+      ],
+      "mappings": [
+        "mixs:dermatology_disord"
+      ],
+      "description": "History of dermatology disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "time_since_last_wash": {
+      "name": "time_since_last_wash",
+      "aliases": [
+        "time since last wash"
+      ],
+      "mappings": [
+        "mixs:time_since_last_wash"
+      ],
+      "description": "Specification of the time since last wash",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "dominant_hand": {
+      "name": "dominant_hand",
+      "aliases": [
+        "dominant hand"
+      ],
+      "mappings": [
+        "mixs:dominant_hand"
+      ],
+      "description": "Dominant hand of the subject",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[left|right|ambidextrous]"
+    },
+    "menarche": {
+      "name": "menarche",
+      "aliases": [
+        "menarche"
+      ],
+      "mappings": [
+        "mixs:menarche"
+      ],
+      "description": "Date of most recent menstruation",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "sexual_act": {
+      "name": "sexual_act",
+      "aliases": [
+        "sexual activity"
+      ],
+      "mappings": [
+        "mixs:sexual_act"
+      ],
+      "description": "Current sexual partner and frequency of sex",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pregnancy": {
+      "name": "pregnancy",
+      "aliases": [
+        "pregnancy"
+      ],
+      "mappings": [
+        "mixs:pregnancy"
+      ],
+      "description": "Date due of pregnancy",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "douche": {
+      "name": "douche",
+      "aliases": [
+        "douche"
+      ],
+      "mappings": [
+        "mixs:douche"
+      ],
+      "description": "Date of most recent douche",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "birth_control": {
+      "name": "birth_control",
+      "aliases": [
+        "birth control"
+      ],
+      "mappings": [
+        "mixs:birth_control"
+      ],
+      "description": "Specification of birth control medication used",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "menopause": {
+      "name": "menopause",
+      "aliases": [
+        "menopause"
+      ],
+      "mappings": [
+        "mixs:menopause"
+      ],
+      "description": "Date of onset of menopause",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "hrt": {
+      "name": "hrt",
+      "aliases": [
+        "HRT"
+      ],
+      "mappings": [
+        "mixs:hrt"
+      ],
+      "description": "Whether subject had hormone replacement theraphy, and if yes start date",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "hysterectomy": {
+      "name": "hysterectomy",
+      "aliases": [
+        "hysterectomy"
+      ],
+      "mappings": [
+        "mixs:hysterectomy"
+      ],
+      "description": "Specification of whether hysterectomy was performed",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "boolean value",
+      "pattern": "[true|false]"
+    },
+    "gynecologic_disord": {
+      "name": "gynecologic_disord",
+      "aliases": [
+        "gynecological disorder"
+      ],
+      "mappings": [
+        "mixs:gynecologic_disord"
+      ],
+      "description": "History of gynecological disorders; can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "urogenit_disord": {
+      "name": "urogenit_disord",
+      "aliases": [
+        "urogenital disorder"
+      ],
+      "mappings": [
+        "mixs:urogenit_disord"
+      ],
+      "description": "History of urogenital disorders, can include multiple disorders",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "hcr": {
+      "name": "hcr",
+      "aliases": [
+        "hydrocarbon resource type"
+      ],
+      "mappings": [
+        "mixs:hcr"
+      ],
+      "description": "Main Hydrocarbon Resource type. The term 'Hydrocarbon Resource' HCR defined as a natural environmental feature containing large amounts of hydrocarbons at high concentrations potentially suitable for commercial exploitation.  This term should not be confused with the Hydrocarbon Occurrence term which also includes hydrocarbon-rich environments with currently limited commercial interest such as seeps, outcrops, gas hydrates etc. If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Oil Reservoir|Gas Reservoir|Oil Sand|Coalbed|Shale|Tight Oil Reservoir|Tight Gas Reservoir|other]"
+    },
+    "hc_produced": {
+      "name": "hc_produced",
+      "aliases": [
+        "hydrocarbon type produced"
+      ],
+      "mappings": [
+        "mixs:hc_produced"
+      ],
+      "description": "Main hydrocarbon type produced from resource (i.e. Oil, gas, condensate, etc). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Oil|Gas\\-Condensate|Gas|Bitumen|Coalbed Methane|other]"
+    },
+    "basin": {
+      "name": "basin",
+      "aliases": [
+        "basin name"
+      ],
+      "mappings": [
+        "mixs:basin"
+      ],
+      "description": "Name of the basin (e.g. Campos)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "field": {
+      "name": "field",
+      "aliases": [
+        "field name"
+      ],
+      "mappings": [
+        "mixs:field"
+      ],
+      "description": "Name of the hydrocarbon field (e.g. Albacora)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "reservoir": {
+      "name": "reservoir",
+      "aliases": [
+        "reservoir name"
+      ],
+      "mappings": [
+        "mixs:reservoir"
+      ],
+      "description": "Name of the reservoir (e.g. Carapebus)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "hcr_temp": {
+      "name": "hcr_temp",
+      "aliases": [
+        "hydrocarbon resource original temperature"
+      ],
+      "mappings": [
+        "mixs:hcr_temp"
+      ],
+      "description": "Original temperature of the hydrocarbon resource",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} - {float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\- \\d+[.\\d+] \\S+"
+    },
+    "tvdss_of_hcr_temp": {
+      "name": "tvdss_of_hcr_temp",
+      "aliases": [
+        "depth (TVDSS) of hydrocarbon resource temperature"
+      ],
+      "mappings": [
+        "mixs:tvdss_of_hcr_temp"
+      ],
+      "description": "True vertical depth subsea (TVDSS) of the hydrocarbon resource where the original temperature was measured (e.g. 1345 m)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "hcr_pressure": {
+      "name": "hcr_pressure",
+      "aliases": [
+        "hydrocarbon resource original pressure"
+      ],
+      "mappings": [
+        "mixs:hcr_pressure"
+      ],
+      "description": "Original pressure of the hydrocarbon resource ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} - {float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\- \\d+[.\\d+] \\S+"
+    },
+    "tvdss_of_hcr_pressure": {
+      "name": "tvdss_of_hcr_pressure",
+      "aliases": [
+        "depth (TVDSS) of hydrocarbon resource pressure"
+      ],
+      "mappings": [
+        "mixs:tvdss_of_hcr_pressure"
+      ],
+      "description": "True vertical depth subsea (TVDSS) of the hydrocarbon resource where the original pressure was measured (e.g. 1578 m )",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "permeability": {
+      "name": "permeability",
+      "aliases": [
+        "permeability"
+      ],
+      "mappings": [
+        "mixs:permeability"
+      ],
+      "description": "Measure of the ability of a hydrocarbon resource to allow fluids to pass through it. (Additional information: https://en.wikipedia.org/wiki/Permeability_(earth_sciences))",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{integer} - {integer} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "porosity": {
+      "name": "porosity",
+      "aliases": [
+        "porosity"
+      ],
+      "mappings": [
+        "mixs:porosity"
+      ],
+      "description": "Porosity of deposited sediment is volume of voids divided by the total volume of sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} - {float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\- \\d+[.\\d+] \\S+"
+    },
+    "lithology": {
+      "name": "lithology",
+      "aliases": [
+        "lithology"
+      ],
+      "mappings": [
+        "mixs:lithology"
+      ],
+      "description": "Hydrocarbon resource main lithology (Additional information: http://petrowiki.org/Lithology_and_rock_type_determination). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Basement|Chalk|Chert|Coal|Conglomerate|Diatomite|Dolomite|Limestone|Sandstone|Shale|Siltstone|Volcanic|other]"
+    },
+    "depos_env": {
+      "name": "depos_env",
+      "aliases": [
+        "depositional environment"
+      ],
+      "mappings": [
+        "mixs:depos_env"
+      ],
+      "description": "Main depositional environment (https://en.wikipedia.org/wiki/Depositional_environment). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Continental \\- Alluvial|Continental \\- Aeolian|Continental \\- Fluvial|Continental \\- Lacustrine|Transitional \\- Deltaic|Transitional \\- Tidal|Transitional \\- Lagoonal|Transitional \\- Beach|Transitional \\- Lake|Marine \\- Shallow|Marine \\- Deep|Marine \\- Reef|Other \\- Evaporite|Other \\- Glacial|Other \\- Volcanic|other]"
+    },
+    "hcr_geol_age": {
+      "name": "hcr_geol_age",
+      "aliases": [
+        "hydrocarbon resource geological age"
+      ],
+      "mappings": [
+        "mixs:hcr_geol_age"
+      ],
+      "description": "Geological age of hydrocarbon resource (Additional info: https://en.wikipedia.org/wiki/Period_(geology)). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Archean|Cambrian|Carboniferous|Cenozoic|Cretaceous|Devonian|Jurassic|Mesozoic|Neogene|Ordovician|Paleogene|Paleozoic|Permian|Precambrian|Proterozoic|Silurian|Triassic|other]"
+    },
+    "owc_tvdss": {
+      "name": "owc_tvdss",
+      "aliases": [
+        "oil water contact depth"
+      ],
+      "mappings": [
+        "mixs:owc_tvdss"
+      ],
+      "description": "Depth of the original oil water contact (OWC) zone (average) (m TVDSS)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "hcr_fw_salinity": {
+      "name": "hcr_fw_salinity",
+      "aliases": [
+        "formation water salinity"
+      ],
+      "mappings": [
+        "mixs:hcr_fw_salinity"
+      ],
+      "description": "Original formation water salinity (prior to secondary recovery e.g. Waterflooding) expressed as TDS",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "sulfate_fw": {
+      "name": "sulfate_fw",
+      "aliases": [
+        "sulfate in formation water"
+      ],
+      "mappings": [
+        "mixs:sulfate_fw"
+      ],
+      "description": "Original sulfate concentration in the hydrocarbon resource",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "vfa_fw": {
+      "name": "vfa_fw",
+      "aliases": [
+        "vfa in formation water"
+      ],
+      "mappings": [
+        "mixs:vfa_fw"
+      ],
+      "description": "Original volatile fatty acid concentration in the hydrocarbon resource",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "sr_kerog_type": {
+      "name": "sr_kerog_type",
+      "aliases": [
+        "source rock kerogen type"
+      ],
+      "mappings": [
+        "mixs:sr_kerog_type"
+      ],
+      "description": "Origin of kerogen. Type I: Algal (aquatic), Type II: planktonic and soft plant material (aquatic or terrestrial), Type III: terrestrial woody/ fibrous plant material (terrestrial), Type IV: oxidized recycled woody debris (terrestrial) (additional information: https://en.wikipedia.org/wiki/Kerogen). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Type I|Type II|Type III|Type IV|other]"
+    },
+    "sr_lithology": {
+      "name": "sr_lithology",
+      "aliases": [
+        "source rock lithology"
+      ],
+      "mappings": [
+        "mixs:sr_lithology"
+      ],
+      "description": "Lithology of source rock (https://en.wikipedia.org/wiki/Source_rock). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Clastic|Carbonate|Coal|Biosilicieous|other]"
+    },
+    "sr_dep_env": {
+      "name": "sr_dep_env",
+      "aliases": [
+        "source rock depositional environment"
+      ],
+      "mappings": [
+        "mixs:sr_dep_env"
+      ],
+      "description": "Source rock depositional environment (https://en.wikipedia.org/wiki/Source_rock). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Lacustine|Fluvioldeltaic|Fluviomarine|Marine|other]"
+    },
+    "sr_geol_age": {
+      "name": "sr_geol_age",
+      "aliases": [
+        "source rock geological age"
+      ],
+      "mappings": [
+        "mixs:sr_geol_age"
+      ],
+      "description": "Geological age of source rock (Additional info: https://en.wikipedia.org/wiki/Period_(geology)). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Archean|Cambrian|Carboniferous|Cenozoic|Cretaceous|Devonian|Jurassic|Mesozoic|Neogene|Ordovician|Paleogene|Paleozoic|Permian|Precambrian|Proterozoic|Silurian|Triassic|other]"
+    },
+    "samp_well_name": {
+      "name": "samp_well_name",
+      "aliases": [
+        "sample well name"
+      ],
+      "mappings": [
+        "mixs:samp_well_name"
+      ],
+      "description": "Name of the well (e.g. BXA1123) where sample was taken",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "win": {
+      "name": "win",
+      "aliases": [
+        "well identification number"
+      ],
+      "mappings": [
+        "mixs:win"
+      ],
+      "description": "A unique identifier of a well or wellbore. This is part of the Global Framework for Well Identification initiative which is compiled by the Professional Petroleum Data Management Association (PPDM) in an effort to improve well identification systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "samp_type": {
+      "name": "samp_type",
+      "aliases": [
+        "sample type"
+      ],
+      "mappings": [
+        "mixs:samp_type"
+      ],
+      "description": "Type of material (i.e. sample) collected. Includes types like core, rock trimmings, drill cuttings, piping section, coupon, pigging debris, solid deposit, produced fluid, produced water, injected water, swabs, etc. If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[core|rock trimmings|drill cuttings|piping section|coupon|pigging debris|solid deposit|produced fluid|produced water|injected water|water from treatment plant|fresh water|sea water|drilling fluid|procedural blank|positive control|negative control|other]"
+    },
+    "samp_subtype": {
+      "name": "samp_subtype",
+      "aliases": [
+        "sample subtype"
+      ],
+      "mappings": [
+        "mixs:samp_subtype"
+      ],
+      "description": "Name of sample sub-type. For example if 'sample type' is 'Produced Water' then subtype could be 'Oil Phase' or 'Water Phase'. If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[oil phase|water phase|biofilm|not applicable|other]"
+    },
+    "pressure": {
+      "name": "pressure",
+      "aliases": [
+        "pressure"
+      ],
+      "mappings": [
+        "mixs:pressure"
+      ],
+      "description": "Pressure to which the sample is subject to, in atmospheres",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "samp_tvdss": {
+      "name": "samp_tvdss",
+      "aliases": [
+        "sample true vertical depth subsea"
+      ],
+      "mappings": [
+        "mixs:samp_tvdss"
+      ],
+      "description": "Depth of the sample i.e. The vertical distance between the sea level and the sampled position in the subsurface. Depth can be reported as an interval for subsurface samples e.g. 1325.75-1362.25 m",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float}-{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]\\-\\d+[.\\d+] \\S+"
+    },
+    "samp_md": {
+      "name": "samp_md",
+      "aliases": [
+        "sample measured depth"
+      ],
+      "mappings": [
+        "mixs:samp_md"
+      ],
+      "description": "In non deviated well, measured depth is equal to the true vertical depth, TVD (TVD=TVDSS plus the reference or datum it refers to). In deviated wells, the MD is the length of trajectory of the borehole measured from the same reference or datum. Common datums used are ground level (GL), drilling rig floor (DF), rotary table (RT), kelly bushing (KB) and mean sea level (MSL). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};[GL|DF|RT|KB|MSL|other]",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+;[GL|DF|RT|KB|MSL|other]"
+    },
+    "samp_transport_cond": {
+      "name": "samp_transport_cond",
+      "aliases": [
+        "sample transport conditions"
+      ],
+      "mappings": [
+        "mixs:samp_transport_cond"
+      ],
+      "description": "Sample transport duration (in days or hrs) and temperature the sample was exposed to (e.g. 5.5 days; 20 B0C)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+;\\d+[.\\d+] \\S+"
+    },
+    "organism_count_qpcr_info": {
+      "name": "organism_count_qpcr_info",
+      "aliases": [
+        "organism count qPCR information"
+      ],
+      "mappings": [
+        "mixs:organism_count_qpcr_info"
+      ],
+      "description": "If qpcr was used for the cell count, the target gene name, the primer sequence and the cycling conditions should also be provided. (Example: 16S rrna; FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min; denaturation:90C_2min; annealing:52C_30 sec; elongation:72C_30 sec; 90 C for 1 min; final elongation:72C_5min; 30 cycles)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ph": {
+      "name": "ph",
+      "aliases": [
+        "pH"
+      ],
+      "mappings": [
+        "mixs:ph"
+      ],
+      "description": "Ph measurement of the sample, or liquid portion of sample, or aqueous phase of the fluid",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "alkalinity": {
+      "name": "alkalinity",
+      "aliases": [
+        "alkalinity"
+      ],
+      "mappings": [
+        "mixs:alkalinity"
+      ],
+      "description": "Alkalinity, the ability of a solution to neutralize acids to the equivalence point of carbonate or bicarbonate",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "alkalinity_method": {
+      "name": "alkalinity_method",
+      "aliases": [
+        "alkalinity method"
+      ],
+      "mappings": [
+        "mixs:alkalinity_method"
+      ],
+      "description": "Method used for alkalinity measurement",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "sulfate": {
+      "name": "sulfate",
+      "aliases": [
+        "sulfate"
+      ],
+      "mappings": [
+        "mixs:sulfate"
+      ],
+      "description": "Concentration of sulfate in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "sulfide": {
+      "name": "sulfide",
+      "aliases": [
+        "sulfide"
+      ],
+      "mappings": [
+        "mixs:sulfide"
+      ],
+      "description": "Concentration of sulfide in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_sulfur": {
+      "name": "tot_sulfur",
+      "aliases": [
+        "total sulfur"
+      ],
+      "mappings": [
+        "mixs:tot_sulfur"
+      ],
+      "description": "Concentration of total sulfur in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "nitrate": {
+      "name": "nitrate",
+      "aliases": [
+        "nitrate"
+      ],
+      "mappings": [
+        "mixs:nitrate"
+      ],
+      "description": "Concentration of nitrate in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "nitrite": {
+      "name": "nitrite",
+      "aliases": [
+        "nitrite"
+      ],
+      "mappings": [
+        "mixs:nitrite"
+      ],
+      "description": "Concentration of nitrite in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "ammonium": {
+      "name": "ammonium",
+      "aliases": [
+        "ammonium"
+      ],
+      "mappings": [
+        "mixs:ammonium"
+      ],
+      "description": "Concentration of ammonium in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_nitro": {
+      "name": "tot_nitro",
+      "aliases": [
+        "total nitrogen concentration"
+      ],
+      "mappings": [
+        "mixs:tot_nitro"
+      ],
+      "description": "Total nitrogen concentration of water samples, calculated by: total nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured without filtering, reported as nitrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_iron": {
+      "name": "diss_iron",
+      "aliases": [
+        "dissolved iron"
+      ],
+      "mappings": [
+        "mixs:diss_iron"
+      ],
+      "description": "Concentration of dissolved iron in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "sodium": {
+      "name": "sodium",
+      "aliases": [
+        "sodium"
+      ],
+      "mappings": [
+        "mixs:sodium"
+      ],
+      "description": "Sodium concentration in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "chloride": {
+      "name": "chloride",
+      "aliases": [
+        "chloride"
+      ],
+      "mappings": [
+        "mixs:chloride"
+      ],
+      "description": "Concentration of chloride in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "potassium": {
+      "name": "potassium",
+      "aliases": [
+        "potassium"
+      ],
+      "mappings": [
+        "mixs:potassium"
+      ],
+      "description": "Concentration of potassium in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "magnesium": {
+      "name": "magnesium",
+      "aliases": [
+        "magnesium"
+      ],
+      "mappings": [
+        "mixs:magnesium"
+      ],
+      "description": "Concentration of magnesium in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "calcium": {
+      "name": "calcium",
+      "aliases": [
+        "calcium"
+      ],
+      "mappings": [
+        "mixs:calcium"
+      ],
+      "description": "Concentration of calcium in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_iron": {
+      "name": "tot_iron",
+      "aliases": [
+        "total iron"
+      ],
+      "mappings": [
+        "mixs:tot_iron"
+      ],
+      "description": "Concentration of total iron in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_org_carb": {
+      "name": "diss_org_carb",
+      "aliases": [
+        "dissolved organic carbon"
+      ],
+      "mappings": [
+        "mixs:diss_org_carb"
+      ],
+      "description": "Concentration of dissolved organic carbon in the sample, liquid portion of the sample, or aqueous phase of the fluid",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_inorg_carb": {
+      "name": "diss_inorg_carb",
+      "aliases": [
+        "dissolved inorganic carbon"
+      ],
+      "mappings": [
+        "mixs:diss_inorg_carb"
+      ],
+      "description": "Dissolved inorganic carbon concentration in the sample, typically measured after filtering the sample using a 0.45 micrometer filter",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_inorg_phosp": {
+      "name": "diss_inorg_phosp",
+      "aliases": [
+        "dissolved inorganic phosphorus"
+      ],
+      "mappings": [
+        "mixs:diss_inorg_phosp"
+      ],
+      "description": "Concentration of dissolved inorganic phosphorus in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_phosp": {
+      "name": "tot_phosp",
+      "aliases": [
+        "total phosphorus"
+      ],
+      "mappings": [
+        "mixs:tot_phosp"
+      ],
+      "description": "Total phosphorus concentration in the sample, calculated by: total phosphorus = total dissolved phosphorus + particulate phosphorus",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "suspend_solids": {
+      "name": "suspend_solids",
+      "aliases": [
+        "suspended solids"
+      ],
+      "mappings": [
+        "mixs:suspend_solids"
+      ],
+      "description": "Concentration of substances including a wide variety of material, such as silt, decaying plant and animal matter; can include multiple substances",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "density": {
+      "name": "density",
+      "aliases": [
+        "density"
+      ],
+      "mappings": [
+        "mixs:density"
+      ],
+      "description": "Density of the sample, which is its mass per unit volume (aka volumetric mass density)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_carb_dioxide": {
+      "name": "diss_carb_dioxide",
+      "aliases": [
+        "dissolved carbon dioxide"
+      ],
+      "mappings": [
+        "mixs:diss_carb_dioxide"
+      ],
+      "description": "Concentration of dissolved carbon dioxide in the sample or liquid portion of the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_oxygen_fluid": {
+      "name": "diss_oxygen_fluid",
+      "aliases": [
+        "dissolved oxygen in fluids"
+      ],
+      "mappings": [
+        "mixs:diss_oxygen_fluid"
+      ],
+      "description": "Concentration of dissolved oxygen in the oil field produced fluids as it contributes to oxgen-corrosion and microbial activity (e.g. Mic).",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "vfa": {
+      "name": "vfa",
+      "aliases": [
+        "volatile fatty acids"
+      ],
+      "mappings": [
+        "mixs:vfa"
+      ],
+      "description": "Concentration of Volatile Fatty Acids in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "benzene": {
+      "name": "benzene",
+      "aliases": [
+        "benzene"
+      ],
+      "mappings": [
+        "mixs:benzene"
+      ],
+      "description": "Concentration of benzene in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "toluene": {
+      "name": "toluene",
+      "aliases": [
+        "toluene"
+      ],
+      "mappings": [
+        "mixs:toluene"
+      ],
+      "description": "Concentration of toluene in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "ethylbenzene": {
+      "name": "ethylbenzene",
+      "aliases": [
+        "ethylbenzene"
+      ],
+      "mappings": [
+        "mixs:ethylbenzene"
+      ],
+      "description": "Concentration of ethylbenzene in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "xylene": {
+      "name": "xylene",
+      "aliases": [
+        "xylene"
+      ],
+      "mappings": [
+        "mixs:xylene"
+      ],
+      "description": "Concentration of xylene in the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "api": {
+      "name": "api",
+      "aliases": [
+        "API gravity"
+      ],
+      "mappings": [
+        "mixs:api"
+      ],
+      "description": "API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g. 31.1B0 API) ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tan": {
+      "name": "tan",
+      "aliases": [
+        "total acid number"
+      ],
+      "mappings": [
+        "mixs:tan"
+      ],
+      "description": "Total Acid NumberB (TAN) is a measurement of acidity that is determined by the amount ofB potassium hydroxideB in milligrams that is needed to neutralize the acids in one gram of oil.B It is an important quality measurement ofB crude oil. (source: https://en.wikipedia.org/wiki/Total_acid_number)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "viscosity": {
+      "name": "viscosity",
+      "aliases": [
+        "viscosity"
+      ],
+      "mappings": [
+        "mixs:viscosity"
+      ],
+      "description": "A measure of oil's resistanceB to gradual deformation byB shear stressB orB tensile stress (e.g. 3.5 cp;  100 B0C)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+;\\d+[.\\d+] \\S+"
+    },
+    "pour_point": {
+      "name": "pour_point",
+      "aliases": [
+        "pour point"
+      ],
+      "mappings": [
+        "mixs:pour_point"
+      ],
+      "description": "Temperature at which a liquid becomes semi solid and loses its flow characteristics. In crude oil a highB pour pointB is generally associated with a high paraffin content, typically found in crude deriving from a larger proportion of plant material.  (soure: https://en.wikipedia.org/wiki/pour_point)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "saturates_pc": {
+      "name": "saturates_pc",
+      "aliases": [
+        "saturates wt%"
+      ],
+      "mappings": [
+        "mixs:saturates_pc"
+      ],
+      "description": "Saturate, Aromatic, Resin and AsphalteneB (SARA) is an analysis method that dividesB crude oilB components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "aromatics_pc": {
+      "name": "aromatics_pc",
+      "aliases": [
+        "aromatics wt%"
+      ],
+      "mappings": [
+        "mixs:aromatics_pc"
+      ],
+      "description": "Saturate, Aromatic, Resin and AsphalteneB (SARA) is an analysis method that dividesB crude oilB components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "resins_pc": {
+      "name": "resins_pc",
+      "aliases": [
+        "resins wt%"
+      ],
+      "mappings": [
+        "mixs:resins_pc"
+      ],
+      "description": "Saturate, Aromatic, Resin and AsphalteneB (SARA) is an analysis method that dividesB crude oilB components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "asphaltenes_pc": {
+      "name": "asphaltenes_pc",
+      "aliases": [
+        "asphaltenes wt%"
+      ],
+      "mappings": [
+        "mixs:asphaltenes_pc"
+      ],
+      "description": "Saturate, Aromatic, Resin and AsphalteneB (SARA) is an analysis method that dividesB crude oilB components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "additional_info": {
+      "name": "additional_info",
+      "aliases": [
+        "additional info"
+      ],
+      "mappings": [
+        "mixs:additional_info"
+      ],
+      "description": "Information that doesn't fit anywhere else. Can also be used to propose new entries for fields with controlled vocabulary",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "prod_start_date": {
+      "name": "prod_start_date",
+      "aliases": [
+        "production start date"
+      ],
+      "mappings": [
+        "mixs:prod_start_date"
+      ],
+      "description": "Date of field's first production",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "prod_rate": {
+      "name": "prod_rate",
+      "aliases": [
+        "production rate"
+      ],
+      "mappings": [
+        "mixs:prod_rate"
+      ],
+      "description": "Oil and/or gas production rates per well (e.g. 524 m3 / day)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "water_production_rate": {
+      "name": "water_production_rate",
+      "aliases": [
+        "water production rate"
+      ],
+      "mappings": [
+        "mixs:water_production_rate"
+      ],
+      "description": "Water production rates per well (e.g. 987 m3 / day)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "water_cut": {
+      "name": "water_cut",
+      "aliases": [
+        "water cut"
+      ],
+      "mappings": [
+        "mixs:water_cut"
+      ],
+      "description": "Current amount of water (%) in a produced fluid stream; or the average of the combined streams",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "iwf": {
+      "name": "iwf",
+      "aliases": [
+        "injection water fraction"
+      ],
+      "mappings": [
+        "mixs:iwf"
+      ],
+      "description": "Proportion of the produced fluids derived from injected water at the time of sampling. (e.g. 87%)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "add_recov_method": {
+      "name": "add_recov_method",
+      "aliases": [
+        "secondary and tertiary recovery methods and start date"
+      ],
+      "mappings": [
+        "mixs:add_recov_method"
+      ],
+      "description": "Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed for increase of hydrocarbon recovery from resource and start date for each one of them. If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "iw_bt_date_well": {
+      "name": "iw_bt_date_well",
+      "aliases": [
+        "injection water breakthrough date of specific well"
+      ],
+      "mappings": [
+        "mixs:iw_bt_date_well"
+      ],
+      "description": "Injection water breakthrough date per well following a  secondary and/or tertiary recovery",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "biocide": {
+      "name": "biocide",
+      "aliases": [
+        "biocide administration"
+      ],
+      "mappings": [
+        "mixs:biocide"
+      ],
+      "description": "List of biocides (commercial name of product and supplier) and date of administration",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "biocide_admin_method": {
+      "name": "biocide_admin_method",
+      "aliases": [
+        "biocide administration method"
+      ],
+      "mappings": [
+        "mixs:biocide_admin_method"
+      ],
+      "description": "Method of biocide administration (dose, frequency, duration, time elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr; 3 days)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration};{duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "chem_treatment": {
+      "name": "chem_treatment",
+      "aliases": [
+        "chemical treatment"
+      ],
+      "mappings": [
+        "mixs:chem_treatment"
+      ],
+      "description": "List of chemical compounds administered upstream the sampling location where sampling occurred (e.g. Glycols, H2S scavenger, corrosion and scale inhibitors, demulsifiers, and other production chemicals etc.). The commercial name of the product and name of the supplier should be provided.  The date of administration should also be included",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "chem_treatment_method": {
+      "name": "chem_treatment_method",
+      "aliases": [
+        "chemical treatment method"
+      ],
+      "mappings": [
+        "mixs:chem_treatment_method"
+      ],
+      "description": "Method of chemical administration(dose, frequency, duration, time elapsed between administration and sampling) (e.g. 50 mg/l; twice a week; 1 hr; 0 days)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration};{duration};{duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "samp_loc_corr_rate": {
+      "name": "samp_loc_corr_rate",
+      "aliases": [
+        "corrosion rate at sample location"
+      ],
+      "mappings": [
+        "mixs:samp_loc_corr_rate"
+      ],
+      "description": "Metal corrosion rate is the speed of metal deterioration due to environmental conditions. As environmental conditions change corrosion rates change accordingly. Therefore, long term corrosion rates are generally more informative than short term rates and for that reason they are preferred during reporting. In the case of suspected MIC, corrosion rate measurements at the time of sampling might provide insights into the involvement of certain microbial community members in MIC as well as potential microbial interplays",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} - {float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\- \\d+[.\\d+] \\S+"
+    },
+    "samp_collection_point": {
+      "name": "samp_collection_point",
+      "aliases": [
+        "sample collection point"
+      ],
+      "mappings": [
+        "mixs:samp_collection_point"
+      ],
+      "description": "Sampling  point on the asset were sample was collected (e.g. Wellhead, storage tank, separator, etc). If 'other' is specified, please propose entry in 'additional info' field",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[well|test well|drilling rig|wellhead|separator|storage tank|other]"
+    },
+    "samp_preserv": {
+      "name": "samp_preserv",
+      "aliases": [
+        "preservative added to sample"
+      ],
+      "mappings": [
+        "mixs:samp_preserv"
+      ],
+      "description": "Preservative added to the sample (e.g. Rnalater, alcohol, formaldehyde, etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "alkyl_diethers": {
+      "name": "alkyl_diethers",
+      "aliases": [
+        "alkyl diethers"
+      ],
+      "mappings": [
+        "mixs:alkyl_diethers"
+      ],
+      "description": "Concentration of alkyl diethers ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "aminopept_act": {
+      "name": "aminopept_act",
+      "aliases": [
+        "aminopeptidase activity"
+      ],
+      "mappings": [
+        "mixs:aminopept_act"
+      ],
+      "description": "Measurement of aminopeptidase activity",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "bacteria_carb_prod": {
+      "name": "bacteria_carb_prod",
+      "aliases": [
+        "bacterial carbon production"
+      ],
+      "mappings": [
+        "mixs:bacteria_carb_prod"
+      ],
+      "description": "Measurement of bacterial carbon production",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "biomass": {
+      "name": "biomass",
+      "aliases": [
+        "biomass"
+      ],
+      "mappings": [
+        "mixs:biomass"
+      ],
+      "description": "Amount of biomass; should include the name for the part of biomass measured, e.g. Microbial, total. Can include multiple measurements",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "bishomohopanol": {
+      "name": "bishomohopanol",
+      "aliases": [
+        "bishomohopanol"
+      ],
+      "mappings": [
+        "mixs:bishomohopanol"
+      ],
+      "description": "Concentration of bishomohopanol ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "bromide": {
+      "name": "bromide",
+      "aliases": [
+        "bromide"
+      ],
+      "mappings": [
+        "mixs:bromide"
+      ],
+      "description": "Concentration of bromide ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "carb_nitro_ratio": {
+      "name": "carb_nitro_ratio",
+      "aliases": [
+        "carbon/nitrogen ratio"
+      ],
+      "mappings": [
+        "mixs:carb_nitro_ratio"
+      ],
+      "description": "Ratio of amount or concentrations of carbon to nitrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "chlorophyll": {
+      "name": "chlorophyll",
+      "aliases": [
+        "chlorophyll"
+      ],
+      "mappings": [
+        "mixs:chlorophyll"
+      ],
+      "description": "Concentration of chlorophyll",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diether_lipids": {
+      "name": "diether_lipids",
+      "aliases": [
+        "diether lipids"
+      ],
+      "mappings": [
+        "mixs:diether_lipids"
+      ],
+      "description": "Concentration of diether lipids; can include multiple types of diether lipids",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "diss_hydrogen": {
+      "name": "diss_hydrogen",
+      "aliases": [
+        "dissolved hydrogen"
+      ],
+      "mappings": [
+        "mixs:diss_hydrogen"
+      ],
+      "description": "Concentration of dissolved hydrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_org_nitro": {
+      "name": "diss_org_nitro",
+      "aliases": [
+        "dissolved organic nitrogen"
+      ],
+      "mappings": [
+        "mixs:diss_org_nitro"
+      ],
+      "description": "Dissolved organic nitrogen concentration measured as; total dissolved nitrogen - NH4 - NO3 - NO2",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_oxygen": {
+      "name": "diss_oxygen",
+      "aliases": [
+        "dissolved oxygen"
+      ],
+      "mappings": [
+        "mixs:diss_oxygen"
+      ],
+      "description": "Concentration of dissolved oxygen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "glucosidase_act": {
+      "name": "glucosidase_act",
+      "aliases": [
+        "glucosidase activity"
+      ],
+      "mappings": [
+        "mixs:glucosidase_act"
+      ],
+      "description": "Measurement of glucosidase activity",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "mean_frict_vel": {
+      "name": "mean_frict_vel",
+      "aliases": [
+        "mean friction velocity"
+      ],
+      "mappings": [
+        "mixs:mean_frict_vel"
+      ],
+      "description": "Measurement of mean friction velocity",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "mean_peak_frict_vel": {
+      "name": "mean_peak_frict_vel",
+      "aliases": [
+        "mean peak friction velocity"
+      ],
+      "mappings": [
+        "mixs:mean_peak_frict_vel"
+      ],
+      "description": "Measurement of mean peak friction velocity",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "n_alkanes": {
+      "name": "n_alkanes",
+      "aliases": [
+        "n-alkanes"
+      ],
+      "mappings": [
+        "mixs:n_alkanes"
+      ],
+      "description": "Concentration of n-alkanes; can include multiple n-alkanes",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "nitro": {
+      "name": "nitro",
+      "aliases": [
+        "nitrogen"
+      ],
+      "mappings": [
+        "mixs:nitro"
+      ],
+      "description": "Concentration of nitrogen (total)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "org_carb": {
+      "name": "org_carb",
+      "aliases": [
+        "organic carbon"
+      ],
+      "mappings": [
+        "mixs:org_carb"
+      ],
+      "description": "Concentration of organic carbon",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "org_matter": {
+      "name": "org_matter",
+      "aliases": [
+        "organic matter"
+      ],
+      "mappings": [
+        "mixs:org_matter"
+      ],
+      "description": "Concentration of organic matter ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "org_nitro": {
+      "name": "org_nitro",
+      "aliases": [
+        "organic nitrogen"
+      ],
+      "mappings": [
+        "mixs:org_nitro"
+      ],
+      "description": "Concentration of organic nitrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "part_org_carb": {
+      "name": "part_org_carb",
+      "aliases": [
+        "particulate organic carbon"
+      ],
+      "mappings": [
+        "mixs:part_org_carb"
+      ],
+      "description": "Concentration of particulate organic carbon",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "petroleum_hydrocarb": {
+      "name": "petroleum_hydrocarb",
+      "aliases": [
+        "petroleum hydrocarbon"
+      ],
+      "mappings": [
+        "mixs:petroleum_hydrocarb"
+      ],
+      "description": "Concentration of petroleum hydrocarbon",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "phaeopigments": {
+      "name": "phaeopigments",
+      "aliases": [
+        "phaeopigments"
+      ],
+      "mappings": [
+        "mixs:phaeopigments"
+      ],
+      "description": "Concentration of phaeopigments; can include multiple phaeopigments",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "phosphate": {
+      "name": "phosphate",
+      "aliases": [
+        "phosphate"
+      ],
+      "mappings": [
+        "mixs:phosphate"
+      ],
+      "description": "Concentration of phosphate",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "phosplipid_fatt_acid": {
+      "name": "phosplipid_fatt_acid",
+      "aliases": [
+        "phospholipid fatty acid"
+      ],
+      "mappings": [
+        "mixs:phosplipid_fatt_acid"
+      ],
+      "description": "Concentration of phospholipid fatty acids; can include multiple values",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "redox_potential": {
+      "name": "redox_potential",
+      "aliases": [
+        "redox potential"
+      ],
+      "mappings": [
+        "mixs:redox_potential"
+      ],
+      "description": "Redox potential, measured relative to a hydrogen cell, indicating oxidation or reduction potential",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "salinity": {
+      "name": "salinity",
+      "aliases": [
+        "salinity"
+      ],
+      "mappings": [
+        "mixs:salinity"
+      ],
+      "description": "Salinity is the total concentration of all dissolved salts in a water sample. While salinity can be measured by a complete chemical analysis, this method is difficult and time consuming. More often, it is instead derived from the conductivity measurement. This is known as practical salinity. These derivations compare the specific conductance of the sample to a salinity standard such as seawater",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "silicate": {
+      "name": "silicate",
+      "aliases": [
+        "silicate"
+      ],
+      "mappings": [
+        "mixs:silicate"
+      ],
+      "description": "Concentration of silicate",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_carb": {
+      "name": "tot_carb",
+      "aliases": [
+        "total carbon"
+      ],
+      "mappings": [
+        "mixs:tot_carb"
+      ],
+      "description": "Total carbon content",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_nitro_content": {
+      "name": "tot_nitro_content",
+      "aliases": [
+        "total nitrogen content"
+      ],
+      "mappings": [
+        "mixs:tot_nitro_content"
+      ],
+      "description": "Total nitrogen content of the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_org_carb": {
+      "name": "tot_org_carb",
+      "aliases": [
+        "total organic carbon"
+      ],
+      "mappings": [
+        "mixs:tot_org_carb"
+      ],
+      "description": "Definition for soil: total organic carbon content of the soil, definition otherwise: total organic carbon content",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "turbidity": {
+      "name": "turbidity",
+      "aliases": [
+        "turbidity"
+      ],
+      "mappings": [
+        "mixs:turbidity"
+      ],
+      "description": "Measure of the amount of cloudiness or haziness in water caused by individual particles",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "water_content": {
+      "name": "water_content",
+      "aliases": [
+        "water content"
+      ],
+      "mappings": [
+        "mixs:water_content"
+      ],
+      "description": "Water content measurement",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "water_current": {
+      "name": "water_current",
+      "aliases": [
+        "water current"
+      ],
+      "mappings": [
+        "mixs:water_current"
+      ],
+      "description": "Measurement of magnitude and direction of flow within a fluid",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "air_temp_regm": {
+      "name": "air_temp_regm",
+      "aliases": [
+        "air temperature regimen"
+      ],
+      "mappings": [
+        "mixs:air_temp_regm"
+      ],
+      "description": "Information about treatment involving an exposure to varying temperatures; should include the temperature, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include different temperature regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "antibiotic_regm": {
+      "name": "antibiotic_regm",
+      "aliases": [
+        "antibiotic regimen"
+      ],
+      "mappings": [
+        "mixs:antibiotic_regm"
+      ],
+      "description": "Information about treatment involving antibiotic administration; should include the name of antibiotic, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple antibiotic regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "biotic_regm": {
+      "name": "biotic_regm",
+      "aliases": [
+        "biotic regimen"
+      ],
+      "mappings": [
+        "mixs:biotic_regm"
+      ],
+      "description": "Information about treatment(s) involving use of biotic factors, such as bacteria, viruses or fungi.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "chem_mutagen": {
+      "name": "chem_mutagen",
+      "aliases": [
+        "chemical mutagen"
+      ],
+      "mappings": [
+        "mixs:chem_mutagen"
+      ],
+      "description": "Treatment involving use of mutagens; should include the name of mutagen, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple mutagen regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "climate_environment": {
+      "name": "climate_environment",
+      "aliases": [
+        "climate environment"
+      ],
+      "mappings": [
+        "mixs:climate_environment"
+      ],
+      "description": "Treatment involving an exposure to a particular climate; treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple climates",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "cult_root_med": {
+      "name": "cult_root_med",
+      "aliases": [
+        "culture rooting medium"
+      ],
+      "mappings": [
+        "mixs:cult_root_med"
+      ],
+      "description": "Name or reference for the hydroponic or in vitro culture rooting medium; can be the name of a commonly used medium or reference to a specific medium, e.g. Murashige and Skoog medium. If the medium has not been formally published, use the rooting medium descriptors.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "fertilizer_regm": {
+      "name": "fertilizer_regm",
+      "aliases": [
+        "fertilizer regimen"
+      ],
+      "mappings": [
+        "mixs:fertilizer_regm"
+      ],
+      "description": "Information about treatment involving the use of fertilizers; should include the name of fertilizer, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple fertilizer regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "fungicide_regm": {
+      "name": "fungicide_regm",
+      "aliases": [
+        "fungicide regimen"
+      ],
+      "mappings": [
+        "mixs:fungicide_regm"
+      ],
+      "description": "Information about treatment involving use of fungicides; should include the name of fungicide, amount administered,  treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple fungicide regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "gaseous_environment": {
+      "name": "gaseous_environment",
+      "aliases": [
+        "gaseous environment"
+      ],
+      "mappings": [
+        "mixs:gaseous_environment"
+      ],
+      "description": "Use of conditions with differing gaseous environments; should include the name of gaseous compound, amount administered, treatment duration, interval and total experimental duration; can include multiple gaseous environment regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "gravity": {
+      "name": "gravity",
+      "aliases": [
+        "gravity"
+      ],
+      "mappings": [
+        "mixs:gravity"
+      ],
+      "description": "Information about treatment involving use of gravity factor to study various types of responses in presence, absence or modified levels of gravity; treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple treatments",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "growth_facil": {
+      "name": "growth_facil",
+      "aliases": [
+        "growth facility"
+      ],
+      "mappings": [
+        "mixs:growth_facil"
+      ],
+      "description": "Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value"
+    },
+    "growth_habit": {
+      "name": "growth_habit",
+      "aliases": [
+        "growth habit"
+      ],
+      "mappings": [
+        "mixs:growth_habit"
+      ],
+      "description": "Characteristic shape, appearance or growth form of a plant species",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[erect|semi\\-erect|spreading|prostrate] "
+    },
+    "growth_hormone_regm": {
+      "name": "growth_hormone_regm",
+      "aliases": [
+        "growth hormone regimen"
+      ],
+      "mappings": [
+        "mixs:growth_hormone_regm"
+      ],
+      "description": "Information about treatment involving use of growth hormones; should include the name of growth hormone, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple growth hormone regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "herbicide_regm": {
+      "name": "herbicide_regm",
+      "aliases": [
+        "herbicide regimen"
+      ],
+      "mappings": [
+        "mixs:herbicide_regm"
+      ],
+      "description": "Information about treatment involving use of herbicides; information about treatment involving use of growth hormones; should include the name of herbicide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "host_wet_mass": {
+      "name": "host_wet_mass",
+      "aliases": [
+        "host wet mass"
+      ],
+      "mappings": [
+        "mixs:host_wet_mass"
+      ],
+      "description": "Measurement of wet mass",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "humidity_regm": {
+      "name": "humidity_regm",
+      "aliases": [
+        "humidity regimen"
+      ],
+      "mappings": [
+        "mixs:humidity_regm"
+      ],
+      "description": "Information about treatment involving an exposure to varying degree of humidity; information about treatment involving use of growth hormones; should include amount of humidity administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "light_regm": {
+      "name": "light_regm",
+      "aliases": [
+        "light regimen"
+      ],
+      "mappings": [
+        "mixs:light_regm"
+      ],
+      "description": "Information about treatment(s) involving exposure to light, including both light intensity and quality.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "mechanical_damage": {
+      "name": "mechanical_damage",
+      "aliases": [
+        "mechanical damage"
+      ],
+      "mappings": [
+        "mixs:mechanical_damage"
+      ],
+      "description": "Information about any mechanical damage exerted on the plant; can include multiple damages and sites",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "mineral_nutr_regm": {
+      "name": "mineral_nutr_regm",
+      "aliases": [
+        "mineral nutrient regimen"
+      ],
+      "mappings": [
+        "mixs:mineral_nutr_regm"
+      ],
+      "description": "Information about treatment involving the use of mineral supplements; should include the name of mineral nutrient, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple mineral nutrient regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "non_mineral_nutr_regm": {
+      "name": "non_mineral_nutr_regm",
+      "aliases": [
+        "non-mineral nutrient regimen"
+      ],
+      "mappings": [
+        "mixs:non_mineral_nutr_regm"
+      ],
+      "description": "Information about treatment involving the exposure of plant to non-mineral nutrient such as oxygen, hydrogen or carbon; should include the name of non-mineral nutrient, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple non-mineral nutrient regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "ph_regm": {
+      "name": "ph_regm",
+      "aliases": [
+        "pH regimen"
+      ],
+      "mappings": [
+        "mixs:ph_regm"
+      ],
+      "description": "Information about treatment involving exposure of plants to varying levels of ph of the growth media, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pesticide_regm": {
+      "name": "pesticide_regm",
+      "aliases": [
+        "pesticide regimen"
+      ],
+      "mappings": [
+        "mixs:pesticide_regm"
+      ],
+      "description": "Information about treatment involving use of insecticides; should include the name of pesticide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple pesticide regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "plant_growth_med": {
+      "name": "plant_growth_med",
+      "aliases": [
+        "plant growth medium"
+      ],
+      "mappings": [
+        "mixs:plant_growth_med"
+      ],
+      "description": "Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from EO:plant growth medium (follow this link for terms http://purl.obolibrary.org/obo/EO_0007147) or other controlled vocabulary",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "plant_product": {
+      "name": "plant_product",
+      "aliases": [
+        "plant product"
+      ],
+      "mappings": [
+        "mixs:plant_product"
+      ],
+      "description": "Substance produced by the plant, where the sample was obtained from",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "plant_sex": {
+      "name": "plant_sex",
+      "aliases": [
+        "plant sex"
+      ],
+      "mappings": [
+        "mixs:plant_sex"
+      ],
+      "description": "Sex of the reproductive parts on the whole plant, e.g. pistillate, staminate, monoecieous, hermaphrodite.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Androdioecious|Androecious|Androgynous|Androgynomonoecious|Andromonoecious|Bisexual|Dichogamous|Diclinous|Dioecious|Gynodioecious|Gynoecious|Gynomonoecious|Hermaphroditic|Imperfect|Monoclinous|Monoecious|Perfect|Polygamodioecious|Polygamomonoecious|Polygamous|Protandrous|Protogynous|Subandroecious|Subdioecious|Subgynoecious|Synoecious|Trimonoecious|Trioecious|Unisexual]"
+    },
+    "plant_struc": {
+      "name": "plant_struc",
+      "aliases": [
+        "plant structure"
+      ],
+      "mappings": [
+        "mixs:plant_struc"
+      ],
+      "description": "Name of plant structure the sample was obtained from; for Plant Ontology (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO, e.g. petiole epidermis (PO_0000051). If an individual flower is sampled, the sex of it can be recorded here.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "controlled term value",
+      "pattern": ".* \\S+:\\S+"
+    },
+    "radiation_regm": {
+      "name": "radiation_regm",
+      "aliases": [
+        "radiation regimen"
+      ],
+      "mappings": [
+        "mixs:radiation_regm"
+      ],
+      "description": "Information about treatment involving exposure of plant or a plant part to a particular radiation regimen; should include the radiation type, amount or intensity administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple radiation regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "rainfall_regm": {
+      "name": "rainfall_regm",
+      "aliases": [
+        "rainfall regimen"
+      ],
+      "mappings": [
+        "mixs:rainfall_regm"
+      ],
+      "description": "Information about treatment involving an exposure to a given amount of rainfall, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "root_cond": {
+      "name": "root_cond",
+      "aliases": [
+        "rooting conditions"
+      ],
+      "mappings": [
+        "mixs:root_cond"
+      ],
+      "description": "Relevant rooting conditions such as field plot size, sowing density, container dimensions, number of plants per container.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "root_med_carbon": {
+      "name": "root_med_carbon",
+      "aliases": [
+        "rooting medium carbon"
+      ],
+      "mappings": [
+        "mixs:root_med_carbon"
+      ],
+      "description": "Source of organic carbon in the culture rooting medium; e.g. sucrose.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "root_med_macronutr": {
+      "name": "root_med_macronutr",
+      "aliases": [
+        "rooting medium macronutrients"
+      ],
+      "mappings": [
+        "mixs:root_med_macronutr"
+      ],
+      "description": "Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S); e.g. KH2PO4 (170B mg/L).",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "root_med_micronutr": {
+      "name": "root_med_micronutr",
+      "aliases": [
+        "rooting medium micronutrients"
+      ],
+      "mappings": [
+        "mixs:root_med_micronutr"
+      ],
+      "description": "Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo); e.g. H3BO3 (6.2B mg/L).",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "root_med_suppl": {
+      "name": "root_med_suppl",
+      "aliases": [
+        "rooting medium organic supplements"
+      ],
+      "mappings": [
+        "mixs:root_med_suppl"
+      ],
+      "description": "Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid (0.5B mg/L).",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "root_med_ph": {
+      "name": "root_med_ph",
+      "aliases": [
+        "rooting medium pH"
+      ],
+      "mappings": [
+        "mixs:root_med_ph"
+      ],
+      "description": "pH measurement of the culture rooting medium; e.g. 5.5.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+]"
+    },
+    "root_med_regl": {
+      "name": "root_med_regl",
+      "aliases": [
+        "rooting medium regulators"
+      ],
+      "mappings": [
+        "mixs:root_med_regl"
+      ],
+      "description": "Growth regulators in the culture rooting medium such as cytokinins, auxins, gybberellins, abscisic acid; e.g. 0.5B mg/L NAA.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "root_med_solid": {
+      "name": "root_med_solid",
+      "aliases": [
+        "rooting medium solidifier"
+      ],
+      "mappings": [
+        "mixs:root_med_solid"
+      ],
+      "description": "Specification of the solidifying agent in the culture rooting medium; e.g. agar.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "salt_regm": {
+      "name": "salt_regm",
+      "aliases": [
+        "salt regimen"
+      ],
+      "mappings": [
+        "mixs:salt_regm"
+      ],
+      "description": "Information about treatment involving use of salts as supplement to liquid and soil growth media; should include the name of salt, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple salt regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "season_environment": {
+      "name": "season_environment",
+      "aliases": [
+        "seasonal environment"
+      ],
+      "mappings": [
+        "mixs:season_environment"
+      ],
+      "description": "Treatment involving an exposure to a particular season (e.g. Winter, summer, rabi, rainy etc.), treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "standing_water_regm": {
+      "name": "standing_water_regm",
+      "aliases": [
+        "standing water regimen"
+      ],
+      "mappings": [
+        "mixs:standing_water_regm"
+      ],
+      "description": "Treatment involving an exposure to standing water during a plant's life span, types can be flood water or standing water, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "tiss_cult_growth_med": {
+      "name": "tiss_cult_growth_med",
+      "aliases": [
+        "tissue culture growth media"
+      ],
+      "mappings": [
+        "mixs:tiss_cult_growth_med"
+      ],
+      "description": "Description of plant tissue culture growth media used",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "water_temp_regm": {
+      "name": "water_temp_regm",
+      "aliases": [
+        "water temperature regimen"
+      ],
+      "mappings": [
+        "mixs:water_temp_regm"
+      ],
+      "description": "Information about treatment involving an exposure to water with varying degree of temperature, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "watering_regm": {
+      "name": "watering_regm",
+      "aliases": [
+        "watering regimen"
+      ],
+      "mappings": [
+        "mixs:watering_regm"
+      ],
+      "description": "Information about treatment involving an exposure to watering frequencies, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit};{Rn/start_time/end_time/duration}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "particle_class": {
+      "name": "particle_class",
+      "aliases": [
+        "particle classification"
+      ],
+      "mappings": [
+        "mixs:particle_class"
+      ],
+      "description": "Particles are classified, based on their size, into six general categories:clay, silt, sand, gravel, cobbles, and boulders; should include amount of particle preceded by the name of the particle type; can include multiple values",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "sediment_type": {
+      "name": "sediment_type",
+      "aliases": [
+        "sediment type"
+      ],
+      "mappings": [
+        "mixs:sediment_type"
+      ],
+      "description": "Information about the sediment type based on major constituents",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[biogenous|cosmogenous|hydrogenous|lithogenous]"
+    },
+    "tidal_stage": {
+      "name": "tidal_stage",
+      "aliases": [
+        "tidal stage"
+      ],
+      "mappings": [
+        "mixs:tidal_stage"
+      ],
+      "description": "Stage of tide",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[low tide|ebb tide|flood tide|high tide]"
+    },
+    "tot_depth_water_col": {
+      "name": "tot_depth_water_col",
+      "aliases": [
+        "total depth of water column"
+      ],
+      "mappings": [
+        "mixs:tot_depth_water_col"
+      ],
+      "description": "Measurement of total depth of water column",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "cur_land_use": {
+      "name": "cur_land_use",
+      "aliases": [
+        "current land use"
+      ],
+      "mappings": [
+        "mixs:cur_land_use"
+      ],
+      "description": "Present state of sample site",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[cities|farmstead|industrial areas|roads\\/railroads|rock|sand|gravel|mudflats|salt flats|badlands|permanent snow or ice|saline seeps|mines\\/quarries|oil waste areas|small grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands (grass,sedges,rushes)|tundra (mosses,lichens)|rangeland|pastureland (grasslands used for livestock grazing)|hayland|meadows (grasses,alfalfa,fescue,bromegrass,timothy)|shrub land (e.g. mesquite,sage\\-brush,creosote bush,shrub oak,eucalyptus)|successional shrub land (tree saplings,hazels,sumacs,chokecherry,shrub dogwoods,blackberries)|shrub crops (blueberries,nursery ornamentals,filberts)|vine crops (grapes)|conifers (e.g. pine,spruce,fir,cypress)|hardwoods (e.g. oak,hickory,elm,aspen)|intermixed hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen forest receiving >406 cm annual rainfall)|swamp (permanent or semi\\-permanent water body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery trees)]"
+    },
+    "cur_vegetation": {
+      "name": "cur_vegetation",
+      "aliases": [
+        "current vegetation"
+      ],
+      "mappings": [
+        "mixs:cur_vegetation"
+      ],
+      "description": "Vegetation classification from one or more standard classification systems, or agricultural crop",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "cur_vegetation_meth": {
+      "name": "cur_vegetation_meth",
+      "aliases": [
+        "current vegetation method"
+      ],
+      "mappings": [
+        "mixs:cur_vegetation_meth"
+      ],
+      "description": "Reference or method used in vegetation classification ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "previous_land_use": {
+      "name": "previous_land_use",
+      "aliases": [
+        "history/previous land use"
+      ],
+      "mappings": [
+        "mixs:previous_land_use"
+      ],
+      "description": "Previous land use and dates",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "previous_land_use_meth": {
+      "name": "previous_land_use_meth",
+      "aliases": [
+        "history/previous land use method"
+      ],
+      "mappings": [
+        "mixs:previous_land_use_meth"
+      ],
+      "description": "Reference or method used in determining previous land use and dates",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "crop_rotation": {
+      "name": "crop_rotation",
+      "aliases": [
+        "history/crop rotation"
+      ],
+      "mappings": [
+        "mixs:crop_rotation"
+      ],
+      "description": "Whether or not crop is rotated, and if yes, rotation schedule",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "agrochem_addition": {
+      "name": "agrochem_addition",
+      "aliases": [
+        "history/agrochemical additions"
+      ],
+      "mappings": [
+        "mixs:agrochem_addition"
+      ],
+      "description": "Addition of fertilizers, pesticides, etc. - amount and time of applications",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit};{timestamp}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "tillage": {
+      "name": "tillage",
+      "aliases": [
+        "history/tillage"
+      ],
+      "mappings": [
+        "mixs:tillage"
+      ],
+      "description": "Note method(s) used for tilling",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[drill|cutting disc|ridge till|strip tillage|zonal tillage|chisel|tined|mouldboard|disc plough]"
+    },
+    "fire": {
+      "name": "fire",
+      "aliases": [
+        "history/fire"
+      ],
+      "mappings": [
+        "mixs:fire"
+      ],
+      "description": "Historical and/or physical evidence of fire",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "flooding": {
+      "name": "flooding",
+      "aliases": [
+        "history/flooding"
+      ],
+      "mappings": [
+        "mixs:flooding"
+      ],
+      "description": "Historical and/or physical evidence of flooding",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "extreme_event": {
+      "name": "extreme_event",
+      "aliases": [
+        "history/extreme events"
+      ],
+      "mappings": [
+        "mixs:extreme_event"
+      ],
+      "description": "Unusual physical events that may have affected microbial populations",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "timestamp value"
+    },
+    "horizon": {
+      "name": "horizon",
+      "aliases": [
+        "horizon"
+      ],
+      "mappings": [
+        "mixs:horizon"
+      ],
+      "description": "Specific layer in the land area which measures parallel to the soil surface and possesses physical characteristics which differ from the layers above and beneath",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[O horizon|A horizon|E horizon|B horizon|C horizon|R layer|Permafrost]"
+    },
+    "horizon_meth": {
+      "name": "horizon_meth",
+      "aliases": [
+        "horizon method"
+      ],
+      "mappings": [
+        "mixs:horizon_meth"
+      ],
+      "description": "Reference or method used in determining the horizon",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "sieving": {
+      "name": "sieving",
+      "aliases": [
+        "composite design/sieving (if any)"
+      ],
+      "mappings": [
+        "mixs:sieving"
+      ],
+      "description": "Collection design of pooled samples and/or sieve size and amount of sample sieved ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{{text}|{float} {unit}};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "water_content_soil_meth": {
+      "name": "water_content_soil_meth",
+      "aliases": [
+        "water content method"
+      ],
+      "mappings": [
+        "mixs:water_content_soil_meth"
+      ],
+      "description": "Reference or method used in determining the water content of soil",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "pool_dna_extracts": {
+      "name": "pool_dna_extracts",
+      "aliases": [
+        "pooling of DNA extracts (if done)"
+      ],
+      "mappings": [
+        "mixs:pool_dna_extracts"
+      ],
+      "description": "Indicate whether multiple DNA extractions were mixed. If the answer yes, the number of extracts that were pooled should be given",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "store_cond": {
+      "name": "store_cond",
+      "aliases": [
+        "storage conditions (fresh/frozen/other)"
+      ],
+      "mappings": [
+        "mixs:store_cond"
+      ],
+      "description": "Explain how and for how long the soil sample was stored before DNA extraction",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "link_climate_info": {
+      "name": "link_climate_info",
+      "aliases": [
+        "link to climate information"
+      ],
+      "mappings": [
+        "mixs:link_climate_info"
+      ],
+      "description": "Link to climate resource",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "annual_temp": {
+      "name": "annual_temp",
+      "aliases": [
+        "mean annual temperature"
+      ],
+      "mappings": [
+        "mixs:annual_temp"
+      ],
+      "description": "Mean annual temperature",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "season_temp": {
+      "name": "season_temp",
+      "aliases": [
+        "mean seasonal temperature"
+      ],
+      "mappings": [
+        "mixs:season_temp"
+      ],
+      "description": "Mean seasonal temperature",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "annual_precpt": {
+      "name": "annual_precpt",
+      "aliases": [
+        "mean annual precipitation"
+      ],
+      "mappings": [
+        "mixs:annual_precpt"
+      ],
+      "description": "The average of all annual precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "season_precpt": {
+      "name": "season_precpt",
+      "aliases": [
+        "mean seasonal precipitation"
+      ],
+      "mappings": [
+        "mixs:season_precpt"
+      ],
+      "description": "The average of all seasonal precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "link_class_info": {
+      "name": "link_class_info",
+      "aliases": [
+        "link to classification information"
+      ],
+      "mappings": [
+        "mixs:link_class_info"
+      ],
+      "description": "Link to digitized soil maps or other soil classification information",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "fao_class": {
+      "name": "fao_class",
+      "aliases": [
+        "soil_taxonomic/FAO classification"
+      ],
+      "mappings": [
+        "mixs:fao_class"
+      ],
+      "description": "Soil classification from the FAO World Reference Database for Soil Resources. The list can be found at http://www.fao.org/nr/land/sols/soil/wrb-soil-maps/reference-groups",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[Acrisols|Andosols|Arenosols|Cambisols|Chernozems|Ferralsols|Fluvisols|Gleysols|Greyzems|Gypsisols|Histosols|Kastanozems|Lithosols|Luvisols|Nitosols|Phaeozems|Planosols|Podzols|Podzoluvisols|Rankers|Regosols|Rendzinas|Solonchaks|Solonetz|Vertisols|Yermosols]"
+    },
+    "local_class": {
+      "name": "local_class",
+      "aliases": [
+        "soil_taxonomic/local classification"
+      ],
+      "mappings": [
+        "mixs:local_class"
+      ],
+      "description": "Soil classification based on local soil classification system",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "local_class_meth": {
+      "name": "local_class_meth",
+      "aliases": [
+        "soil_taxonomic/local classification method"
+      ],
+      "mappings": [
+        "mixs:local_class_meth"
+      ],
+      "description": "Reference or method used in determining the local soil classification ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "soil_type": {
+      "name": "soil_type",
+      "aliases": [
+        "soil type"
+      ],
+      "mappings": [
+        "mixs:soil_type"
+      ],
+      "description": "Soil series name or other lower-level classification",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "soil_type_meth": {
+      "name": "soil_type_meth",
+      "aliases": [
+        "soil type method"
+      ],
+      "mappings": [
+        "mixs:soil_type_meth"
+      ],
+      "description": "Reference or method used in determining soil series name or other lower-level classification",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "slope_gradient": {
+      "name": "slope_gradient",
+      "aliases": [
+        "slope gradient"
+      ],
+      "mappings": [
+        "mixs:slope_gradient"
+      ],
+      "description": "Commonly called 'slope'. The angle between ground surface and a horizontal line (in percent). This is the direction that overland water would flow. This measure is usually taken with a hand level meter or clinometer",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "slope_aspect": {
+      "name": "slope_aspect",
+      "aliases": [
+        "slope aspect"
+      ],
+      "mappings": [
+        "mixs:slope_aspect"
+      ],
+      "description": "The direction a slope faces. While looking down a slope use a compass to record the direction you are facing (direction or degrees); e.g., nw or 315 degrees. This measure provides an indication of sun and wind exposure that will influence soil temperature and evapotranspiration.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "profile_position": {
+      "name": "profile_position",
+      "aliases": [
+        "profile position"
+      ],
+      "mappings": [
+        "mixs:profile_position"
+      ],
+      "description": "Cross-sectional position in the hillslope where sample was collected.sample area position in relation to surrounding areas",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[summit|shoulder|backslope|footslope|toeslope]"
+    },
+    "drainage_class": {
+      "name": "drainage_class",
+      "aliases": [
+        "drainage classification"
+      ],
+      "mappings": [
+        "mixs:drainage_class"
+      ],
+      "description": "Drainage classification from a standard system such as the USDA system",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value",
+      "pattern": "[very poorly|poorly|somewhat poorly|moderately well|well|excessively drained]"
+    },
+    "texture": {
+      "name": "texture",
+      "aliases": [
+        "texture"
+      ],
+      "mappings": [
+        "mixs:texture"
+      ],
+      "description": "The relative proportion of different grain sizes of mineral particles in a soil, as described using a standard system; express as % sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty clay loam) optional.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "texture_meth": {
+      "name": "texture_meth",
+      "aliases": [
+        "texture method"
+      ],
+      "mappings": [
+        "mixs:texture_meth"
+      ],
+      "description": "Reference or method used in determining soil texture",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "ph_meth": {
+      "name": "ph_meth",
+      "aliases": [
+        "pH method"
+      ],
+      "mappings": [
+        "mixs:ph_meth"
+      ],
+      "description": "Reference or method used in determining ph",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "tot_org_c_meth": {
+      "name": "tot_org_c_meth",
+      "aliases": [
+        "total organic carbon method"
+      ],
+      "mappings": [
+        "mixs:tot_org_c_meth"
+      ],
+      "description": "Reference or method used in determining total organic carbon",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "tot_nitro_content_meth": {
+      "name": "tot_nitro_content_meth",
+      "aliases": [
+        "total nitrogen content method"
+      ],
+      "mappings": [
+        "mixs:tot_nitro_content_meth"
+      ],
+      "description": "Reference or method used in determining the total nitrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "microbial_biomass": {
+      "name": "microbial_biomass",
+      "aliases": [
+        "microbial biomass"
+      ],
+      "mappings": [
+        "mixs:microbial_biomass"
+      ],
+      "description": "The part of the organic matter in the soil that constitutes living microorganisms smaller than 5-10 micrometer. If you keep this, you would need to have correction factors used for conversion to the final units",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "microbial_biomass_meth": {
+      "name": "microbial_biomass_meth",
+      "aliases": [
+        "microbial biomass method"
+      ],
+      "mappings": [
+        "mixs:microbial_biomass_meth"
+      ],
+      "description": "Reference or method used in determining microbial biomass",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "link_addit_analys": {
+      "name": "link_addit_analys",
+      "aliases": [
+        "links to additional analysis"
+      ],
+      "mappings": [
+        "mixs:link_addit_analys"
+      ],
+      "description": "Link to additional analysis results performed on the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "extreme_salinity": {
+      "name": "extreme_salinity",
+      "aliases": [
+        "extreme_unusual_properties/salinity"
+      ],
+      "mappings": [
+        "mixs:extreme_salinity"
+      ],
+      "description": "Measured salinity ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "salinity_meth": {
+      "name": "salinity_meth",
+      "aliases": [
+        "extreme_unusual_properties/salinity method"
+      ],
+      "mappings": [
+        "mixs:salinity_meth"
+      ],
+      "description": "Reference or method used in determining salinity",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "heavy_metals": {
+      "name": "heavy_metals",
+      "aliases": [
+        "extreme_unusual_properties/heavy metals"
+      ],
+      "mappings": [
+        "mixs:heavy_metals"
+      ],
+      "description": "Heavy metals present and concentrationsany drug used by subject and the frequency of usage; can include multiple heavy metals and concentrations",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "heavy_metals_meth": {
+      "name": "heavy_metals_meth",
+      "aliases": [
+        "extreme_unusual_properties/heavy metals method"
+      ],
+      "mappings": [
+        "mixs:heavy_metals_meth"
+      ],
+      "description": "Reference or method used in determining heavy metals",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "al_sat": {
+      "name": "al_sat",
+      "aliases": [
+        "extreme_unusual_properties/Al saturation"
+      ],
+      "mappings": [
+        "mixs:al_sat"
+      ],
+      "description": "Aluminum saturation (esp. For tropical soils)",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "al_sat_meth": {
+      "name": "al_sat_meth",
+      "aliases": [
+        "extreme_unusual_properties/Al saturation method"
+      ],
+      "mappings": [
+        "mixs:al_sat_meth"
+      ],
+      "description": "Reference or method used in determining Al saturation",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "biochem_oxygen_dem": {
+      "name": "biochem_oxygen_dem",
+      "aliases": [
+        "biochemical oxygen demand"
+      ],
+      "mappings": [
+        "mixs:biochem_oxygen_dem"
+      ],
+      "description": "Amount of dissolved oxygen needed by aerobic biological organisms in a body of water to break down organic material present in a given water sample at certain temperature over a specific time period",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "chem_oxygen_dem": {
+      "name": "chem_oxygen_dem",
+      "aliases": [
+        "chemical oxygen demand"
+      ],
+      "mappings": [
+        "mixs:chem_oxygen_dem"
+      ],
+      "description": "A measure of the capacity of water to consume oxygen during the decomposition of organic matter and the oxidation of inorganic chemicals such as ammonia and nitrite",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "efficiency_percent": {
+      "name": "efficiency_percent",
+      "aliases": [
+        "efficiency percent"
+      ],
+      "mappings": [
+        "mixs:efficiency_percent"
+      ],
+      "description": "Percentage of volatile solids removed from the anaerobic digestor",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "emulsions": {
+      "name": "emulsions",
+      "aliases": [
+        "emulsions"
+      ],
+      "mappings": [
+        "mixs:emulsions"
+      ],
+      "description": "Amount or concentration of substances such as paints, adhesives, mayonnaise, hair colorants, emulsified oils, etc.; can include multiple emulsion types",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "gaseous_substances": {
+      "name": "gaseous_substances",
+      "aliases": [
+        "gaseous substances"
+      ],
+      "mappings": [
+        "mixs:gaseous_substances"
+      ],
+      "description": "Amount or concentration of substances such as hydrogen sulfide, carbon dioxide, methane, etc.; can include multiple substances",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "indust_eff_percent": {
+      "name": "indust_eff_percent",
+      "aliases": [
+        "industrial effluent percent"
+      ],
+      "mappings": [
+        "mixs:indust_eff_percent"
+      ],
+      "description": "Percentage of industrial effluents received by wastewater treatment plant",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "inorg_particles": {
+      "name": "inorg_particles",
+      "aliases": [
+        "inorganic particles"
+      ],
+      "mappings": [
+        "mixs:inorg_particles"
+      ],
+      "description": "Concentration of particles such as sand, grit, metal particles, ceramics, etc.; can include multiple particles",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "org_particles": {
+      "name": "org_particles",
+      "aliases": [
+        "organic particles"
+      ],
+      "mappings": [
+        "mixs:org_particles"
+      ],
+      "description": "Concentration of particles such as faeces, hairs, food, vomit, paper fibers, plant material, humus, etc.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "pre_treatment": {
+      "name": "pre_treatment",
+      "aliases": [
+        "pre-treatment"
+      ],
+      "mappings": [
+        "mixs:pre_treatment"
+      ],
+      "description": "The process of pre-treatment removes materials that can be easily collected from the raw wastewater",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "primary_treatment": {
+      "name": "primary_treatment",
+      "aliases": [
+        "primary treatment"
+      ],
+      "mappings": [
+        "mixs:primary_treatment"
+      ],
+      "description": "The process to produce both a generally homogeneous liquid capable of being treated biologically and a sludge that can be separately treated or processed",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "reactor_type": {
+      "name": "reactor_type",
+      "aliases": [
+        "reactor type"
+      ],
+      "mappings": [
+        "mixs:reactor_type"
+      ],
+      "description": "Anaerobic digesters can be designed and engineered to operate using a number of different process configurations, as batch or continuous, mesophilic, high solid or low solid, and single stage or multistage",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "secondary_treatment": {
+      "name": "secondary_treatment",
+      "aliases": [
+        "secondary treatment"
+      ],
+      "mappings": [
+        "mixs:secondary_treatment"
+      ],
+      "description": "The process for substantially degrading the biological content of the sewage ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "sewage_type": {
+      "name": "sewage_type",
+      "aliases": [
+        "sewage type"
+      ],
+      "mappings": [
+        "mixs:sewage_type"
+      ],
+      "description": "Type of wastewater treatment plant as municipial or industrial",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "sludge_retent_time": {
+      "name": "sludge_retent_time",
+      "aliases": [
+        "sludge retention time"
+      ],
+      "mappings": [
+        "mixs:sludge_retent_time"
+      ],
+      "description": "The time activated sludge remains in reactor",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "soluble_inorg_mat": {
+      "name": "soluble_inorg_mat",
+      "aliases": [
+        "soluble inorganic material"
+      ],
+      "mappings": [
+        "mixs:soluble_inorg_mat"
+      ],
+      "description": "Concentration of substances such as ammonia, road-salt, sea-salt, cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "soluble_org_mat": {
+      "name": "soluble_org_mat",
+      "aliases": [
+        "soluble organic material"
+      ],
+      "mappings": [
+        "mixs:soluble_org_mat"
+      ],
+      "description": "Concentration of substances such as urea, fruit sugars, soluble proteins, drugs, pharmaceuticals, etc.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "tertiary_treatment": {
+      "name": "tertiary_treatment",
+      "aliases": [
+        "tertiary treatment"
+      ],
+      "mappings": [
+        "mixs:tertiary_treatment"
+      ],
+      "description": "The process providing a final treatment stage to raise the effluent quality before it is discharged to the receiving environment",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "tot_phosphate": {
+      "name": "tot_phosphate",
+      "aliases": [
+        "total phosphate"
+      ],
+      "mappings": [
+        "mixs:tot_phosphate"
+      ],
+      "description": "Total amount or concentration of phosphate",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "wastewater_type": {
+      "name": "wastewater_type",
+      "aliases": [
+        "wastewater type"
+      ],
+      "mappings": [
+        "mixs:wastewater_type"
+      ],
+      "description": "The origin of wastewater such as human waste, rainfall, storm drains, etc.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "multivalued": false,
+      "range": "text value"
+    },
+    "atmospheric_data": {
+      "name": "atmospheric_data",
+      "aliases": [
+        "atmospheric data"
+      ],
+      "mappings": [
+        "mixs:atmospheric_data"
+      ],
+      "description": "Measurement of atmospheric data; can include multiple data",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{text};{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value"
+    },
+    "bac_prod": {
+      "name": "bac_prod",
+      "aliases": [
+        "bacterial production"
+      ],
+      "mappings": [
+        "mixs:bac_prod"
+      ],
+      "description": "Bacterial production in the water column measured by isotope uptake",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "bac_resp": {
+      "name": "bac_resp",
+      "aliases": [
+        "bacterial respiration"
+      ],
+      "mappings": [
+        "mixs:bac_resp"
+      ],
+      "description": "Measurement of bacterial respiration in the water column",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "conduc": {
+      "name": "conduc",
+      "aliases": [
+        "conductivity"
+      ],
+      "mappings": [
+        "mixs:conduc"
+      ],
+      "description": "Electrical conductivity of water",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "diss_inorg_nitro": {
+      "name": "diss_inorg_nitro",
+      "aliases": [
+        "dissolved inorganic nitrogen"
+      ],
+      "mappings": [
+        "mixs:diss_inorg_nitro"
+      ],
+      "description": "Concentration of dissolved inorganic nitrogen ",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "down_par": {
+      "name": "down_par",
+      "aliases": [
+        "downward PAR"
+      ],
+      "mappings": [
+        "mixs:down_par"
+      ],
+      "description": "Visible waveband radiance and irradiance measurements in the water column",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "fluor": {
+      "name": "fluor",
+      "aliases": [
+        "fluorescence"
+      ],
+      "mappings": [
+        "mixs:fluor"
+      ],
+      "description": "Raw or converted fluorescence of water",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "light_intensity": {
+      "name": "light_intensity",
+      "aliases": [
+        "light intensity"
+      ],
+      "mappings": [
+        "mixs:light_intensity"
+      ],
+      "description": "Measurement of light intensity",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "part_org_nitro": {
+      "name": "part_org_nitro",
+      "aliases": [
+        "particulate organic nitrogen"
+      ],
+      "mappings": [
+        "mixs:part_org_nitro"
+      ],
+      "description": "Concentration of particulate organic nitrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "photon_flux": {
+      "name": "photon_flux",
+      "aliases": [
+        "photon flux"
+      ],
+      "mappings": [
+        "mixs:photon_flux"
+      ],
+      "description": "Measurement of photon flux",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "primary_prod": {
+      "name": "primary_prod",
+      "aliases": [
+        "primary production"
+      ],
+      "mappings": [
+        "mixs:primary_prod"
+      ],
+      "description": "Measurement of primary production, generally measured as isotope uptake",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "size_frac_low": {
+      "name": "size_frac_low",
+      "aliases": [
+        "size-fraction lower threshold"
+      ],
+      "mappings": [
+        "mixs:size_frac_low"
+      ],
+      "description": "Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials larger than the size threshold are excluded from the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "size_frac_up": {
+      "name": "size_frac_up",
+      "aliases": [
+        "size-fraction upper threshold"
+      ],
+      "mappings": [
+        "mixs:size_frac_up"
+      ],
+      "description": "Refers to the mesh/pore size used to retain the sample. Materials smaller than the size threshold are excluded from the sample",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "soluble_react_phosp": {
+      "name": "soluble_react_phosp",
+      "aliases": [
+        "soluble reactive phosphorus"
+      ],
+      "mappings": [
+        "mixs:soluble_react_phosp"
+      ],
+      "description": "Concentration of soluble reactive phosphorus",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "suspend_part_matter": {
+      "name": "suspend_part_matter",
+      "aliases": [
+        "suspended particulate matter"
+      ],
+      "mappings": [
+        "mixs:suspend_part_matter"
+      ],
+      "description": "Concentration of suspended particulate matter",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_diss_nitro": {
+      "name": "tot_diss_nitro",
+      "aliases": [
+        "total dissolved nitrogen"
+      ],
+      "mappings": [
+        "mixs:tot_diss_nitro"
+      ],
+      "description": "Total dissolved nitrogen concentration, reported as nitrogen, measured by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_inorg_nitro": {
+      "name": "tot_inorg_nitro",
+      "aliases": [
+        "total inorganic nitrogen"
+      ],
+      "mappings": [
+        "mixs:tot_inorg_nitro"
+      ],
+      "description": "Total inorganic nitrogen content",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    },
+    "tot_part_carb": {
+      "name": "tot_part_carb",
+      "aliases": [
+        "total particulate carbon"
+      ],
+      "mappings": [
+        "mixs:tot_part_carb"
+      ],
+      "description": "Total particulate carbon content",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute",
+      "string_serialization": "{float} {unit}",
+      "multivalued": false,
+      "range": "quantity value",
+      "pattern": "\\d+[.\\d+] \\S+"
+    }
+  },
+  "classes": {
+    "database": {
+      "name": "database",
+      "aliases": [
+        "NMDC metadata object"
+      ],
+      "description": "An abstract holder for any set of metadata and data. It does not need to correspond to an actual managed databse top level holder class. When translated to JSON-Schema this is the 'root' object. It should contain pointers to other objects of interest",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "biosample set",
+        "study set",
+        "data object set",
+        "activity set",
+        "mags activity set",
+        "metabolomics analysis activity set",
+        "metaproteomics analysis activity set",
+        "metagenome annotation activity set",
+        "metagenome assembly set",
+        "metatranscriptome activity set",
+        "read QC analysis activity set",
+        "read based analysis activity set",
+        "nom analysis activity set",
+        "omics processing set",
+        "functional annotation set",
+        "genome feature set"
+      ],
+      "slot_usage": {
+        "nmdc schema version": {
+          "name": "nmdc schema version",
+          "description": "TODO"
+        },
+        "date created": {
+          "name": "date created",
+          "description": "TODO"
+        },
+        "etl software version": {
+          "name": "etl software version",
+          "description": "TODO"
+        }
+      },
+      "attributes": {
+        "biosample set": {
+          "name": "biosample set",
+          "description": "This property links a database object to the set of samples within it.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "biosample_set",
+          "owner": "database",
+          "range": "biosample"
+        },
+        "study set": {
+          "name": "study set",
+          "description": "This property links a database object to the set of studies within it.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "study_set",
+          "owner": "database",
+          "range": "study"
+        },
+        "data object set": {
+          "name": "data object set",
+          "description": "This property links a database object to the set of data objects within it.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "data_object_set",
+          "owner": "database",
+          "range": "data object"
+        },
+        "activity set": {
+          "name": "activity set",
+          "description": "This property links a database object to the set of workflow activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "activity_set",
+          "owner": "database",
+          "range": "workflow execution activity"
+        },
+        "mags activity set": {
+          "name": "mags activity set",
+          "description": "This property links a database object to the set of MAGs analysis activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "mags_activity_set",
+          "owner": "database",
+          "range": "MAGs analysis activity"
+        },
+        "metabolomics analysis activity set": {
+          "name": "metabolomics analysis activity set",
+          "description": "This property links a database object to the set of metabolomics analysis activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "metabolomics_analysis_activity_set",
+          "owner": "database",
+          "range": "metabolomics analysis activity"
+        },
+        "metaproteomics analysis activity set": {
+          "name": "metaproteomics analysis activity set",
+          "description": "This property links a database object to the set of metaproteomics analysis activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "metaproteomics_analysis_activity_set",
+          "owner": "database",
+          "range": "metaproteomics analysis activity"
+        },
+        "metagenome annotation activity set": {
+          "name": "metagenome annotation activity set",
+          "description": "This property links a database object to the set of metagenome annotation activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "metagenome_annotation_activity_set",
+          "owner": "database",
+          "range": "metagenome annotation activity"
+        },
+        "metagenome assembly set": {
+          "name": "metagenome assembly set",
+          "description": "This property links a database object to the set of metagenome assembly activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "metagenome_assembly_set",
+          "owner": "database",
+          "range": "metagenome assembly"
+        },
+        "metatranscriptome activity set": {
+          "name": "metatranscriptome activity set",
+          "description": "This property links a database object to the set of metatranscriptome analysis activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "metatranscriptome_activity_set",
+          "owner": "database",
+          "range": "metatranscriptome activity"
+        },
+        "read QC analysis activity set": {
+          "name": "read QC analysis activity set",
+          "description": "This property links a database object to the set of read QC analysis activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "read_QC_analysis_activity_set",
+          "owner": "database",
+          "range": "read QC analysis activity"
+        },
+        "read based analysis activity set": {
+          "name": "read based analysis activity set",
+          "description": "This property links a database object to the set of read based analysis activities.\n  ",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "read_based_analysis_activity_set",
+          "owner": "database",
+          "range": "read based analysis activity"
+        },
+        "nom analysis activity set": {
+          "name": "nom analysis activity set",
+          "description": "This property links a database object to the set of natural organic matter (NOM) analysis activities.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "nom_analysis_activity_set",
+          "owner": "database",
+          "range": "nom analysis activity"
+        },
+        "omics processing set": {
+          "name": "omics processing set",
+          "description": "This property links a database object to the set of omics processings within it.",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "omics_processing_set",
+          "owner": "database",
+          "range": "omics processing"
+        },
+        "functional annotation set": {
+          "name": "functional annotation set",
+          "description": "This property links a database object to the set of all functional annotations",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "functional_annotation_set",
+          "owner": "database",
+          "range": "functional annotation"
+        },
+        "genome feature set": {
+          "name": "genome feature set",
+          "description": "This property links a database object to the set of all features",
+          "from_schema": "https://microbiomedata/schema",
+          "mixins": [
+            "object set"
+          ],
+          "domain": "database",
+          "multivalued": true,
+          "inlined_as_list": true,
+          "alias": "genome_feature_set",
+          "owner": "database",
+          "range": "genome feature"
+        }
+      },
+      "tree_root": true
+    },
+    "data object": {
+      "name": "data object",
+      "id_prefixes": [
+        "GOLD"
+      ],
+      "description": "An object that primarily consists of symbols that represent information.   Files, records, and omics data are examples of data objects. ",
+      "in_subset": [
+        "data object subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "slots": [
+        "file size bytes",
+        "md5 checksum",
+        "data object type",
+        "compression type",
+        "was generated by",
+        "url",
+        "type"
+      ],
+      "slot_usage": {
+        "name": {
+          "name": "name",
+          "required": true
+        },
+        "description": {
+          "name": "description",
+          "required": true
+        }
+      },
+      "attributes": {
+        "file size bytes": {
+          "name": "file size bytes",
+          "description": "Size of the file in bytes",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "file_size_bytes",
+          "owner": "data object",
+          "range": "bytes"
+        },
+        "md5 checksum": {
+          "name": "md5 checksum",
+          "description": "MD5 checksum of file (pre-compressed)",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "md5_checksum",
+          "owner": "data object",
+          "range": "string"
+        },
+        "data object type": {
+          "name": "data object type",
+          "description": "The type of file represented by the data object.",
+          "examples": [
+            {
+              "value": "FT ICR-MS Analysis Results"
+            },
+            {
+              "value": "GC-MS Metabolomics Results"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "data_object_type",
+          "owner": "data object",
+          "range": "file type enum"
+        },
+        "compression type": {
+          "name": "compression type",
+          "description": "If provided, specifies the compression type",
+          "todos": [
+            "consider enum"
+          ],
+          "examples": [
+            {
+              "value": "gzip"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "compression_type",
+          "owner": "data object",
+          "range": "string"
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "data object",
+          "range": "activity"
+        },
+        "url": {
+          "name": "url",
+          "notes": [
+            "See issue 207 - this clashes with the mixs field"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "url",
+          "owner": "data object",
+          "range": "string"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "examples": [
+            {
+              "value": "nmdc:Biosample"
+            },
+            {
+              "value": "nmdc:Study"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "data object",
+          "range": "string"
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "data object",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "data object",
+          "range": "string",
+          "required": true
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "data object",
+          "range": "string",
+          "required": true
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "data object",
+          "range": "string"
+        }
+      }
+    },
+    "biosample": {
+      "name": "biosample",
+      "id_prefixes": [
+        "GOLD"
+      ],
+      "aliases": [
+        "sample",
+        "material sample",
+        "specimen",
+        "biospecimen"
+      ],
+      "exact_mappings": [
+        "OBI:0000747",
+        "NCIT:C43412"
+      ],
+      "description": "A material sample. It may be environmental (encompassing many organisms) or isolate or tissue.   An environmental sample containing genetic material from multiple individuals is commonly referred to as a biosample.",
+      "alt_descriptions": {
+        "embl.ena": {
+          "source": "embl.ena",
+          "description": "A sample contains information about the sequenced source material. Samples are associated with checklists, which define the fields used to annotate the samples. Samples are always associated with a taxon."
+        }
+      },
+      "in_subset": [
+        "sample subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "slots": [
+        "type",
+        "alternative identifiers",
+        "part of",
+        "agrochem_addition",
+        "alkalinity",
+        "alkalinity_method",
+        "alkyl_diethers",
+        "alt",
+        "al_sat",
+        "al_sat_meth",
+        "aminopept_act",
+        "ammonium",
+        "annual_precpt",
+        "annual_temp",
+        "bacteria_carb_prod",
+        "bishomohopanol",
+        "bromide",
+        "calcium",
+        "carb_nitro_ratio",
+        "chem_administration",
+        "chloride",
+        "chlorophyll",
+        "collection_date",
+        "cur_land_use",
+        "cur_vegetation",
+        "cur_vegetation_meth",
+        "crop_rotation",
+        "density",
+        "depth",
+        "diss_carb_dioxide",
+        "diss_hydrogen",
+        "diss_inorg_carb",
+        "diss_inorg_phosp",
+        "diss_org_carb",
+        "diss_org_nitro",
+        "diss_oxygen",
+        "drainage_class",
+        "elev",
+        "env_package",
+        "env_broad_scale",
+        "env_local_scale",
+        "env_medium",
+        "extreme_event",
+        "fao_class",
+        "fire",
+        "flooding",
+        "geo_loc_name",
+        "glucosidase_act",
+        "heavy_metals",
+        "heavy_metals_meth",
+        "horizon",
+        "horizon_meth",
+        "lat_lon",
+        "link_addit_analys",
+        "link_class_info",
+        "link_climate_info",
+        "local_class",
+        "local_class_meth",
+        "magnesium",
+        "mean_frict_vel",
+        "mean_peak_frict_vel",
+        "microbial_biomass",
+        "microbial_biomass_meth",
+        "misc_param",
+        "n_alkanes",
+        "nitrate",
+        "nitrite",
+        "org_matter",
+        "org_nitro",
+        "organism_count",
+        "oxy_stat_samp",
+        "part_org_carb",
+        "perturbation",
+        "petroleum_hydrocarb",
+        "ph",
+        "ph_meth",
+        "phaeopigments",
+        "phosplipid_fatt_acid",
+        "pool_dna_extracts",
+        "potassium",
+        "pressure",
+        "previous_land_use",
+        "previous_land_use_meth",
+        "profile_position",
+        "redox_potential",
+        "salinity",
+        "salinity_meth",
+        "samp_collect_device",
+        "samp_mat_process",
+        "samp_store_dur",
+        "samp_store_loc",
+        "samp_store_temp",
+        "samp_vol_we_dna_ext",
+        "season_temp",
+        "season_precpt",
+        "sieving",
+        "size_frac_low",
+        "size_frac_up",
+        "slope_gradient",
+        "slope_aspect",
+        "sodium",
+        "soil_type",
+        "soil_type_meth",
+        "store_cond",
+        "sulfate",
+        "sulfide",
+        "temp",
+        "texture",
+        "texture_meth",
+        "tillage",
+        "tidal_stage",
+        "tot_carb",
+        "tot_depth_water_col",
+        "tot_diss_nitro",
+        "tot_org_carb",
+        "tot_org_c_meth",
+        "tot_nitro_content",
+        "tot_nitro_content_meth",
+        "tot_phosp",
+        "water_content",
+        "water_content_soil_meth",
+        "ecosystem",
+        "ecosystem_category",
+        "ecosystem_type",
+        "ecosystem_subtype",
+        "specific_ecosystem",
+        "add_date",
+        "community",
+        "depth2",
+        "habitat",
+        "host_name",
+        "identifier",
+        "location",
+        "mod_date",
+        "ncbi_taxonomy_name",
+        "proport_woa_temperature",
+        "salinity_category",
+        "sample_collection_site",
+        "soluble_iron_micromol",
+        "subsurface_depth",
+        "subsurface_depth2",
+        "GOLD sample identifiers",
+        "INSDC biosample identifiers",
+        "INSDC secondary sample identifiers"
+      ],
+      "slot_usage": {
+        "lat_lon": {
+          "name": "lat_lon",
+          "description": "This is currently a required field but it's not clear if this should be required for human hosts",
+          "required": false
+        },
+        "env_broad_scale": {
+          "name": "env_broad_scale",
+          "required": true
+        },
+        "env_local_scale": {
+          "name": "env_local_scale",
+          "required": true
+        },
+        "env_medium": {
+          "name": "env_medium",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "required": true
+        }
+      },
+      "attributes": {
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "examples": [
+            {
+              "value": "nmdc:Biosample"
+            },
+            {
+              "value": "nmdc:Study"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "part of": {
+          "name": "part of",
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "biosample",
+          "range": "named thing",
+          "required": true
+        },
+        "agrochem_addition": {
+          "name": "agrochem_addition",
+          "aliases": [
+            "history/agrochemical additions"
+          ],
+          "mappings": [
+            "mixs:agrochem_addition"
+          ],
+          "description": "Addition of fertilizers, pesticides, etc. - amount and time of applications",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit};{timestamp}",
+          "multivalued": false,
+          "alias": "agrochem_addition",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "alkalinity": {
+          "name": "alkalinity",
+          "aliases": [
+            "alkalinity"
+          ],
+          "mappings": [
+            "mixs:alkalinity"
+          ],
+          "description": "Alkalinity, the ability of a solution to neutralize acids to the equivalence point of carbonate or bicarbonate",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "alkalinity",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "alkalinity_method": {
+          "name": "alkalinity_method",
+          "aliases": [
+            "alkalinity method"
+          ],
+          "mappings": [
+            "mixs:alkalinity_method"
+          ],
+          "description": "Method used for alkalinity measurement",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "alkalinity_method",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "alkyl_diethers": {
+          "name": "alkyl_diethers",
+          "aliases": [
+            "alkyl diethers"
+          ],
+          "mappings": [
+            "mixs:alkyl_diethers"
+          ],
+          "description": "Concentration of alkyl diethers ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "alkyl_diethers",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "alt": {
+          "name": "alt",
+          "aliases": [
+            "altitude"
+          ],
+          "mappings": [
+            "mixs:alt"
+          ],
+          "description": "Altitude is a term used to identify heights of objects such as airplanes, space shuttles, rockets, atmospheric balloons and heights of places such as atmospheric layers and clouds. It is used to measure the height of an object which is above the earthbs surface. In this context, the altitude measurement is the vertical distance between the earth's surface above sea level and the sampled position in the air",
+          "in_subset": [
+            "environment"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "alt",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "al_sat": {
+          "name": "al_sat",
+          "aliases": [
+            "extreme_unusual_properties/Al saturation"
+          ],
+          "mappings": [
+            "mixs:al_sat"
+          ],
+          "description": "Aluminum saturation (esp. For tropical soils)",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "al_sat",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "al_sat_meth": {
+          "name": "al_sat_meth",
+          "aliases": [
+            "extreme_unusual_properties/Al saturation method"
+          ],
+          "mappings": [
+            "mixs:al_sat_meth"
+          ],
+          "description": "Reference or method used in determining Al saturation",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "al_sat_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "aminopept_act": {
+          "name": "aminopept_act",
+          "aliases": [
+            "aminopeptidase activity"
+          ],
+          "mappings": [
+            "mixs:aminopept_act"
+          ],
+          "description": "Measurement of aminopeptidase activity",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "aminopept_act",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "ammonium": {
+          "name": "ammonium",
+          "aliases": [
+            "ammonium"
+          ],
+          "mappings": [
+            "mixs:ammonium"
+          ],
+          "description": "Concentration of ammonium in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "ammonium",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "annual_precpt": {
+          "name": "annual_precpt",
+          "aliases": [
+            "mean annual precipitation"
+          ],
+          "mappings": [
+            "mixs:annual_precpt"
+          ],
+          "description": "The average of all annual precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "annual_precpt",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "annual_temp": {
+          "name": "annual_temp",
+          "aliases": [
+            "mean annual temperature"
+          ],
+          "mappings": [
+            "mixs:annual_temp"
+          ],
+          "description": "Mean annual temperature",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "annual_temp",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "bacteria_carb_prod": {
+          "name": "bacteria_carb_prod",
+          "aliases": [
+            "bacterial carbon production"
+          ],
+          "mappings": [
+            "mixs:bacteria_carb_prod"
+          ],
+          "description": "Measurement of bacterial carbon production",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "bacteria_carb_prod",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "bishomohopanol": {
+          "name": "bishomohopanol",
+          "aliases": [
+            "bishomohopanol"
+          ],
+          "mappings": [
+            "mixs:bishomohopanol"
+          ],
+          "description": "Concentration of bishomohopanol ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "bishomohopanol",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "bromide": {
+          "name": "bromide",
+          "aliases": [
+            "bromide"
+          ],
+          "mappings": [
+            "mixs:bromide"
+          ],
+          "description": "Concentration of bromide ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "bromide",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "calcium": {
+          "name": "calcium",
+          "aliases": [
+            "calcium"
+          ],
+          "mappings": [
+            "mixs:calcium"
+          ],
+          "description": "Concentration of calcium in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "calcium",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "carb_nitro_ratio": {
+          "name": "carb_nitro_ratio",
+          "aliases": [
+            "carbon/nitrogen ratio"
+          ],
+          "mappings": [
+            "mixs:carb_nitro_ratio"
+          ],
+          "description": "Ratio of amount or concentrations of carbon to nitrogen",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "carb_nitro_ratio",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "chem_administration": {
+          "name": "chem_administration",
+          "aliases": [
+            "chemical administration"
+          ],
+          "mappings": [
+            "mixs:chem_administration"
+          ],
+          "description": "List of chemical compounds administered to the host or site where sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can include multiple compounds. For chemical entities of biological interest ontology (chebi) (v 163), http://purl.bioontology.org/ontology/chebi",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "chem_administration",
+          "owner": "biosample",
+          "range": "controlled term value"
+        },
+        "chloride": {
+          "name": "chloride",
+          "aliases": [
+            "chloride"
+          ],
+          "mappings": [
+            "mixs:chloride"
+          ],
+          "description": "Concentration of chloride in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "chloride",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "chlorophyll": {
+          "name": "chlorophyll",
+          "aliases": [
+            "chlorophyll"
+          ],
+          "mappings": [
+            "mixs:chlorophyll"
+          ],
+          "description": "Concentration of chlorophyll",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "chlorophyll",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "collection_date": {
+          "name": "collection_date",
+          "aliases": [
+            "collection date"
+          ],
+          "mappings": [
+            "mixs:collection_date"
+          ],
+          "description": "The time of sampling, either as an instance (single point in time) or interval. In case no exact time is available, the date/time can be right truncated i.e. all of these are valid times: 2008-01-23T19:23:10+00:00; 2008-01-23T19:23:10; 2008-01-23; 2008-01; 2008; Except: 2008-01; 2008 all are ISO8601 compliant",
+          "in_subset": [
+            "environment"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "collection_date",
+          "owner": "biosample",
+          "range": "timestamp value"
+        },
+        "cur_land_use": {
+          "name": "cur_land_use",
+          "aliases": [
+            "current land use"
+          ],
+          "mappings": [
+            "mixs:cur_land_use"
+          ],
+          "description": "Present state of sample site",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "cur_land_use",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[cities|farmstead|industrial areas|roads\\/railroads|rock|sand|gravel|mudflats|salt flats|badlands|permanent snow or ice|saline seeps|mines\\/quarries|oil waste areas|small grains|row crops|vegetable crops|horticultural plants (e.g. tulips)|marshlands (grass,sedges,rushes)|tundra (mosses,lichens)|rangeland|pastureland (grasslands used for livestock grazing)|hayland|meadows (grasses,alfalfa,fescue,bromegrass,timothy)|shrub land (e.g. mesquite,sage\\-brush,creosote bush,shrub oak,eucalyptus)|successional shrub land (tree saplings,hazels,sumacs,chokecherry,shrub dogwoods,blackberries)|shrub crops (blueberries,nursery ornamentals,filberts)|vine crops (grapes)|conifers (e.g. pine,spruce,fir,cypress)|hardwoods (e.g. oak,hickory,elm,aspen)|intermixed hardwood and conifers|tropical (e.g. mangrove,palms)|rainforest (evergreen forest receiving >406 cm annual rainfall)|swamp (permanent or semi\\-permanent water body dominated by woody plants)|crop trees (nuts,fruit,christmas trees,nursery trees)]"
+        },
+        "cur_vegetation": {
+          "name": "cur_vegetation",
+          "aliases": [
+            "current vegetation"
+          ],
+          "mappings": [
+            "mixs:cur_vegetation"
+          ],
+          "description": "Vegetation classification from one or more standard classification systems, or agricultural crop",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "cur_vegetation",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "cur_vegetation_meth": {
+          "name": "cur_vegetation_meth",
+          "aliases": [
+            "current vegetation method"
+          ],
+          "mappings": [
+            "mixs:cur_vegetation_meth"
+          ],
+          "description": "Reference or method used in vegetation classification ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "cur_vegetation_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "crop_rotation": {
+          "name": "crop_rotation",
+          "aliases": [
+            "history/crop rotation"
+          ],
+          "mappings": [
+            "mixs:crop_rotation"
+          ],
+          "description": "Whether or not crop is rotated, and if yes, rotation schedule",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "crop_rotation",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "density": {
+          "name": "density",
+          "aliases": [
+            "density"
+          ],
+          "mappings": [
+            "mixs:density"
+          ],
+          "description": "Density of the sample, which is its mass per unit volume (aka volumetric mass density)",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "density",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "depth": {
+          "name": "depth",
+          "aliases": [
+            "geographic location (depth)"
+          ],
+          "mappings": [
+            "mixs:depth"
+          ],
+          "description": "Depth is defined as the vertical distance below local surface, e.g. For sediment or soil samples depth is measured from sediment or soil surface, respectively. Depth can be reported as an interval for subsurface samples",
+          "in_subset": [
+            "environment"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "depth",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "diss_carb_dioxide": {
+          "name": "diss_carb_dioxide",
+          "aliases": [
+            "dissolved carbon dioxide"
+          ],
+          "mappings": [
+            "mixs:diss_carb_dioxide"
+          ],
+          "description": "Concentration of dissolved carbon dioxide in the sample or liquid portion of the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_carb_dioxide",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "diss_hydrogen": {
+          "name": "diss_hydrogen",
+          "aliases": [
+            "dissolved hydrogen"
+          ],
+          "mappings": [
+            "mixs:diss_hydrogen"
+          ],
+          "description": "Concentration of dissolved hydrogen",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_hydrogen",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "diss_inorg_carb": {
+          "name": "diss_inorg_carb",
+          "aliases": [
+            "dissolved inorganic carbon"
+          ],
+          "mappings": [
+            "mixs:diss_inorg_carb"
+          ],
+          "description": "Dissolved inorganic carbon concentration in the sample, typically measured after filtering the sample using a 0.45 micrometer filter",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_inorg_carb",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "diss_inorg_phosp": {
+          "name": "diss_inorg_phosp",
+          "aliases": [
+            "dissolved inorganic phosphorus"
+          ],
+          "mappings": [
+            "mixs:diss_inorg_phosp"
+          ],
+          "description": "Concentration of dissolved inorganic phosphorus in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_inorg_phosp",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "diss_org_carb": {
+          "name": "diss_org_carb",
+          "aliases": [
+            "dissolved organic carbon"
+          ],
+          "mappings": [
+            "mixs:diss_org_carb"
+          ],
+          "description": "Concentration of dissolved organic carbon in the sample, liquid portion of the sample, or aqueous phase of the fluid",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_org_carb",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "diss_org_nitro": {
+          "name": "diss_org_nitro",
+          "aliases": [
+            "dissolved organic nitrogen"
+          ],
+          "mappings": [
+            "mixs:diss_org_nitro"
+          ],
+          "description": "Dissolved organic nitrogen concentration measured as; total dissolved nitrogen - NH4 - NO3 - NO2",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_org_nitro",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "diss_oxygen": {
+          "name": "diss_oxygen",
+          "aliases": [
+            "dissolved oxygen"
+          ],
+          "mappings": [
+            "mixs:diss_oxygen"
+          ],
+          "description": "Concentration of dissolved oxygen",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "diss_oxygen",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "drainage_class": {
+          "name": "drainage_class",
+          "aliases": [
+            "drainage classification"
+          ],
+          "mappings": [
+            "mixs:drainage_class"
+          ],
+          "description": "Drainage classification from a standard system such as the USDA system",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "drainage_class",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[very poorly|poorly|somewhat poorly|moderately well|well|excessively drained]"
+        },
+        "elev": {
+          "name": "elev",
+          "aliases": [
+            "elevation"
+          ],
+          "mappings": [
+            "mixs:elev"
+          ],
+          "description": "Elevation of the sampling site is its height above a fixed reference point, most commonly the mean sea level. Elevation is mainly used when referring to points on the earth's surface, while altitude is used for points above the surface, such as an aircraft in flight or a spacecraft in orbit",
+          "in_subset": [
+            "environment"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "elev",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "env_package": {
+          "name": "env_package",
+          "aliases": [
+            "environmental package"
+          ],
+          "mappings": [
+            "mixs:env_package"
+          ],
+          "description": "MIxS extension for reporting of measurements and observations obtained from one or more of the environments where the sample was obtained. All environmental packages listed here are further defined in separate subtables. By giving the name of the environmental package, a selection of fields can be made from the subtables and can be reported",
+          "in_subset": [
+            "mixs extension"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "env_package",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[air|built environment|host\\-associated|human\\-associated|human\\-skin|human\\-oral|human\\-gut|human\\-vaginal|hydrocarbon resources\\-cores|hydrocarbon resources\\-fluids\\/swabs|microbial mat\\/biofilm|misc environment|plant\\-associated|sediment|soil|wastewater\\/sludge|water]"
+        },
+        "env_broad_scale": {
+          "name": "env_broad_scale",
+          "description": "In this field, report which major environmental system your sample or specimen came from. The systems identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. were you in the desert or a rainforest?). We recommend using subclasses of ENVOUs biome class: http://purl.obolibrary.org/obo/ENVO_00000428. Format (one term): termLabel [termID], Format (multiple terms): termLabel [termID]|termLabel [termID]|termLabel [termID]. Example: Annotating a water sample from the photic zone in middle of the Atlantic Ocean, consider: oceanic epipelagic zone biome [ENVO:01000033]. Example: Annotating a sample from the Amazon rainforest consider: tropical moist broadleaf forest biome [ENVO:01000228]. If needed, request new terms on the ENVO tracker, identified here: http://www.obofoundry.org/ontology/envo.html",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "env_broad_scale",
+          "owner": "biosample",
+          "range": "controlled term value",
+          "required": true,
+          "pattern": ".* \\S+:\\S+"
+        },
+        "env_local_scale": {
+          "name": "env_local_scale",
+          "description": "In this field, report the entity or entities which are in your sample or specimenUs local vicinity and which you believe have significant causal influences on your sample or specimen. Please use terms that are present in ENVO and which are of smaller spatial grain than your entry for env_broad_scale. Format (one term): termLabel [termID]; Format (multiple terms): termLabel [termID]|termLabel [termID]|termLabel [termID]. Example: Annotating a pooled sample taken from various vegetation layers in a forest consider: canopy [ENVO:00000047]|herb and fern layer [ENVO:01000337]|litter layer [ENVO:01000338]|understory [01000335]|shrub layer [ENVO:01000336]. If needed, request new terms on the ENVO tracker, identified here: http://www.obofoundry.org/ontology/envo.html",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "env_local_scale",
+          "owner": "biosample",
+          "range": "controlled term value",
+          "required": true,
+          "pattern": ".* \\S+:\\S+"
+        },
+        "env_medium": {
+          "name": "env_medium",
+          "description": "In this field, report which environmental material or materials (pipe separated) immediately surrounded your sample or specimen prior to sampling, using one or more subclasses of ENVOUs environmental material class: http://purl.obolibrary.org/obo/ENVO_00010483. Format (one term): termLabel [termID]; Format (multiple terms): termLabel [termID]|termLabel [termID]|termLabel [termID]. Example: Annotating a fish swimming in the upper 100 m of the Atlantic Ocean, consider: ocean water [ENVO:00002151]. Example: Annotating a duck on a pond consider: pond water [ENVO:00002228]|air ENVO_00002005. If needed, request new terms on the ENVO tracker, identified here: http://www.obofoundry.org/ontology/envo.html",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "env_medium",
+          "owner": "biosample",
+          "range": "controlled term value",
+          "required": true,
+          "pattern": ".* \\S+:\\S+"
+        },
+        "extreme_event": {
+          "name": "extreme_event",
+          "aliases": [
+            "history/extreme events"
+          ],
+          "mappings": [
+            "mixs:extreme_event"
+          ],
+          "description": "Unusual physical events that may have affected microbial populations",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "extreme_event",
+          "owner": "biosample",
+          "range": "timestamp value"
+        },
+        "fao_class": {
+          "name": "fao_class",
+          "aliases": [
+            "soil_taxonomic/FAO classification"
+          ],
+          "mappings": [
+            "mixs:fao_class"
+          ],
+          "description": "Soil classification from the FAO World Reference Database for Soil Resources. The list can be found at http://www.fao.org/nr/land/sols/soil/wrb-soil-maps/reference-groups",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "fao_class",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[Acrisols|Andosols|Arenosols|Cambisols|Chernozems|Ferralsols|Fluvisols|Gleysols|Greyzems|Gypsisols|Histosols|Kastanozems|Lithosols|Luvisols|Nitosols|Phaeozems|Planosols|Podzols|Podzoluvisols|Rankers|Regosols|Rendzinas|Solonchaks|Solonetz|Vertisols|Yermosols]"
+        },
+        "fire": {
+          "name": "fire",
+          "aliases": [
+            "history/fire"
+          ],
+          "mappings": [
+            "mixs:fire"
+          ],
+          "description": "Historical and/or physical evidence of fire",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "fire",
+          "owner": "biosample",
+          "range": "timestamp value"
+        },
+        "flooding": {
+          "name": "flooding",
+          "aliases": [
+            "history/flooding"
+          ],
+          "mappings": [
+            "mixs:flooding"
+          ],
+          "description": "Historical and/or physical evidence of flooding",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "flooding",
+          "owner": "biosample",
+          "range": "timestamp value"
+        },
+        "geo_loc_name": {
+          "name": "geo_loc_name",
+          "aliases": [
+            "geographic location (country and/or sea,region)"
+          ],
+          "mappings": [
+            "mixs:geo_loc_name"
+          ],
+          "description": "The geographical origin of the sample as defined by the country or sea name followed by specific region name. Country or sea names should be chosen from the INSDC country list (http://insdc.org/country.html), or the GAZ ontology (v 1.512) (http://purl.bioontology.org/ontology/GAZ)",
+          "in_subset": [
+            "environment"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "geo_loc_name",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "glucosidase_act": {
+          "name": "glucosidase_act",
+          "aliases": [
+            "glucosidase activity"
+          ],
+          "mappings": [
+            "mixs:glucosidase_act"
+          ],
+          "description": "Measurement of glucosidase activity",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "glucosidase_act",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "heavy_metals": {
+          "name": "heavy_metals",
+          "aliases": [
+            "extreme_unusual_properties/heavy metals"
+          ],
+          "mappings": [
+            "mixs:heavy_metals"
+          ],
+          "description": "Heavy metals present and concentrationsany drug used by subject and the frequency of usage; can include multiple heavy metals and concentrations",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit}",
+          "multivalued": false,
+          "alias": "heavy_metals",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "heavy_metals_meth": {
+          "name": "heavy_metals_meth",
+          "aliases": [
+            "extreme_unusual_properties/heavy metals method"
+          ],
+          "mappings": [
+            "mixs:heavy_metals_meth"
+          ],
+          "description": "Reference or method used in determining heavy metals",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "heavy_metals_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "horizon": {
+          "name": "horizon",
+          "aliases": [
+            "horizon"
+          ],
+          "mappings": [
+            "mixs:horizon"
+          ],
+          "description": "Specific layer in the land area which measures parallel to the soil surface and possesses physical characteristics which differ from the layers above and beneath",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "horizon",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[O horizon|A horizon|E horizon|B horizon|C horizon|R layer|Permafrost]"
+        },
+        "horizon_meth": {
+          "name": "horizon_meth",
+          "aliases": [
+            "horizon method"
+          ],
+          "mappings": [
+            "mixs:horizon_meth"
+          ],
+          "description": "Reference or method used in determining the horizon",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "horizon_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "lat_lon": {
+          "name": "lat_lon",
+          "description": "This is currently a required field but it's not clear if this should be required for human hosts",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {float}",
+          "multivalued": false,
+          "alias": "lat_lon",
+          "owner": "biosample",
+          "range": "geolocation value",
+          "required": false,
+          "pattern": "\\d+[.\\d+] \\d+[.\\d+]"
+        },
+        "link_addit_analys": {
+          "name": "link_addit_analys",
+          "aliases": [
+            "links to additional analysis"
+          ],
+          "mappings": [
+            "mixs:link_addit_analys"
+          ],
+          "description": "Link to additional analysis results performed on the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "link_addit_analys",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "link_class_info": {
+          "name": "link_class_info",
+          "aliases": [
+            "link to classification information"
+          ],
+          "mappings": [
+            "mixs:link_class_info"
+          ],
+          "description": "Link to digitized soil maps or other soil classification information",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "link_class_info",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "link_climate_info": {
+          "name": "link_climate_info",
+          "aliases": [
+            "link to climate information"
+          ],
+          "mappings": [
+            "mixs:link_climate_info"
+          ],
+          "description": "Link to climate resource",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "link_climate_info",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "local_class": {
+          "name": "local_class",
+          "aliases": [
+            "soil_taxonomic/local classification"
+          ],
+          "mappings": [
+            "mixs:local_class"
+          ],
+          "description": "Soil classification based on local soil classification system",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "local_class",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "local_class_meth": {
+          "name": "local_class_meth",
+          "aliases": [
+            "soil_taxonomic/local classification method"
+          ],
+          "mappings": [
+            "mixs:local_class_meth"
+          ],
+          "description": "Reference or method used in determining the local soil classification ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "local_class_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "magnesium": {
+          "name": "magnesium",
+          "aliases": [
+            "magnesium"
+          ],
+          "mappings": [
+            "mixs:magnesium"
+          ],
+          "description": "Concentration of magnesium in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "magnesium",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "mean_frict_vel": {
+          "name": "mean_frict_vel",
+          "aliases": [
+            "mean friction velocity"
+          ],
+          "mappings": [
+            "mixs:mean_frict_vel"
+          ],
+          "description": "Measurement of mean friction velocity",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "mean_frict_vel",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "mean_peak_frict_vel": {
+          "name": "mean_peak_frict_vel",
+          "aliases": [
+            "mean peak friction velocity"
+          ],
+          "mappings": [
+            "mixs:mean_peak_frict_vel"
+          ],
+          "description": "Measurement of mean peak friction velocity",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "mean_peak_frict_vel",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "microbial_biomass": {
+          "name": "microbial_biomass",
+          "aliases": [
+            "microbial biomass"
+          ],
+          "mappings": [
+            "mixs:microbial_biomass"
+          ],
+          "description": "The part of the organic matter in the soil that constitutes living microorganisms smaller than 5-10 micrometer. If you keep this, you would need to have correction factors used for conversion to the final units",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "microbial_biomass",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "microbial_biomass_meth": {
+          "name": "microbial_biomass_meth",
+          "aliases": [
+            "microbial biomass method"
+          ],
+          "mappings": [
+            "mixs:microbial_biomass_meth"
+          ],
+          "description": "Reference or method used in determining microbial biomass",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "microbial_biomass_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "misc_param": {
+          "name": "misc_param",
+          "aliases": [
+            "miscellaneous parameter"
+          ],
+          "mappings": [
+            "mixs:misc_param"
+          ],
+          "description": "Any other measurement performed or parameter collected, that is not listed here",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit}",
+          "multivalued": false,
+          "alias": "misc_param",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "n_alkanes": {
+          "name": "n_alkanes",
+          "aliases": [
+            "n-alkanes"
+          ],
+          "mappings": [
+            "mixs:n_alkanes"
+          ],
+          "description": "Concentration of n-alkanes; can include multiple n-alkanes",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit}",
+          "multivalued": false,
+          "alias": "n_alkanes",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "nitrate": {
+          "name": "nitrate",
+          "aliases": [
+            "nitrate"
+          ],
+          "mappings": [
+            "mixs:nitrate"
+          ],
+          "description": "Concentration of nitrate in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "nitrate",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "nitrite": {
+          "name": "nitrite",
+          "aliases": [
+            "nitrite"
+          ],
+          "mappings": [
+            "mixs:nitrite"
+          ],
+          "description": "Concentration of nitrite in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "nitrite",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "org_matter": {
+          "name": "org_matter",
+          "aliases": [
+            "organic matter"
+          ],
+          "mappings": [
+            "mixs:org_matter"
+          ],
+          "description": "Concentration of organic matter ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "org_matter",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "org_nitro": {
+          "name": "org_nitro",
+          "aliases": [
+            "organic nitrogen"
+          ],
+          "mappings": [
+            "mixs:org_nitro"
+          ],
+          "description": "Concentration of organic nitrogen",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "org_nitro",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "organism_count": {
+          "name": "organism_count",
+          "aliases": [
+            "organism count"
+          ],
+          "mappings": [
+            "mixs:organism_count"
+          ],
+          "description": "Total cell count of any organism (or group of organisms) per gram, volume or area of sample, should include name of organism followed by count. The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should also be provided. (example: total prokaryotes; 3.5e7 cells per ml; qpcr)",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit};[qPCR|ATP|MPN|other]",
+          "multivalued": false,
+          "alias": "organism_count",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "oxy_stat_samp": {
+          "name": "oxy_stat_samp",
+          "aliases": [
+            "oxygenation status of sample"
+          ],
+          "mappings": [
+            "mixs:oxy_stat_samp"
+          ],
+          "description": "Oxygenation status of sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "oxy_stat_samp",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[aerobic|anaerobic|other]"
+        },
+        "part_org_carb": {
+          "name": "part_org_carb",
+          "aliases": [
+            "particulate organic carbon"
+          ],
+          "mappings": [
+            "mixs:part_org_carb"
+          ],
+          "description": "Concentration of particulate organic carbon",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "part_org_carb",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "perturbation": {
+          "name": "perturbation",
+          "aliases": [
+            "perturbation"
+          ],
+          "mappings": [
+            "mixs:perturbation"
+          ],
+          "description": "Type of perturbation, e.g. chemical administration, physical disturbance, etc., coupled with perturbation regimen including how many times the perturbation was repeated, how long each perturbation lasted, and the start and end time of the entire perturbation period; can include multiple perturbation types",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "perturbation",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "petroleum_hydrocarb": {
+          "name": "petroleum_hydrocarb",
+          "aliases": [
+            "petroleum hydrocarbon"
+          ],
+          "mappings": [
+            "mixs:petroleum_hydrocarb"
+          ],
+          "description": "Concentration of petroleum hydrocarbon",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "petroleum_hydrocarb",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "ph": {
+          "name": "ph",
+          "aliases": [
+            "pH"
+          ],
+          "mappings": [
+            "mixs:ph"
+          ],
+          "description": "Ph measurement of the sample, or liquid portion of sample, or aqueous phase of the fluid",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "ph",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+]"
+        },
+        "ph_meth": {
+          "name": "ph_meth",
+          "aliases": [
+            "pH method"
+          ],
+          "mappings": [
+            "mixs:ph_meth"
+          ],
+          "description": "Reference or method used in determining ph",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "ph_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "phaeopigments": {
+          "name": "phaeopigments",
+          "aliases": [
+            "phaeopigments"
+          ],
+          "mappings": [
+            "mixs:phaeopigments"
+          ],
+          "description": "Concentration of phaeopigments; can include multiple phaeopigments",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit}",
+          "multivalued": false,
+          "alias": "phaeopigments",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "phosplipid_fatt_acid": {
+          "name": "phosplipid_fatt_acid",
+          "aliases": [
+            "phospholipid fatty acid"
+          ],
+          "mappings": [
+            "mixs:phosplipid_fatt_acid"
+          ],
+          "description": "Concentration of phospholipid fatty acids; can include multiple values",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{text};{float} {unit}",
+          "multivalued": false,
+          "alias": "phosplipid_fatt_acid",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "pool_dna_extracts": {
+          "name": "pool_dna_extracts",
+          "aliases": [
+            "pooling of DNA extracts (if done)"
+          ],
+          "mappings": [
+            "mixs:pool_dna_extracts"
+          ],
+          "description": "Indicate whether multiple DNA extractions were mixed. If the answer yes, the number of extracts that were pooled should be given",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "pool_dna_extracts",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "potassium": {
+          "name": "potassium",
+          "aliases": [
+            "potassium"
+          ],
+          "mappings": [
+            "mixs:potassium"
+          ],
+          "description": "Concentration of potassium in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "potassium",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "pressure": {
+          "name": "pressure",
+          "aliases": [
+            "pressure"
+          ],
+          "mappings": [
+            "mixs:pressure"
+          ],
+          "description": "Pressure to which the sample is subject to, in atmospheres",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "pressure",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "previous_land_use": {
+          "name": "previous_land_use",
+          "aliases": [
+            "history/previous land use"
+          ],
+          "mappings": [
+            "mixs:previous_land_use"
+          ],
+          "description": "Previous land use and dates",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "previous_land_use",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "previous_land_use_meth": {
+          "name": "previous_land_use_meth",
+          "aliases": [
+            "history/previous land use method"
+          ],
+          "mappings": [
+            "mixs:previous_land_use_meth"
+          ],
+          "description": "Reference or method used in determining previous land use and dates",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "previous_land_use_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "profile_position": {
+          "name": "profile_position",
+          "aliases": [
+            "profile position"
+          ],
+          "mappings": [
+            "mixs:profile_position"
+          ],
+          "description": "Cross-sectional position in the hillslope where sample was collected.sample area position in relation to surrounding areas",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "profile_position",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[summit|shoulder|backslope|footslope|toeslope]"
+        },
+        "redox_potential": {
+          "name": "redox_potential",
+          "aliases": [
+            "redox potential"
+          ],
+          "mappings": [
+            "mixs:redox_potential"
+          ],
+          "description": "Redox potential, measured relative to a hydrogen cell, indicating oxidation or reduction potential",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "redox_potential",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "salinity": {
+          "name": "salinity",
+          "aliases": [
+            "salinity"
+          ],
+          "mappings": [
+            "mixs:salinity"
+          ],
+          "description": "Salinity is the total concentration of all dissolved salts in a water sample. While salinity can be measured by a complete chemical analysis, this method is difficult and time consuming. More often, it is instead derived from the conductivity measurement. This is known as practical salinity. These derivations compare the specific conductance of the sample to a salinity standard such as seawater",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "salinity",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "salinity_meth": {
+          "name": "salinity_meth",
+          "aliases": [
+            "extreme_unusual_properties/salinity method"
+          ],
+          "mappings": [
+            "mixs:salinity_meth"
+          ],
+          "description": "Reference or method used in determining salinity",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "salinity_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "samp_collect_device": {
+          "name": "samp_collect_device",
+          "aliases": [
+            "sample collection device or method"
+          ],
+          "mappings": [
+            "mixs:samp_collect_device"
+          ],
+          "description": "The method or device employed for collecting the sample",
+          "in_subset": [
+            "nucleic acid sequence source"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "samp_collect_device",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "samp_mat_process": {
+          "name": "samp_mat_process",
+          "aliases": [
+            "sample material processing"
+          ],
+          "mappings": [
+            "mixs:samp_mat_process"
+          ],
+          "description": "Any processing applied to the sample during or after retrieving the sample from environment. This field accepts OBI, for a browser of OBI (v 2018-02-12) terms please see http://purl.bioontology.org/ontology/OBI",
+          "in_subset": [
+            "nucleic acid sequence source"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "samp_mat_process",
+          "owner": "biosample",
+          "range": "controlled term value"
+        },
+        "samp_store_dur": {
+          "name": "samp_store_dur",
+          "aliases": [
+            "sample storage duration"
+          ],
+          "mappings": [
+            "mixs:samp_store_dur"
+          ],
+          "description": "Duration for which the sample was stored",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "samp_store_dur",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "samp_store_loc": {
+          "name": "samp_store_loc",
+          "aliases": [
+            "sample storage location"
+          ],
+          "mappings": [
+            "mixs:samp_store_loc"
+          ],
+          "description": "Location at which sample was stored, usually name of a specific freezer/room",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "samp_store_loc",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "samp_store_temp": {
+          "name": "samp_store_temp",
+          "aliases": [
+            "sample storage temperature"
+          ],
+          "mappings": [
+            "mixs:samp_store_temp"
+          ],
+          "description": "Temperature at which sample was stored, e.g. -80 degree Celsius",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "samp_store_temp",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "samp_vol_we_dna_ext": {
+          "name": "samp_vol_we_dna_ext",
+          "aliases": [
+            "sample volume or weight for DNA extraction"
+          ],
+          "mappings": [
+            "mixs:samp_vol_we_dna_ext"
+          ],
+          "description": "Volume (ml), weight (g) of processed sample, or surface area swabbed from sample for DNA extraction",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "samp_vol_we_dna_ext",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "season_temp": {
+          "name": "season_temp",
+          "aliases": [
+            "mean seasonal temperature"
+          ],
+          "mappings": [
+            "mixs:season_temp"
+          ],
+          "description": "Mean seasonal temperature",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "season_temp",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "season_precpt": {
+          "name": "season_precpt",
+          "aliases": [
+            "mean seasonal precipitation"
+          ],
+          "mappings": [
+            "mixs:season_precpt"
+          ],
+          "description": "The average of all seasonal precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "season_precpt",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "sieving": {
+          "name": "sieving",
+          "aliases": [
+            "composite design/sieving (if any)"
+          ],
+          "mappings": [
+            "mixs:sieving"
+          ],
+          "description": "Collection design of pooled samples and/or sieve size and amount of sample sieved ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{{text}|{float} {unit}};{float} {unit}",
+          "multivalued": false,
+          "alias": "sieving",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "size_frac_low": {
+          "name": "size_frac_low",
+          "aliases": [
+            "size-fraction lower threshold"
+          ],
+          "mappings": [
+            "mixs:size_frac_low"
+          ],
+          "description": "Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials larger than the size threshold are excluded from the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "size_frac_low",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "size_frac_up": {
+          "name": "size_frac_up",
+          "aliases": [
+            "size-fraction upper threshold"
+          ],
+          "mappings": [
+            "mixs:size_frac_up"
+          ],
+          "description": "Refers to the mesh/pore size used to retain the sample. Materials smaller than the size threshold are excluded from the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "size_frac_up",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "slope_gradient": {
+          "name": "slope_gradient",
+          "aliases": [
+            "slope gradient"
+          ],
+          "mappings": [
+            "mixs:slope_gradient"
+          ],
+          "description": "Commonly called 'slope'. The angle between ground surface and a horizontal line (in percent). This is the direction that overland water would flow. This measure is usually taken with a hand level meter or clinometer",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "slope_gradient",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "slope_aspect": {
+          "name": "slope_aspect",
+          "aliases": [
+            "slope aspect"
+          ],
+          "mappings": [
+            "mixs:slope_aspect"
+          ],
+          "description": "The direction a slope faces. While looking down a slope use a compass to record the direction you are facing (direction or degrees); e.g., nw or 315 degrees. This measure provides an indication of sun and wind exposure that will influence soil temperature and evapotranspiration.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "slope_aspect",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "sodium": {
+          "name": "sodium",
+          "aliases": [
+            "sodium"
+          ],
+          "mappings": [
+            "mixs:sodium"
+          ],
+          "description": "Sodium concentration in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "sodium",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "soil_type": {
+          "name": "soil_type",
+          "aliases": [
+            "soil type"
+          ],
+          "mappings": [
+            "mixs:soil_type"
+          ],
+          "description": "Soil series name or other lower-level classification",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "soil_type",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "soil_type_meth": {
+          "name": "soil_type_meth",
+          "aliases": [
+            "soil type method"
+          ],
+          "mappings": [
+            "mixs:soil_type_meth"
+          ],
+          "description": "Reference or method used in determining soil series name or other lower-level classification",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "soil_type_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "store_cond": {
+          "name": "store_cond",
+          "aliases": [
+            "storage conditions (fresh/frozen/other)"
+          ],
+          "mappings": [
+            "mixs:store_cond"
+          ],
+          "description": "Explain how and for how long the soil sample was stored before DNA extraction",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "store_cond",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "sulfate": {
+          "name": "sulfate",
+          "aliases": [
+            "sulfate"
+          ],
+          "mappings": [
+            "mixs:sulfate"
+          ],
+          "description": "Concentration of sulfate in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "sulfate",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "sulfide": {
+          "name": "sulfide",
+          "aliases": [
+            "sulfide"
+          ],
+          "mappings": [
+            "mixs:sulfide"
+          ],
+          "description": "Concentration of sulfide in the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "sulfide",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "temp": {
+          "name": "temp",
+          "aliases": [
+            "temperature"
+          ],
+          "mappings": [
+            "mixs:temp"
+          ],
+          "description": "Temperature of the sample at the time of sampling",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "temp",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "texture": {
+          "name": "texture",
+          "aliases": [
+            "texture"
+          ],
+          "mappings": [
+            "mixs:texture"
+          ],
+          "description": "The relative proportion of different grain sizes of mineral particles in a soil, as described using a standard system; express as % sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty clay loam) optional.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "texture",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "texture_meth": {
+          "name": "texture_meth",
+          "aliases": [
+            "texture method"
+          ],
+          "mappings": [
+            "mixs:texture_meth"
+          ],
+          "description": "Reference or method used in determining soil texture",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "texture_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "tillage": {
+          "name": "tillage",
+          "aliases": [
+            "history/tillage"
+          ],
+          "mappings": [
+            "mixs:tillage"
+          ],
+          "description": "Note method(s) used for tilling",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "tillage",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[drill|cutting disc|ridge till|strip tillage|zonal tillage|chisel|tined|mouldboard|disc plough]"
+        },
+        "tidal_stage": {
+          "name": "tidal_stage",
+          "aliases": [
+            "tidal stage"
+          ],
+          "mappings": [
+            "mixs:tidal_stage"
+          ],
+          "description": "Stage of tide",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "tidal_stage",
+          "owner": "biosample",
+          "range": "text value",
+          "pattern": "[low tide|ebb tide|flood tide|high tide]"
+        },
+        "tot_carb": {
+          "name": "tot_carb",
+          "aliases": [
+            "total carbon"
+          ],
+          "mappings": [
+            "mixs:tot_carb"
+          ],
+          "description": "Total carbon content",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "tot_carb",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "tot_depth_water_col": {
+          "name": "tot_depth_water_col",
+          "aliases": [
+            "total depth of water column"
+          ],
+          "mappings": [
+            "mixs:tot_depth_water_col"
+          ],
+          "description": "Measurement of total depth of water column",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "tot_depth_water_col",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "tot_diss_nitro": {
+          "name": "tot_diss_nitro",
+          "aliases": [
+            "total dissolved nitrogen"
+          ],
+          "mappings": [
+            "mixs:tot_diss_nitro"
+          ],
+          "description": "Total dissolved nitrogen concentration, reported as nitrogen, measured by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "tot_diss_nitro",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "tot_org_carb": {
+          "name": "tot_org_carb",
+          "aliases": [
+            "total organic carbon"
+          ],
+          "mappings": [
+            "mixs:tot_org_carb"
+          ],
+          "description": "Definition for soil: total organic carbon content of the soil, definition otherwise: total organic carbon content",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "tot_org_carb",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "tot_org_c_meth": {
+          "name": "tot_org_c_meth",
+          "aliases": [
+            "total organic carbon method"
+          ],
+          "mappings": [
+            "mixs:tot_org_c_meth"
+          ],
+          "description": "Reference or method used in determining total organic carbon",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "tot_org_c_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "tot_nitro_content": {
+          "name": "tot_nitro_content",
+          "aliases": [
+            "total nitrogen content"
+          ],
+          "mappings": [
+            "mixs:tot_nitro_content"
+          ],
+          "description": "Total nitrogen content of the sample",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "tot_nitro_content",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "tot_nitro_content_meth": {
+          "name": "tot_nitro_content_meth",
+          "aliases": [
+            "total nitrogen content method"
+          ],
+          "mappings": [
+            "mixs:tot_nitro_content_meth"
+          ],
+          "description": "Reference or method used in determining the total nitrogen",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "tot_nitro_content_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "tot_phosp": {
+          "name": "tot_phosp",
+          "aliases": [
+            "total phosphorus"
+          ],
+          "mappings": [
+            "mixs:tot_phosp"
+          ],
+          "description": "Total phosphorus concentration in the sample, calculated by: total phosphorus = total dissolved phosphorus + particulate phosphorus",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "tot_phosp",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "water_content": {
+          "name": "water_content",
+          "aliases": [
+            "water content"
+          ],
+          "mappings": [
+            "mixs:water_content"
+          ],
+          "description": "Water content measurement",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "water_content",
+          "owner": "biosample",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "water_content_soil_meth": {
+          "name": "water_content_soil_meth",
+          "aliases": [
+            "water content method"
+          ],
+          "mappings": [
+            "mixs:water_content_soil_meth"
+          ],
+          "description": "Reference or method used in determining the water content of soil",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "water_content_soil_meth",
+          "owner": "biosample",
+          "range": "text value"
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "description": "An ecosystem is a combination of a physical environment (abiotic factors) and all the organisms (biotic factors) that interact with this environment. Ecosystem is in position 1/5 in a GOLD path.",
+          "comments": [
+            "The abiotic factors play a profound role on the type and composition of organisms in a given environment. The GOLD Ecosystem at the top of the five-level classification system is aimed at capturing the broader environment from which an organism or environmental sample is collected. The three broad groups under Ecosystem are Environmental, Host-associated, and Engineered. They represent samples collected from a natural environment or from another organism or from engineered environments like bioreactors respectively."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "ecosystem_category": {
+          "name": "ecosystem_category",
+          "description": "Ecosystem categories represent divisions within the ecosystem based on specific characteristics of the environment from where an organism or sample is isolated. Ecosystem category is in position 2/5 in a GOLD path.",
+          "comments": [
+            "The Environmental ecosystem (for example) is divided into Air, Aquatic and Terrestrial. Ecosystem categories for Host-associated samples can be individual hosts or phyla and for engineered samples it may be manipulated environments like bioreactors, solid waste etc."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem_category",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "ecosystem_type": {
+          "name": "ecosystem_type",
+          "description": "Ecosystem types represent things having common characteristics within the Ecosystem Category. These common characteristics based grouping is still broad but specific to the characteristics of a given environment. Ecosystem type is in position 3/5 in a GOLD path.",
+          "comments": [
+            "The Aquatic ecosystem category (for example) may have ecosystem types like Marine or Thermal springs etc. Ecosystem category Air may have Indoor air or Outdoor air as different Ecosystem Types. In the case of Host-associated samples, ecosystem type can represent Respiratory system, Digestive system, Roots etc."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem_type",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "ecosystem_subtype": {
+          "name": "ecosystem_subtype",
+          "description": "Ecosystem subtypes represent further subdivision of Ecosystem types into more distinct subtypes. Ecosystem subtype is in position 4/5 in a GOLD path.",
+          "comments": [
+            "Ecosystem Type Marine (Environmental -> Aquatic -> Marine) is further divided (for example) into Intertidal zone, Coastal, Pelagic, Intertidal zone etc. in the Ecosystem subtype category."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem_subtype",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "specific_ecosystem": {
+          "name": "specific_ecosystem",
+          "description": "Specific ecosystems represent specific features of the environment like aphotic zone in an ocean or gastric mucosa within a host digestive system. Specific ecosystem is in position 5/5 in a GOLD path.",
+          "comments": [
+            "Specific ecosystems help to define samples based on very specific characteristics of an environment under the five-level classification system."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "specific_ecosystem",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "add_date": {
+          "name": "add_date",
+          "description": "The date on which the information was added to the database.",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "add_date",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "community": {
+          "name": "community",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "community",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "depth2": {
+          "name": "depth2",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "depth2",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "habitat": {
+          "name": "habitat",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "habitat",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "host_name": {
+          "name": "host_name",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "host_name",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "identifier": {
+          "name": "identifier",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "identifier",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "location": {
+          "name": "location",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "location",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "mod_date": {
+          "name": "mod_date",
+          "description": "The last date on which the database information was modified.",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "mod_date",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "ncbi_taxonomy_name": {
+          "name": "ncbi_taxonomy_name",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ncbi_taxonomy_name",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "proport_woa_temperature": {
+          "name": "proport_woa_temperature",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "proport_woa_temperature",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "salinity_category": {
+          "name": "salinity_category",
+          "description": "Categorcial description of the sample's salinity. Examples: halophile, halotolerant, hypersaline, huryhaline",
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://github.com/microbiomedata/nmdc-metadata/pull/297"
+          ],
+          "alias": "salinity_category",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "sample_collection_site": {
+          "name": "sample_collection_site",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "sample_collection_site",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "soluble_iron_micromol": {
+          "name": "soluble_iron_micromol",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "soluble_iron_micromol",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "subsurface_depth": {
+          "name": "subsurface_depth",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "subsurface_depth",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "subsurface_depth2": {
+          "name": "subsurface_depth2",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "subsurface_depth2",
+          "owner": "biosample",
+          "range": "quantity value"
+        },
+        "GOLD sample identifiers": {
+          "name": "GOLD sample identifiers",
+          "description": "identifiers for corresponding sample in GOLD",
+          "examples": [
+            {
+              "value": "https://identifiers.org/gold:Gb0312930"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "sample identifiers",
+          "mixins": [
+            "GOLD identifiers"
+          ],
+          "multivalued": true,
+          "alias": "GOLD_sample_identifiers",
+          "owner": "biosample",
+          "range": "external identifier",
+          "pattern": "^GOLD:Gb[0-9]+$"
+        },
+        "INSDC biosample identifiers": {
+          "name": "INSDC biosample identifiers",
+          "aliases": [
+            "EBI biosample identifiers",
+            "NCBI biosample identifiers",
+            "DDBJ biosample identifiers"
+          ],
+          "description": "identifiers for corresponding sample in INSDC",
+          "examples": [
+            {
+              "value": "https://identifiers.org/biosample:SAMEA5989477"
+            },
+            {
+              "value": "https://identifiers.org/biosample:SAMD00212331",
+              "description": "I13_N_5-10 sample from Soil fungal diversity along elevational gradients"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://github.com/bioregistry/bioregistry/issues/108",
+            "https://www.ebi.ac.uk/biosamples/",
+            "https://www.ncbi.nlm.nih.gov/biosample",
+            "https://www.ddbj.nig.ac.jp/biosample/index-e.html"
+          ],
+          "is_a": "sample identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "multivalued": true,
+          "alias": "INSDC_biosample_identifiers",
+          "owner": "biosample",
+          "range": "external identifier",
+          "pattern": "^biosample:SAM[NED]([A-Z])?[0-9]+$"
+        },
+        "INSDC secondary sample identifiers": {
+          "name": "INSDC secondary sample identifiers",
+          "description": "secondary identifiers for corresponding sample in INSDC",
+          "comments": [
+            "ENA redirects these to primary IDs, e.g. https://www.ebi.ac.uk/ena/browser/view/DRS166340 -> SAMD00212331",
+            "MGnify uses these as their primary sample IDs"
+          ],
+          "examples": [
+            {
+              "value": "https://identifiers.org/insdc.sra:DRS166340",
+              "description": "I13_N_5-10 sample from Soil fungal diversity along elevational gradients"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "sample identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "multivalued": true,
+          "alias": "INSDC_secondary_sample_identifiers",
+          "owner": "biosample",
+          "range": "external identifier",
+          "pattern": "^biosample:(E|D|S)RS[0-9]{6,}$"
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "biosample",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "biosample",
+          "range": "string"
+        }
+      }
+    },
+    "study": {
+      "name": "study",
+      "id_prefixes": [
+        "GOLD",
+        "insdc.srs",
+        "mgnify"
+      ],
+      "aliases": [
+        "proposal",
+        "research proposal",
+        "research study",
+        "investigation",
+        "project",
+        "umbrella project"
+      ],
+      "exact_mappings": [
+        "SIO:001066",
+        "NCIT:C63536",
+        "OBI:0000066",
+        "ISA:Study"
+      ],
+      "close_mappings": [
+        "NCIT:C41198",
+        "ISA:Investigation"
+      ],
+      "broad_mappings": [
+        "prov:Activity"
+      ],
+      "description": "A study summarizes the overall goal of a research initiative and outlines the key objective of its underlying projects.  ",
+      "alt_descriptions": {
+        "embl.ena": {
+          "source": "embl.ena",
+          "description": "A study (project) groups together data submitted to the archive and controls its release date. A study accession is typically used when citing data submitted to ENA"
+        }
+      },
+      "todos": [
+        "determine how to get data values for submitted_to_insdc, investigation_type, experimental_factor",
+        "project_name is redundant with name, so excluding it"
+      ],
+      "in_subset": [
+        "sample subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "slots": [
+        "ecosystem",
+        "ecosystem_category",
+        "ecosystem_type",
+        "ecosystem_subtype",
+        "specific_ecosystem",
+        "principal investigator",
+        "doi",
+        "title",
+        "alternative titles",
+        "alternative descriptions",
+        "alternative names",
+        "abstract",
+        "objective",
+        "websites",
+        "publications",
+        "ess dive datasets",
+        "type",
+        "relevant protocols",
+        "funding sources",
+        "INSDC bioproject identifiers",
+        "INSDC SRA ENA study identifiers",
+        "GOLD study identifiers",
+        "MGnify project identifiers",
+        "has credit associations",
+        "study image"
+      ],
+      "slot_usage": {
+        "doi": {
+          "name": "doi",
+          "description": "The dataset citation for this study"
+        }
+      },
+      "attributes": {
+        "ecosystem": {
+          "name": "ecosystem",
+          "description": "An ecosystem is a combination of a physical environment (abiotic factors) and all the organisms (biotic factors) that interact with this environment. Ecosystem is in position 1/5 in a GOLD path.",
+          "comments": [
+            "The abiotic factors play a profound role on the type and composition of organisms in a given environment. The GOLD Ecosystem at the top of the five-level classification system is aimed at capturing the broader environment from which an organism or environmental sample is collected. The three broad groups under Ecosystem are Environmental, Host-associated, and Engineered. They represent samples collected from a natural environment or from another organism or from engineered environments like bioreactors respectively."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem",
+          "owner": "study",
+          "range": "string"
+        },
+        "ecosystem_category": {
+          "name": "ecosystem_category",
+          "description": "Ecosystem categories represent divisions within the ecosystem based on specific characteristics of the environment from where an organism or sample is isolated. Ecosystem category is in position 2/5 in a GOLD path.",
+          "comments": [
+            "The Environmental ecosystem (for example) is divided into Air, Aquatic and Terrestrial. Ecosystem categories for Host-associated samples can be individual hosts or phyla and for engineered samples it may be manipulated environments like bioreactors, solid waste etc."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem_category",
+          "owner": "study",
+          "range": "string"
+        },
+        "ecosystem_type": {
+          "name": "ecosystem_type",
+          "description": "Ecosystem types represent things having common characteristics within the Ecosystem Category. These common characteristics based grouping is still broad but specific to the characteristics of a given environment. Ecosystem type is in position 3/5 in a GOLD path.",
+          "comments": [
+            "The Aquatic ecosystem category (for example) may have ecosystem types like Marine or Thermal springs etc. Ecosystem category Air may have Indoor air or Outdoor air as different Ecosystem Types. In the case of Host-associated samples, ecosystem type can represent Respiratory system, Digestive system, Roots etc."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem_type",
+          "owner": "study",
+          "range": "string"
+        },
+        "ecosystem_subtype": {
+          "name": "ecosystem_subtype",
+          "description": "Ecosystem subtypes represent further subdivision of Ecosystem types into more distinct subtypes. Ecosystem subtype is in position 4/5 in a GOLD path.",
+          "comments": [
+            "Ecosystem Type Marine (Environmental -> Aquatic -> Marine) is further divided (for example) into Intertidal zone, Coastal, Pelagic, Intertidal zone etc. in the Ecosystem subtype category."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "ecosystem_subtype",
+          "owner": "study",
+          "range": "string"
+        },
+        "specific_ecosystem": {
+          "name": "specific_ecosystem",
+          "description": "Specific ecosystems represent specific features of the environment like aphotic zone in an ocean or gastric mucosa within a host digestive system. Specific ecosystem is in position 5/5 in a GOLD path.",
+          "comments": [
+            "Specific ecosystems help to define samples based on very specific characteristics of an environment under the five-level classification system."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/help"
+          ],
+          "is_a": "gold_path_field",
+          "alias": "specific_ecosystem",
+          "owner": "study",
+          "range": "string"
+        },
+        "principal investigator": {
+          "name": "principal investigator",
+          "aliases": [
+            "PI"
+          ],
+          "description": "Principal Investigator who led the study and/or generated the dataset.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "principal_investigator",
+          "owner": "study",
+          "range": "person value"
+        },
+        "doi": {
+          "name": "doi",
+          "description": "The dataset citation for this study",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "doi",
+          "owner": "study",
+          "range": "attribute value"
+        },
+        "title": {
+          "name": "title",
+          "exact_mappings": [
+            "dcterms:title"
+          ],
+          "description": "A name given to the entity that differs from the name/label programatically assigned to it. For example, when extracting study information for GOLD, the GOLD system has assigned a name/label. However, for display purposes, we may also wish the capture the title of the proposal that was used to fund the study.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "title",
+          "owner": "study",
+          "range": "string"
+        },
+        "alternative titles": {
+          "name": "alternative titles",
+          "exact_mappings": [
+            "dcterms:alternative"
+          ],
+          "description": "A list of alternative titles for the entity. The distinction between title and alternative titles is application-specific.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_titles",
+          "owner": "study",
+          "range": "string"
+        },
+        "alternative descriptions": {
+          "name": "alternative descriptions",
+          "description": "A list of alternative descriptions for the entity. The distinction between desciption and alternative descriptions is application-specific.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_descriptions",
+          "owner": "study",
+          "range": "string"
+        },
+        "alternative names": {
+          "name": "alternative names",
+          "exact_mappings": [
+            "dcterms:alternative",
+            "skos:altLabel"
+          ],
+          "description": "A list of alternative names used to refer to the entity. The distinction between name and alternative names is application-specific.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_names",
+          "owner": "study",
+          "range": "string"
+        },
+        "abstract": {
+          "name": "abstract",
+          "exact_mappings": [
+            "dcterms:abstract"
+          ],
+          "description": "The abstract of manuscript/grant associated with the entity; i.e., a summary of the resource.",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "abstract",
+          "owner": "study",
+          "range": "string"
+        },
+        "objective": {
+          "name": "objective",
+          "mappings": [
+            "sio:000337"
+          ],
+          "description": "The scientific objectives associated with the entity. It SHOULD correspond to scientific norms for objectives field in a structured abstract.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "objective",
+          "owner": "study",
+          "range": "string"
+        },
+        "websites": {
+          "name": "websites",
+          "description": "A list of websites that are assocatiated with the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "websites",
+          "owner": "study",
+          "range": "string"
+        },
+        "publications": {
+          "name": "publications",
+          "description": "A list of publications that are assocatiated with the entity. The publicatons SHOULD be given using an identifier, such as a DOI or Pubmed ID, if possible.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "publications",
+          "owner": "study",
+          "range": "string"
+        },
+        "ess dive datasets": {
+          "name": "ess dive datasets",
+          "description": "List of ESS-DIVE dataset DOIs",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "ess_dive_datasets",
+          "owner": "study",
+          "range": "string"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "examples": [
+            {
+              "value": "nmdc:Biosample"
+            },
+            {
+              "value": "nmdc:Study"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "study",
+          "range": "string"
+        },
+        "relevant protocols": {
+          "name": "relevant protocols",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "relevant_protocols",
+          "owner": "study",
+          "range": "string"
+        },
+        "funding sources": {
+          "name": "funding sources",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "funding_sources",
+          "owner": "study",
+          "range": "string"
+        },
+        "INSDC bioproject identifiers": {
+          "name": "INSDC bioproject identifiers",
+          "aliases": [
+            "NCBI bioproject identifiers",
+            "DDBJ bioproject identifiers"
+          ],
+          "description": "identifiers for corresponding project in INSDC Bioproject",
+          "comments": [
+            "these are distinct IDs from INSDC SRA/ENA project identifiers, but are usually(?) one to one"
+          ],
+          "examples": [
+            {
+              "value": "https://identifiers.org/bioproject:PRJNA366857",
+              "description": "Avena fatua rhizosphere microbial communities - H1_Rhizo_Litter_2 metatranscriptome"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://www.ncbi.nlm.nih.gov/bioproject/",
+            "https://www.ddbj.nig.ac.jp/bioproject/index-e.html"
+          ],
+          "is_a": "study identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "multivalued": true,
+          "alias": "INSDC_bioproject_identifiers",
+          "owner": "study",
+          "range": "external identifier",
+          "pattern": "^bioproject:PRJ[DEN][A-Z][0-9]+$"
+        },
+        "INSDC SRA ENA study identifiers": {
+          "name": "INSDC SRA ENA study identifiers",
+          "aliases": [
+            "EBI ENA study identifiers",
+            "NCBI SRA identifiers",
+            "DDBJ SRA identifiers"
+          ],
+          "description": "identifiers for corresponding project in INSDC SRA / ENA",
+          "examples": [
+            {
+              "value": "https://identifiers.org/insdc.sra:SRP121659",
+              "description": "Avena fatua rhizosphere microbial communities - H1_Rhizo_Litter_2 metatranscriptome"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://github.com/bioregistry/bioregistry/issues/109",
+            "https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies",
+            "https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?view=studies"
+          ],
+          "is_a": "study identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "multivalued": true,
+          "alias": "INSDC_SRA_ENA_study_identifiers",
+          "owner": "study",
+          "range": "external identifier",
+          "pattern": "^insdc.sra:(E|D|S)RP[0-9]{6,}$"
+        },
+        "GOLD study identifiers": {
+          "name": "GOLD study identifiers",
+          "description": "identifiers for corresponding project in GOLD",
+          "examples": [
+            {
+              "value": "https://identifiers.org/gold:Gs0110115"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "see_also": [
+            "https://gold.jgi.doe.gov/studies"
+          ],
+          "is_a": "study identifiers",
+          "mixins": [
+            "GOLD identifiers"
+          ],
+          "multivalued": true,
+          "alias": "GOLD_study_identifiers",
+          "owner": "study",
+          "range": "external identifier",
+          "pattern": "^GOLD:Gs[0-9]+$"
+        },
+        "MGnify project identifiers": {
+          "name": "MGnify project identifiers",
+          "description": "identifiers for corresponding project in MGnify",
+          "examples": [
+            {
+              "value": "https://identifiers.org/mgnify.proj:MGYS00005757"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "study identifiers",
+          "multivalued": true,
+          "alias": "MGnify_project_identifiers",
+          "owner": "study",
+          "range": "external identifier",
+          "pattern": "^mgnify.proj:[A-Z]+[0-9]+$"
+        },
+        "has credit associations": {
+          "name": "has credit associations",
+          "description": "This slot links a study to a credit association.  The credit association will be linked to a person value and to a CRediT Contributor Roles term. Overall semantics: person should get credit X for their participation in the study",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "study",
+          "slot_uri": "prov:qualifiedAssociation",
+          "multivalued": true,
+          "inlined": true,
+          "alias": "has_credit_associations",
+          "owner": "study",
+          "range": "credit association"
+        },
+        "study image": {
+          "name": "study image",
+          "description": "Links a study to one or more images.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "study",
+          "multivalued": true,
+          "inlined": true,
+          "alias": "study_image",
+          "owner": "study",
+          "range": "image value"
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "study",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "study",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "study",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "study",
+          "range": "string"
+        }
+      }
+    },
+    "biosample processing": {
+      "name": "biosample processing",
+      "aliases": [
+        "material processing"
+      ],
+      "broad_mappings": [
+        "OBI:0000094"
+      ],
+      "description": "A process that takes one or more biosamples as inputs and generates one or as outputs. Examples of outputs include samples cultivated from another sample or data objects created by instruments runs.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "slots": [
+        "has input"
+      ],
+      "slot_usage": {
+        "has input": {
+          "name": "has input",
+          "range": "biosample"
+        }
+      },
+      "attributes": {
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "biosample processing",
+          "range": "biosample"
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "biosample processing",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "biosample processing",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "biosample processing",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "biosample processing",
+          "range": "string"
+        }
+      }
+    },
+    "omics processing": {
+      "name": "omics processing",
+      "aliases": [
+        "omics assay",
+        "sequencing project",
+        "experiment"
+      ],
+      "broad_mappings": [
+        "OBI:0000070",
+        "ISA:Assay"
+      ],
+      "description": "The methods and processes used to generate omics data from a biosample or organism.",
+      "alt_descriptions": {
+        "embl.ena": {
+          "source": "embl.ena",
+          "description": "An experiment contains information about a sequencing experiment including library and instrument details."
+        }
+      },
+      "comments": [
+        "The IDs for objects coming from GOLD will have prefixes gold:GpNNNN"
+      ],
+      "in_subset": [
+        "sample subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "biosample processing",
+      "slots": [
+        "add_date",
+        "mod_date",
+        "has input",
+        "has output",
+        "instrument_name",
+        "ncbi_project_name",
+        "omics type",
+        "part of",
+        "principal investigator",
+        "processing_institution",
+        "type",
+        "GOLD sequencing project identifiers",
+        "INSDC experiment identifiers",
+        "samp_vol_we_dna_ext",
+        "nucl_acid_ext",
+        "nucl_acid_amp",
+        "target_gene",
+        "target_subfragment",
+        "pcr_primers",
+        "pcr_cond",
+        "seq_meth",
+        "seq_quality_check",
+        "chimera_check"
+      ],
+      "slot_usage": {
+        "has input": {
+          "name": "has input",
+          "required": true
+        }
+      },
+      "attributes": {
+        "add_date": {
+          "name": "add_date",
+          "description": "The date on which the information was added to the database.",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "add_date",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "mod_date": {
+          "name": "mod_date",
+          "description": "The last date on which the database information was modified.",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "mod_date",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "omics processing",
+          "range": "biosample",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "aliases": [
+            "output"
+          ],
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "omics processing",
+          "range": "named thing"
+        },
+        "instrument_name": {
+          "name": "instrument_name",
+          "description": "The name of the instrument that was used for processing the sample.\n   ",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "instrument_name",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "ncbi_project_name": {
+          "name": "ncbi_project_name",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ncbi_project_name",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "omics type": {
+          "name": "omics type",
+          "description": "The type of omics data",
+          "examples": [
+            {
+              "value": "metatranscriptome"
+            },
+            {
+              "value": "metagenome"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "omics_type",
+          "owner": "omics processing",
+          "range": "controlled term value"
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "omics processing",
+          "range": "named thing"
+        },
+        "principal investigator": {
+          "name": "principal investigator",
+          "aliases": [
+            "PI"
+          ],
+          "description": "Principal Investigator who led the study and/or generated the dataset.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "principal_investigator",
+          "owner": "omics processing",
+          "range": "person value"
+        },
+        "processing_institution": {
+          "name": "processing_institution",
+          "description": "The organization that processed the sample.",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "processing_institution",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "examples": [
+            {
+              "value": "nmdc:Biosample"
+            },
+            {
+              "value": "nmdc:Study"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "GOLD sequencing project identifiers": {
+          "name": "GOLD sequencing project identifiers",
+          "description": "identifiers for corresponding sequencing project in GOLD",
+          "examples": [
+            {
+              "value": "https://identifiers.org/gold:Gp0108335"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "external database identifiers",
+          "mixins": [
+            "GOLD identifiers"
+          ],
+          "multivalued": true,
+          "alias": "GOLD_sequencing_project_identifiers",
+          "owner": "omics processing",
+          "range": "external identifier",
+          "pattern": "^GOLD:Gp[0-9]+$"
+        },
+        "INSDC experiment identifiers": {
+          "name": "INSDC experiment identifiers",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "external database identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "multivalued": true,
+          "alias": "INSDC_experiment_identifiers",
+          "owner": "omics processing",
+          "range": "external identifier",
+          "pattern": "^insdc.sra:(E|D|S)RX[0-9]{6,}$"
+        },
+        "samp_vol_we_dna_ext": {
+          "name": "samp_vol_we_dna_ext",
+          "aliases": [
+            "sample volume or weight for DNA extraction"
+          ],
+          "mappings": [
+            "mixs:samp_vol_we_dna_ext"
+          ],
+          "description": "Volume (ml), weight (g) of processed sample, or surface area swabbed from sample for DNA extraction",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "string_serialization": "{float} {unit}",
+          "multivalued": false,
+          "alias": "samp_vol_we_dna_ext",
+          "owner": "omics processing",
+          "range": "quantity value",
+          "pattern": "\\d+[.\\d+] \\S+"
+        },
+        "nucl_acid_ext": {
+          "name": "nucl_acid_ext",
+          "aliases": [
+            "nucleic acid extraction"
+          ],
+          "mappings": [
+            "mixs:nucl_acid_ext"
+          ],
+          "description": "A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the material separation to recover the nucleic acid fraction from a sample",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "nucl_acid_ext",
+          "owner": "omics processing",
+          "range": "text value"
+        },
+        "nucl_acid_amp": {
+          "name": "nucl_acid_amp",
+          "aliases": [
+            "nucleic acid amplification"
+          ],
+          "mappings": [
+            "mixs:nucl_acid_amp"
+          ],
+          "description": "A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the enzymatic amplification (PCR, TMA, NASBA) of specific nucleic acids",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "nucl_acid_amp",
+          "owner": "omics processing",
+          "range": "text value"
+        },
+        "target_gene": {
+          "name": "target_gene",
+          "aliases": [
+            "target gene"
+          ],
+          "mappings": [
+            "mixs:target_gene"
+          ],
+          "description": "Targeted gene or locus name for marker gene studies",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "target_gene",
+          "owner": "omics processing",
+          "range": "text value"
+        },
+        "target_subfragment": {
+          "name": "target_subfragment",
+          "aliases": [
+            "target subfragment"
+          ],
+          "mappings": [
+            "mixs:target_subfragment"
+          ],
+          "description": "Name of subfragment of a gene or locus. Important to e.g. identify special regions on marker genes like V6 on 16S rRNA",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "target_subfragment",
+          "owner": "omics processing",
+          "range": "text value"
+        },
+        "pcr_primers": {
+          "name": "pcr_primers",
+          "aliases": [
+            "pcr primers"
+          ],
+          "mappings": [
+            "mixs:pcr_primers"
+          ],
+          "description": "PCR primers that were used to amplify the sequence of the targeted gene, locus or subfragment. This field should contain all the primers used for a single PCR reaction if multiple forward or reverse primers are present in a single PCR reaction. The primer sequence should be reported in uppercase letters",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "pcr_primers",
+          "owner": "omics processing",
+          "range": "text value"
+        },
+        "pcr_cond": {
+          "name": "pcr_cond",
+          "aliases": [
+            "pcr conditions"
+          ],
+          "mappings": [
+            "mixs:pcr_cond"
+          ],
+          "description": "Description of reaction conditions and components of PCR in the form of  'initial denaturation:94degC_1.5min; annealing=...'",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "pcr_cond",
+          "owner": "omics processing",
+          "range": "text value",
+          "pattern": "initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles"
+        },
+        "seq_meth": {
+          "name": "seq_meth",
+          "aliases": [
+            "sequencing method"
+          ],
+          "mappings": [
+            "mixs:seq_meth"
+          ],
+          "description": "Sequencing method used; e.g. Sanger, pyrosequencing, ABI-solid",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "seq_meth",
+          "owner": "omics processing",
+          "range": "text value",
+          "pattern": "[MinION|GridION|PromethION|454 GS|454 GS 20|454 GS FLX|454 GS FLX+|454 GS FLX Titanium|454 GS Junior|Illumina Genome Analyzer|Illumina Genome Analyzer II|Illumina Genome Analyzer IIx|Illumina HiSeq 4000|Illumina HiSeq 3000|Illumina HiSeq 2500|Illumina HiSeq 2000|Illumina HiSeq 1500|Illumina HiSeq 1000|Illumina HiScanSQ|Illumina MiSeq|Illumina HiSeq X Five|Illumina HiSeq X Ten|Illumina NextSeq 500|Illumina NextSeq 550|AB SOLiD System|AB SOLiD System 2.0|AB SOLiD System 3.0|AB SOLiD 3 Plus System|AB SOLiD 4 System|AB SOLiD 4hq System|AB SOLiD PI System|AB 5500 Genetic Analyzer|AB 5500xl Genetic Analyzer|AB 5500xl\\-W Genetic Analysis System|Ion Torrent PGM|Ion Torrent Proton|Ion Torrent S5|Ion Torrent S5 XL|PacBio RS|PacBio RS II|Sequel|AB 3730xL Genetic Analyzer|AB 3730 Genetic Analyzer|AB 3500xL Genetic Analyzer|AB 3500 Genetic Analyzer|AB 3130xL Genetic Analyzer|AB 3130 Genetic Analyzer|AB 310 Genetic Analyzer|BGISEQ\\-500]"
+        },
+        "seq_quality_check": {
+          "name": "seq_quality_check",
+          "aliases": [
+            "sequence quality check"
+          ],
+          "mappings": [
+            "mixs:seq_quality_check"
+          ],
+          "description": "Indicate if the sequence has been called by automatic systems (none) or undergone a manual editing procedure (e.g. by inspecting the raw data or chromatograms). Applied only for sequences that are not submitted to SRA,ENA or DRA",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "seq_quality_check",
+          "owner": "omics processing",
+          "range": "text value",
+          "pattern": "[none|manually edited]"
+        },
+        "chimera_check": {
+          "name": "chimera_check",
+          "aliases": [
+            "chimera check"
+          ],
+          "mappings": [
+            "mixs:chimera_check"
+          ],
+          "description": "A chimeric sequence, or chimera for short, is a sequence comprised of two or more phylogenetically distinct parent sequences. Chimeras are usually PCR artifacts thought to occur when a prematurely terminated amplicon reanneals to a foreign DNA strand and is copied to completion in the following PCR cycles. The point at which the chimeric sequence changes from one parent to the next is called the breakpoint or conversion point",
+          "in_subset": [
+            "sequencing"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "multivalued": false,
+          "alias": "chimera_check",
+          "owner": "omics processing",
+          "range": "text value"
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "omics processing",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "omics processing",
+          "range": "string"
+        }
+      }
+    },
+    "credit association": {
+      "name": "credit association",
+      "aliases": [
+        "study role",
+        "credit table",
+        "associated researchers"
+      ],
+      "description": "This class supports binding associated researchers to studies. There will be at least a slot for a CRediT Contributor Role (https://casrai.org/credit/) and for a person value Specifically see the associated researchers tab on the NMDC_SampleMetadata-V4_CommentsForUpdates at https://docs.google.com/spreadsheets/d/1INlBo5eoqn2efn4H2P2i8rwRBtnbDVTqXrochJEAPko/edit#gid=0 ",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "applies to person",
+        "applied role",
+        "applied roles",
+        "type"
+      ],
+      "attributes": {
+        "applies to person": {
+          "name": "applies to person",
+          "todos": [
+            "prov:agent takes an Agent object. Is a person value an Agent? Also try to relate to principal investigator slot? could include OBI:0000103 principal investigator role... do we need to define the OBI prefix?"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "credit association",
+          "slot_uri": "prov:agent",
+          "multivalued": false,
+          "alias": "applies_to_person",
+          "owner": "credit association",
+          "range": "person value",
+          "required": true
+        },
+        "applied role": {
+          "name": "applied role",
+          "deprecated": "A credit association may have multiple roles. So, use the applied roles slot.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "credit association",
+          "slot_uri": "prov:hadRole",
+          "multivalued": false,
+          "alias": "applied_role",
+          "owner": "credit association",
+          "range": "credit enum",
+          "required": false
+        },
+        "applied roles": {
+          "name": "applied roles",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "credit association",
+          "multivalued": true,
+          "alias": "applied_roles",
+          "owner": "credit association",
+          "range": "credit enum",
+          "required": true
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "examples": [
+            {
+              "value": "nmdc:Biosample"
+            },
+            {
+              "value": "nmdc:Study"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "credit association",
+          "range": "string"
+        }
+      },
+      "class_uri": "prov:Association"
+    },
+    "named thing": {
+      "name": "named thing",
+      "description": "a databased entity or concept/class",
+      "from_schema": "https://microbiomedata/schema",
+      "abstract": true,
+      "slots": [
+        "id",
+        "name",
+        "description",
+        "alternative identifiers"
+      ],
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "named thing",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "named thing",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "named thing",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "named thing",
+          "range": "string"
+        }
+      }
+    },
+    "ontology class": {
+      "name": "ontology class",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "ontology class",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "ontology class",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "ontology class",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "ontology class",
+          "range": "string"
+        }
+      }
+    },
+    "environmental material term": {
+      "name": "environmental material term",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "ontology class",
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "environmental material term",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "environmental material term",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "environmental material term",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "environmental material term",
+          "range": "string"
+        }
+      }
+    },
+    "attribute value": {
+      "name": "attribute value",
+      "description": "The value for any value of a attribute for a sample. This object can hold both the un-normalized atomic value and the structured value",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "has raw value",
+        "was generated by"
+      ],
+      "slot_usage": {
+        "type": {
+          "name": "type",
+          "description": "An optional string that specified the type of object.",
+          "required": false
+        }
+      },
+      "attributes": {
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "attribute value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "attribute value",
+          "range": "activity"
+        }
+      }
+    },
+    "quantity value": {
+      "name": "quantity value",
+      "mappings": [
+        "schema:QuantityValue"
+      ],
+      "description": "A simple quantity, e.g. 2cm",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "has unit",
+        "has numeric value",
+        "has minimum numeric value",
+        "has maximum numeric value"
+      ],
+      "slot_usage": {
+        "has raw value": {
+          "name": "has raw value",
+          "description": "Unnormalized atomic string representation, should in syntax {number} {unit}"
+        },
+        "has unit": {
+          "name": "has unit",
+          "description": "The unit of the quantity"
+        },
+        "has numeric value": {
+          "name": "has numeric value",
+          "description": "The number part of the quantity",
+          "range": "double"
+        }
+      },
+      "attributes": {
+        "has unit": {
+          "name": "has unit",
+          "description": "The unit of the quantity",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "has_unit",
+          "owner": "quantity value",
+          "range": "unit"
+        },
+        "has numeric value": {
+          "name": "has numeric value",
+          "description": "The number part of the quantity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "has_numeric_value",
+          "owner": "quantity value",
+          "range": "double"
+        },
+        "has minimum numeric value": {
+          "name": "has minimum numeric value",
+          "description": "The minimum value part, expressed as number, of the quantity value when the value covers a range.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "has numeric value",
+          "alias": "has_minimum_numeric_value",
+          "owner": "quantity value",
+          "range": "float"
+        },
+        "has maximum numeric value": {
+          "name": "has maximum numeric value",
+          "description": "The maximum value part, expressed as number, of the quantity value when the value covers a range.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "has numeric value",
+          "alias": "has_maximum_numeric_value",
+          "owner": "quantity value",
+          "range": "float"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "Unnormalized atomic string representation, should in syntax {number} {unit}",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "quantity value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "quantity value",
+          "range": "activity"
+        }
+      }
+    },
+    "image value": {
+      "name": "image value",
+      "description": "An attribute value representing an image.",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "url",
+        "description",
+        "display order"
+      ],
+      "attributes": {
+        "url": {
+          "name": "url",
+          "notes": [
+            "See issue 207 - this clashes with the mixs field"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "url",
+          "owner": "image value",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "image value",
+          "range": "string"
+        },
+        "display order": {
+          "name": "display order",
+          "description": "When rendering information, this attribute to specify the order in which the information should be rendered.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "display_order",
+          "owner": "image value",
+          "range": "string"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "image value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "image value",
+          "range": "activity"
+        }
+      }
+    },
+    "person value": {
+      "name": "person value",
+      "description": "An attribute value representing a person",
+      "todos": [
+        "add additional fields e.g for institution",
+        "deprecate \"has raw value\" in favor of \"name\""
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "orcid",
+        "profile image url",
+        "email",
+        "name",
+        "websites"
+      ],
+      "slot_usage": {
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The full name of the Investgator in format FIRST LAST.",
+          "notes": [
+            "May eventually be deprecated in favor of \"name\"."
+          ]
+        },
+        "name": {
+          "name": "name",
+          "description": "The full name of the Investgator. It should follow the format FIRST [MIDDLE NAME| MIDDLE INITIAL] LAST, where MIDDLE NAME| MIDDLE INITIAL is optional."
+        }
+      },
+      "attributes": {
+        "orcid": {
+          "name": "orcid",
+          "description": "The ORICD of a person.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "person value",
+          "alias": "orcid",
+          "owner": "person value",
+          "range": "string"
+        },
+        "profile image url": {
+          "name": "profile image url",
+          "description": "A url that points to an image of a person.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "person value",
+          "alias": "profile_image_url",
+          "owner": "person value",
+          "range": "string"
+        },
+        "email": {
+          "name": "email",
+          "description": "An email address for an entity such as a person. This should be the primarly email address used.",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "schema:email",
+          "alias": "email",
+          "owner": "person value",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "The full name of the Investgator. It should follow the format FIRST [MIDDLE NAME| MIDDLE INITIAL] LAST, where MIDDLE NAME| MIDDLE INITIAL is optional.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "person value",
+          "range": "string"
+        },
+        "websites": {
+          "name": "websites",
+          "description": "A list of websites that are assocatiated with the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "websites",
+          "owner": "person value",
+          "range": "string"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The full name of the Investgator in format FIRST LAST.",
+          "notes": [
+            "May eventually be deprecated in favor of \"name\"."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "person value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "person value",
+          "range": "activity"
+        }
+      }
+    },
+    "person": {
+      "name": "person",
+      "description": "represents a person, such as a researcher",
+      "comments": [
+        "not yet in use"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "slot_usage": {
+        "id": {
+          "name": "id",
+          "description": "Should be an ORCID. Specify in CURIE format. E.g ORCID:0000-1111-..."
+        }
+      },
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "Should be an ORCID. Specify in CURIE format. E.g ORCID:0000-1111-...",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "person",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "person",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "person",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "person",
+          "range": "string"
+        }
+      }
+    },
+    "MAG bin": {
+      "name": "MAG bin",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "type"
+      ],
+      "attributes": {
+        "bin name": {
+          "name": "bin name",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "bin_name",
+          "owner": "MAG bin",
+          "range": "string"
+        },
+        "number of contig": {
+          "name": "number of contig",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "number_of_contig",
+          "owner": "MAG bin",
+          "range": "integer"
+        },
+        "completeness": {
+          "name": "completeness",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "completeness",
+          "owner": "MAG bin",
+          "range": "float"
+        },
+        "contamination": {
+          "name": "contamination",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "contamination",
+          "owner": "MAG bin",
+          "range": "float"
+        },
+        "gene count": {
+          "name": "gene count",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gene_count",
+          "owner": "MAG bin",
+          "range": "integer"
+        },
+        "bin quality": {
+          "name": "bin quality",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "bin_quality",
+          "owner": "MAG bin",
+          "range": "string"
+        },
+        "num 16s": {
+          "name": "num 16s",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "num_16s",
+          "owner": "MAG bin",
+          "range": "integer"
+        },
+        "num 5s": {
+          "name": "num 5s",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "num_5s",
+          "owner": "MAG bin",
+          "range": "integer"
+        },
+        "num 23s": {
+          "name": "num 23s",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "num_23s",
+          "owner": "MAG bin",
+          "range": "integer"
+        },
+        "num tRNA": {
+          "name": "num tRNA",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "num_tRNA",
+          "owner": "MAG bin",
+          "range": "integer"
+        },
+        "gtdbtk domain": {
+          "name": "gtdbtk domain",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_domain",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "gtdbtk phylum": {
+          "name": "gtdbtk phylum",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_phylum",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "gtdbtk class": {
+          "name": "gtdbtk class",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_class",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "gtdbtk order": {
+          "name": "gtdbtk order",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_order",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "gtdbtk family": {
+          "name": "gtdbtk family",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_family",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "gtdbtk genus": {
+          "name": "gtdbtk genus",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_genus",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "gtdbtk species": {
+          "name": "gtdbtk species",
+          "from_schema": "https://microbiomedata/schema/core",
+          "alias": "gtdbtk_species",
+          "owner": "MAG bin",
+          "range": "string",
+          "required": false
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "examples": [
+            {
+              "value": "nmdc:Biosample"
+            },
+            {
+              "value": "nmdc:Study"
+            }
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "MAG bin",
+          "range": "string"
+        }
+      }
+    },
+    "instrument": {
+      "name": "instrument",
+      "aliases": [
+        "device"
+      ],
+      "exact_mappings": [
+        "OBI:0000485"
+      ],
+      "description": "A material entity that is designed to perform a function in a scientific investigation, but is not a reagent[OBI].",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "instrument",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "instrument",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "instrument",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "instrument",
+          "range": "string"
+        }
+      }
+    },
+    "metabolite quantification": {
+      "name": "metabolite quantification",
+      "description": "This is used to link a metabolomics analysis workflow to a specific metabolite",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "alternative identifiers"
+      ],
+      "slot_usage": {
+        "metabolite quantified": {
+          "name": "metabolite quantified",
+          "description": "the specific metabolite identifier",
+          "range": "chemical entity"
+        },
+        "highest similarity score": {
+          "name": "highest similarity score",
+          "description": "TODO: Yuri to fill in",
+          "range": "float"
+        }
+      },
+      "attributes": {
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "metabolite quantification",
+          "range": "string"
+        }
+      }
+    },
+    "peptide quantification": {
+      "name": "peptide quantification",
+      "description": "This is used to link a metaproteomics analysis workflow to a specific peptide sequence and related information",
+      "from_schema": "https://microbiomedata/schema",
+      "slot_usage": {
+        "peptide sequence": {
+          "name": "peptide sequence",
+          "range": "string"
+        },
+        "best protein": {
+          "name": "best protein",
+          "description": "the specific protein identifier most correctly associated with the peptide sequence",
+          "range": "gene product"
+        },
+        "all proteins": {
+          "name": "all proteins",
+          "description": "the list of protein identifiers that are associated with the peptide sequence",
+          "multivalued": true,
+          "range": "gene product"
+        },
+        "min_q_value": {
+          "name": "min_q_value",
+          "description": "smallest Q-Value associated with the peptide sequence as provided by MSGFPlus tool",
+          "see_also": [
+            "OBI:0001442"
+          ],
+          "range": "float"
+        },
+        "peptide_spectral_count": {
+          "name": "peptide_spectral_count",
+          "description": "sum of filter passing MS2 spectra associated with the peptide sequence within a given LC-MS/MS data file",
+          "range": "integer"
+        },
+        "peptide_sum_masic_abundance": {
+          "name": "peptide_sum_masic_abundance",
+          "description": "combined MS1 extracted ion chromatograms derived from MS2 spectra associated with the peptide sequence from a given LC-MS/MS data file using the MASIC tool",
+          "range": "integer"
+        }
+      }
+    },
+    "protein quantification": {
+      "name": "protein quantification",
+      "description": "This is used to link a metaproteomics analysis workflow to a specific protein",
+      "from_schema": "https://microbiomedata/schema",
+      "slot_usage": {
+        "best protein": {
+          "name": "best protein",
+          "description": "the specific protein identifier most correctly grouped to its associated peptide sequences",
+          "range": "gene product"
+        },
+        "all proteins": {
+          "name": "all proteins",
+          "description": "the grouped list of protein identifiers associated with the peptide sequences that were grouped to a best protein",
+          "multivalued": true,
+          "range": "gene product"
+        },
+        "peptide_sequence_count": {
+          "name": "peptide_sequence_count",
+          "description": "count of peptide sequences grouped to the best_protein",
+          "range": "integer"
+        },
+        "protein_spectral_count": {
+          "name": "protein_spectral_count",
+          "description": "sum of filter passing MS2 spectra associated with the best protein within a given LC-MS/MS data file",
+          "range": "integer"
+        },
+        "protein_sum_masic_abundance": {
+          "name": "protein_sum_masic_abundance",
+          "description": "combined MS1 extracted ion chromatograms derived from MS2 spectra associated with the best protein from a given LC-MS/MS data file using the MASIC tool",
+          "range": "integer"
+        }
+      }
+    },
+    "chemical entity": {
+      "name": "chemical entity",
+      "id_prefixes": [
+        "KEGG.COMPOUND",
+        "CHEBI",
+        "CHEMBL.COMPOUND",
+        "DRUGBANK",
+        "PUBCHEM.COMPOUND",
+        "CAS",
+        "HMDB",
+        "MESH"
+      ],
+      "aliases": [
+        "metabolite",
+        "chemical substance",
+        "chemical compound",
+        "chemical"
+      ],
+      "exact_mappings": [
+        "biolink:ChemicalSubstance"
+      ],
+      "description": "An atom or molecule that can be represented with a chemical formula. Include lipids, glycans, natural products, drugs. There may be different terms for distinct acid-base forms, protonation states",
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://bioconductor.org/packages/devel/data/annotation/vignettes/metaboliteIDmapping/inst/doc/metaboliteIDmapping.html"
+      ],
+      "is_a": "ontology class",
+      "slot_usage": {
+        "inchi": {
+          "name": "inchi",
+          "multivalued": false,
+          "key": false,
+          "range": "string"
+        },
+        "inchi key": {
+          "name": "inchi key",
+          "multivalued": false,
+          "key": false,
+          "range": "string"
+        },
+        "smiles": {
+          "name": "smiles",
+          "description": "A string encoding of a molecular graph, no chiral or isotopic information. There are usually a large number of valid SMILES which represent a given structure. For example, CCO, OCC and C(O)C all specify the structure of ethanol.",
+          "multivalued": true,
+          "range": "string"
+        },
+        "chemical formula": {
+          "name": "chemical formula",
+          "description": "A generic grouping for miolecular formulae and empirican formulae",
+          "multivalued": false,
+          "key": false,
+          "range": "string"
+        }
+      },
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "chemical entity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "chemical entity",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "chemical entity",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "chemical entity",
+          "range": "string"
+        }
+      }
+    },
+    "gene product": {
+      "name": "gene product",
+      "id_prefixes": [
+        "UniProtKB",
+        "gtpo",
+        "PR"
+      ],
+      "exact_mappings": [
+        "biolink:GeneProduct"
+      ],
+      "description": "A molecule encoded by a gene that has an evolved function",
+      "comments": [
+        "we may include a more general gene product class in future to allow for ncRNA annotation"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "named thing",
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "gene product",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "gene product",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "gene product",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "gene product",
+          "range": "string"
+        }
+      }
+    },
+    "text value": {
+      "name": "text value",
+      "description": "A basic string value",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "language"
+      ],
+      "attributes": {
+        "language": {
+          "name": "language",
+          "description": "Should use ISO 639-1 code e.g. \"en\", \"fr\"",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "language",
+          "owner": "text value",
+          "range": "language code"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "text value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "text value",
+          "range": "activity"
+        }
+      }
+    },
+    "url value": {
+      "name": "url value",
+      "description": "A value that is a string that conforms to URL syntax",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "attributes": {
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "url value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "url value",
+          "range": "activity"
+        }
+      }
+    },
+    "timestamp value": {
+      "name": "timestamp value",
+      "description": "A value that is a timestamp. The range should be ISO-8601",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "attributes": {
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "timestamp value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "timestamp value",
+          "range": "activity"
+        }
+      }
+    },
+    "integer value": {
+      "name": "integer value",
+      "description": "A value that is an integer",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "has numeric value"
+      ],
+      "attributes": {
+        "has numeric value": {
+          "name": "has numeric value",
+          "mappings": [
+            "qud:quantityValue",
+            "schema:value"
+          ],
+          "description": "Links a quantity value to a number",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "has_numeric_value",
+          "owner": "integer value",
+          "range": "float"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "integer value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "integer value",
+          "range": "activity"
+        }
+      }
+    },
+    "boolean value": {
+      "name": "boolean value",
+      "description": "A value that is a boolean",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "has boolean value"
+      ],
+      "attributes": {
+        "has boolean value": {
+          "name": "has boolean value",
+          "description": "Links a quantity value to a boolean",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "has_boolean_value",
+          "owner": "boolean value",
+          "range": "boolean"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "boolean value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "boolean value",
+          "range": "activity"
+        }
+      }
+    },
+    "controlled term value": {
+      "name": "controlled term value",
+      "description": "A controlled term or class from an ontology",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "term"
+      ],
+      "attributes": {
+        "term": {
+          "name": "term",
+          "description": "pointer to an ontology class",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "controlled term value",
+          "slot_uri": "rdf:type",
+          "inlined": true,
+          "alias": "term",
+          "owner": "controlled term value",
+          "range": "ontology class"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The value that was specified for an annotation in raw form, i.e. a string. E.g. \"2 cm\" or \"2-4 cm\"",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "controlled term value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "controlled term value",
+          "range": "activity"
+        }
+      }
+    },
+    "geolocation value": {
+      "name": "geolocation value",
+      "mappings": [
+        "schema:GeoCoordinates"
+      ],
+      "description": "A normalized value for a location on the earth's surface",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "attribute value",
+      "slots": [
+        "latitude",
+        "longitude"
+      ],
+      "slot_usage": {
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The raw value for a  geolocation should follow {lat} {long}"
+        }
+      },
+      "attributes": {
+        "latitude": {
+          "name": "latitude",
+          "mappings": [
+            "schema:latitude"
+          ],
+          "description": "latitude",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "geolocation value",
+          "slot_uri": "wgs:lat",
+          "alias": "latitude",
+          "owner": "geolocation value",
+          "range": "decimal degree"
+        },
+        "longitude": {
+          "name": "longitude",
+          "mappings": [
+            "schema:longitude"
+          ],
+          "description": "longitude",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "geolocation value",
+          "slot_uri": "wgs:long",
+          "alias": "longitude",
+          "owner": "geolocation value",
+          "range": "decimal degree"
+        },
+        "has raw value": {
+          "name": "has raw value",
+          "description": "The raw value for a  geolocation should follow {lat} {long}",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "attribute value",
+          "multivalued": false,
+          "alias": "has_raw_value",
+          "owner": "geolocation value",
+          "range": "string",
+          "required": false
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "mappings": [
+            "prov:wasGeneratedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "geolocation value",
+          "range": "activity"
+        }
+      }
+    },
+    "activity": {
+      "name": "activity",
+      "mappings": [
+        "prov:Activity"
+      ],
+      "description": "a provence-generating activity",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "id",
+        "name",
+        "started at time",
+        "ended at time",
+        "was informed by",
+        "was associated with",
+        "used"
+      ],
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "mappings": [
+            "prov:startedAtTime"
+          ],
+          "comments": [
+            "The regex for ISO-8601 format was taken from here: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ It may not be complete, but it is good enough for now."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "activity",
+          "range": "datetime",
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "mappings": [
+            "prov:endedAtTime"
+          ],
+          "comments": [
+            "The regex for ISO-8601 format was taken from here: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ It may not be complete, but it is good enough for now."
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "activity",
+          "range": "datetime",
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "mappings": [
+            "prov:wasInformedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "activity",
+          "range": "activity"
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "mappings": [
+            "prov:wasAssociatedWith"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_associated_with",
+          "owner": "activity",
+          "range": "agent"
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "activity",
+          "range": "string"
+        }
+      }
+    },
+    "agent": {
+      "name": "agent",
+      "mappings": [
+        "prov:Agent"
+      ],
+      "description": "a provence-generating agent",
+      "from_schema": "https://microbiomedata/schema",
+      "slots": [
+        "acted on behalf of",
+        "was informed by"
+      ],
+      "attributes": {
+        "acted on behalf of": {
+          "name": "acted on behalf of",
+          "mappings": [
+            "prov:actedOnBehalfOf"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "acted_on_behalf_of",
+          "owner": "agent",
+          "range": "agent"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "mappings": [
+            "prov:wasInformedBy"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "agent",
+          "range": "activity"
+        }
+      }
+    },
+    "genome feature": {
+      "name": "genome feature",
+      "description": "A feature localized to an interval along a genome",
+      "comments": [
+        "corresponds to an entry in GFF3"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md"
+      ],
+      "slot_usage": {
+        "seqid": {
+          "name": "seqid",
+          "description": "The ID of the landmark used to establish the coordinate system for the current feature.",
+          "range": "string",
+          "required": true
+        },
+        "type": {
+          "name": "type",
+          "description": "A type from the sequence ontology",
+          "slot_uri": "rdf:type",
+          "range": "ontology class"
+        },
+        "start": {
+          "name": "start",
+          "close_mappings": [
+            "biolink:start_interbase_coordinate"
+          ],
+          "description": "The start of the feature in positive 1-based integer coordinates",
+          "is_a": "gff coordinate",
+          "required": true
+        },
+        "end": {
+          "name": "end",
+          "close_mappings": [
+            "biolink:end_interbase_coordinate"
+          ],
+          "description": "The end of the feature in positive 1-based integer coordinates",
+          "comments": [
+            "- \"constraint: end > start\" - \"For features that cross the origin of a circular feature,  end = the position of the end + the length of the landmark feature.\""
+          ],
+          "is_a": "gff coordinate",
+          "required": true
+        },
+        "strand": {
+          "name": "strand",
+          "exact_mappings": [
+            "biolink:strand"
+          ],
+          "description": "The strand on which a feature is located. Has a value of '+' (sense strand or forward strand) or '-' (anti-sense strand or reverse strand)."
+        },
+        "phase": {
+          "name": "phase",
+          "exact_mappings": [
+            "biolink:phase"
+          ],
+          "description": "The phase for a coding sequence entity. For example, phase of a CDS as represented in a GFF3 with a value of 0, 1 or 2.",
+          "range": "integer",
+          "minimum_value": 0,
+          "maximum_value": 0
+        },
+        "encodes": {
+          "name": "encodes",
+          "description": "The gene product encoded by this feature. Typically this is used for a CDS feature or gene feature which will encode a protein. It can also be used by a nc transcript ot gene feature that encoded a ncRNA",
+          "range": "gene product",
+          "required": false
+        },
+        "feature type": {
+          "name": "feature type",
+          "description": "TODO: Yuri to write"
+        }
+      }
+    },
+    "functional annotation term": {
+      "name": "functional annotation term",
+      "aliases": [
+        "function",
+        "functional annotation"
+      ],
+      "description": "Abstract grouping class for any term/descriptor that can be applied to a functional unit of a genome (protein, ncRNA, complex).",
+      "todos": [
+        "decide if this should be used for product naming"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "ontology class",
+      "abstract": true,
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "functional annotation term",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "functional annotation term",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "functional annotation term",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "functional annotation term",
+          "range": "string"
+        }
+      }
+    },
+    "pathway": {
+      "name": "pathway",
+      "id_prefixes": [
+        "KEGG.PATHWAY",
+        "COG"
+      ],
+      "aliases": [
+        "biological process",
+        "metabolic pathway",
+        "signaling pathway"
+      ],
+      "exact_mappings": [
+        "biolink:Pathway"
+      ],
+      "description": "A pathway is a sequence of steps/reactions carried out by an organism or community of organisms",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "functional annotation term",
+      "slot_usage": {
+        "has_part": {
+          "name": "has_part",
+          "description": "A pathway can be broken down to a series of reaction step",
+          "multivalued": true,
+          "range": "reaction"
+        }
+      },
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "pathway",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "pathway",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "pathway",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "pathway",
+          "range": "string"
+        }
+      }
+    },
+    "reaction": {
+      "name": "reaction",
+      "id_prefixes": [
+        "KEGG.REACTION",
+        "RHEA",
+        "MetaCyc",
+        "EC",
+        "GO",
+        "MetaNetX",
+        "SEED",
+        "RetroRules"
+      ],
+      "exact_mappings": [
+        "biolink:MolecularActivity"
+      ],
+      "description": "An individual biochemical transformation carried out by a functional unit of an organism, in which a collection of substrates are transformed into a collection of products. Can also represent transporters",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "functional annotation term",
+      "slot_usage": {
+        "left participants": {
+          "name": "left participants",
+          "is_a": "has participants",
+          "multivalued": true,
+          "range": "reaction participant"
+        },
+        "right participants": {
+          "name": "right participants",
+          "is_a": "has participants",
+          "multivalued": true,
+          "range": "reaction participant"
+        },
+        "direction": {
+          "name": "direction",
+          "description": "One of l->r, r->l, bidirectional, neutral"
+        },
+        "smarts string": {
+          "name": "smarts string",
+          "range": "string"
+        },
+        "is diastereoselective": {
+          "name": "is diastereoselective",
+          "range": "boolean"
+        },
+        "is stereo": {
+          "name": "is stereo",
+          "range": "boolean"
+        },
+        "is balanced": {
+          "name": "is balanced",
+          "range": "boolean"
+        },
+        "is transport": {
+          "name": "is transport",
+          "range": "boolean"
+        },
+        "is fully characterized": {
+          "name": "is fully characterized",
+          "description": "False if includes R-groups",
+          "range": "boolean"
+        }
+      },
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "reaction",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "reaction",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "reaction",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "reaction",
+          "range": "string"
+        }
+      }
+    },
+    "reaction participant": {
+      "name": "reaction participant",
+      "description": "Instances of this link a reaction to a chemical entity participant",
+      "from_schema": "https://microbiomedata/schema",
+      "slot_usage": {
+        "chemical": {
+          "name": "chemical",
+          "range": "chemical entity"
+        },
+        "stoichiometry": {
+          "name": "stoichiometry",
+          "range": "integer"
+        }
+      }
+    },
+    "orthology group": {
+      "name": "orthology group",
+      "id_prefixes": [
+        "KEGG.ORTHOLOGY",
+        "EGGNOG",
+        "PFAM",
+        "TIGRFAM",
+        "SUPFAM",
+        "CATH",
+        "PANTHER.FAMILY"
+      ],
+      "exact_mappings": [
+        "biolink:GeneFamily"
+      ],
+      "description": "A set of genes or gene products in which all members are orthologous",
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "functional annotation term",
+      "attributes": {
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "orthology group",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "orthology group",
+          "range": "string"
+        },
+        "description": {
+          "name": "description",
+          "description": "a human-readable description of a thing",
+          "from_schema": "https://microbiomedata/schema",
+          "slot_uri": "dcterms:description",
+          "multivalued": false,
+          "alias": "description",
+          "owner": "orthology group",
+          "range": "string"
+        },
+        "alternative identifiers": {
+          "name": "alternative identifiers",
+          "description": "A list of alternative identifiers for the entity.",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "alternative_identifiers",
+          "owner": "orthology group",
+          "range": "string"
+        }
+      }
+    },
+    "functional annotation": {
+      "name": "functional annotation",
+      "narrow_mappings": [
+        "biolink:GeneToGoTermAssociation"
+      ],
+      "description": "An assignment of a function term (e.g. reaction or pathway) that is executed by a gene product, or which the gene product plays an active role in. Functional annotations can be assigned manually by curators, or automatically in workflows. In the context of NMDC, all function annotation is performed automatically, typically using HMM or Blast type methods",
+      "comments": [
+        "move id slot usage patterns to has_function slot usage?"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "see_also": [
+        "https://img.jgi.doe.gov/docs/functional-annotation.pdf",
+        "https://github.com/microbiomedata/mg_annotation/blob/master/functional-annotation.wdl"
+      ],
+      "slots": [
+        "was generated by",
+        "subject",
+        "has function"
+      ],
+      "slot_usage": {
+        "has function": {
+          "name": "has function",
+          "comments": [
+            "Still missing patterns for COG and RetroRules.",
+            "These patterns aren't tied to the listed prefixes. A discussion about that possibility had been started, including the question of whether these lists are intended to be open examples or closed"
+          ],
+          "pattern": "^(KEGG.PATHWAY:\\w{2,4}\\d{5}|KEGG.REACTION:R\\d+|RHEA:\\d{5}|MetaCyc:[A-Za-z0-9+_.%-:]+|EC:\\d{1,2}(\\.\\d{0,3}){0,3}|GO:\\d{7}|MetaNetX:(MNXR\\d+|EMPTY)|SEED:\\w+|KEGG\\.ORTHOLOGY:K\\d+|EGGNOG:\\w+|PFAM:PF\\d{5}|TIGRFAM:TIGR\\d+|SUPFAM:\\w+|CATH:[1-6]\\.[0-9]+\\.[0-9]+\\.[0-9]+|PANTHER.FAMILY:PTHR\\d{5}(\\:SF\\d{1,3})?)$"
+        },
+        "type": {
+          "name": "type",
+          "description": "TODO",
+          "range": "ontology class"
+        },
+        "was generated by": {
+          "name": "was generated by",
+          "description": "provenance for the annotation.",
+          "notes": [
+            "Note to be consistent with the rest of the NMDC schema we use the PROV annotation model, rather than GPAD"
+          ],
+          "range": "metagenome annotation activity"
+        }
+      },
+      "attributes": {
+        "was generated by": {
+          "name": "was generated by",
+          "description": "provenance for the annotation.",
+          "notes": [
+            "Note to be consistent with the rest of the NMDC schema we use the PROV annotation model, rather than GPAD"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_generated_by",
+          "owner": "functional annotation",
+          "range": "metagenome annotation activity"
+        },
+        "subject": {
+          "name": "subject",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "subject",
+          "owner": "functional annotation",
+          "range": "gene product"
+        },
+        "has function": {
+          "name": "has function",
+          "comments": [
+            "Still missing patterns for COG and RetroRules.",
+            "These patterns aren't tied to the listed prefixes. A discussion about that possibility had been started, including the question of whether these lists are intended to be open examples or closed"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "has_function",
+          "owner": "functional annotation",
+          "range": "string",
+          "pattern": "^(KEGG.PATHWAY:\\w{2,4}\\d{5}|KEGG.REACTION:R\\d+|RHEA:\\d{5}|MetaCyc:[A-Za-z0-9+_.%-:]+|EC:\\d{1,2}(\\.\\d{0,3}){0,3}|GO:\\d{7}|MetaNetX:(MNXR\\d+|EMPTY)|SEED:\\w+|KEGG\\.ORTHOLOGY:K\\d+|EGGNOG:\\w+|PFAM:PF\\d{5}|TIGRFAM:TIGR\\d+|SUPFAM:\\w+|CATH:[1-6]\\.[0-9]+\\.[0-9]+\\.[0-9]+|PANTHER.FAMILY:PTHR\\d{5}(\\:SF\\d{1,3})?)$"
+        }
+      }
+    },
+    "workflow execution activity": {
+      "name": "workflow execution activity",
+      "aliases": [
+        "analysis"
+      ],
+      "description": "Represents an instance of an execution of a particular workflow",
+      "alt_descriptions": {
+        "embl.ena": {
+          "source": "embl.ena",
+          "description": "An analysis contains secondary analysis results derived from sequence reads (e.g. a genome assembly)"
+        }
+      },
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "activity",
+      "slots": [
+        "execution resource",
+        "git url",
+        "has input",
+        "has output",
+        "part of",
+        "type"
+      ],
+      "slot_usage": {
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "inlined": false,
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "started at time": {
+          "name": "started at time",
+          "required": true
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "required": true
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "required": true
+        },
+        "execution resource": {
+          "name": "execution resource",
+          "required": true
+        },
+        "type": {
+          "name": "type",
+          "required": true
+        }
+      },
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "workflow execution activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "workflow execution activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "workflow execution activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "workflow execution activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "workflow execution activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "workflow execution activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "workflow execution activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "workflow execution activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "workflow execution activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "workflow execution activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "workflow execution activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "workflow execution activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "workflow execution activity",
+          "range": "string"
+        }
+      }
+    },
+    "metagenome assembly": {
+      "name": "metagenome assembly",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slots": [
+        "asm_score",
+        "scaffolds",
+        "scaf_logsum",
+        "scaf_powsum",
+        "scaf_max",
+        "scaf_bp",
+        "scaf_N50",
+        "scaf_N90",
+        "scaf_L50",
+        "scaf_L90",
+        "scaf_n_gt50K",
+        "scaf_l_gt50K",
+        "scaf_pct_gt50K",
+        "contigs",
+        "contig_bp",
+        "ctg_N50",
+        "ctg_L50",
+        "ctg_N90",
+        "ctg_L90",
+        "ctg_logsum",
+        "ctg_powsum",
+        "ctg_max",
+        "gap_pct",
+        "gc_std",
+        "gc_avg",
+        "num_input_reads",
+        "num_aligned_reads",
+        "INSDC assembly identifiers"
+      ],
+      "attributes": {
+        "asm_score": {
+          "name": "asm_score",
+          "description": "A score for comparing metagenomic assembly quality from same sample.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "asm_score",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaffolds": {
+          "name": "scaffolds",
+          "description": "Total sequence count of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaffolds",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_logsum": {
+          "name": "scaf_logsum",
+          "description": "The sum of the (length*log(length)) of all scaffolds, times some constant.  Increase the contiguity, the score will increase",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_logsum",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_powsum": {
+          "name": "scaf_powsum",
+          "description": "Powersum of all scaffolds is the same as logsum except that it uses the sum of (length*(length^P)) for some power P (default P=0.25).",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_powsum",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_max": {
+          "name": "scaf_max",
+          "description": "Maximum scaffold length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_max",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_bp": {
+          "name": "scaf_bp",
+          "description": "Total size in bp of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_bp",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_N50": {
+          "name": "scaf_N50",
+          "description": "Given a set of scaffolds, each with its own length, the N50 count is defined as the smallest number of scaffolds whose length sum makes up half of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_N50",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_N90": {
+          "name": "scaf_N90",
+          "description": "Given a set of scaffolds, each with its own length, the N90 count is defined as the smallest number of scaffolds whose length sum makes up 90% of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_N90",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_L50": {
+          "name": "scaf_L50",
+          "description": "Given a set of scaffolds, the L50 is defined as the sequence length of the shortest scaffold at 50% of the total genome length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_L50",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_L90": {
+          "name": "scaf_L90",
+          "description": "The L90 statistic is less than or equal to the L50 statistic; it is the length for which the collection of all scaffolds of that length or longer contains at least 90% of the sum of the lengths of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_L90",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_n_gt50K": {
+          "name": "scaf_n_gt50K",
+          "description": "Total sequence count of scaffolds greater than 50 KB.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_n_gt50K",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_l_gt50K": {
+          "name": "scaf_l_gt50K",
+          "description": "Total size in bp of all scaffolds greater than 50 KB.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_l_gt50K",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "scaf_pct_gt50K": {
+          "name": "scaf_pct_gt50K",
+          "description": "Total sequence size percentage of scaffolds greater than 50 KB.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_pct_gt50K",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "contigs": {
+          "name": "contigs",
+          "description": "The sum of the (length*log(length)) of all contigs, times some constant.  Increase the contiguity, the score will increase",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "contigs",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "contig_bp": {
+          "name": "contig_bp",
+          "description": "Total size in bp of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "contig_bp",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_N50": {
+          "name": "ctg_N50",
+          "description": "Given a set of contigs, each with its own length, the N50 count is defined as the smallest number of contigs whose length sum makes up half of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_N50",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_L50": {
+          "name": "ctg_L50",
+          "description": "Given a set of contigs, the L50 is defined as the sequence length of the shortest contig at 50% of the total genome length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_L50",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_N90": {
+          "name": "ctg_N90",
+          "description": "Given a set of contigs, each with its own length, the N90 count is defined as the smallest number of contigs whose length sum makes up 90% of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_N90",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_L90": {
+          "name": "ctg_L90",
+          "description": "The L90 statistic is less than or equal to the L50 statistic; it is the length for which the collection of all contigs of that length or longer contains at least 90% of the sum of the lengths of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_L90",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_logsum": {
+          "name": "ctg_logsum",
+          "description": "Maximum contig length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_logsum",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_powsum": {
+          "name": "ctg_powsum",
+          "description": "Powersum of all contigs is the same as logsum except that it uses the sum of (length*(length^P)) for some power P (default P=0.25).",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_powsum",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "ctg_max": {
+          "name": "ctg_max",
+          "description": "Maximum contig length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_max",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "gap_pct": {
+          "name": "gap_pct",
+          "description": "The gap size percentage of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "gap_pct",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "gc_std": {
+          "name": "gc_std",
+          "description": "Standard deviation of GC content of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "gc_std",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "gc_avg": {
+          "name": "gc_avg",
+          "description": "Average of GC content of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "gc_avg",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "num_input_reads": {
+          "name": "num_input_reads",
+          "description": "The sequence count number of input reads for assembly.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "num_input_reads",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "num_aligned_reads": {
+          "name": "num_aligned_reads",
+          "description": "The sequence count number of input reads aligned to assembled contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "num_aligned_reads",
+          "owner": "metagenome assembly",
+          "range": "float"
+        },
+        "INSDC assembly identifiers": {
+          "name": "INSDC assembly identifiers",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "assembly identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "alias": "INSDC_assembly_identifiers",
+          "owner": "metagenome assembly",
+          "range": "string",
+          "pattern": "^insdc.sra:[A-Z]+[0-9]+(\\.[0-9]+)?$"
+        },
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metagenome assembly",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metagenome assembly",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metagenome assembly",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metagenome assembly",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metagenome assembly",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metagenome assembly",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metagenome assembly",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metagenome assembly",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metagenome assembly",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metagenome assembly",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metagenome assembly",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metagenome assembly",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "metagenome assembly",
+          "range": "string"
+        }
+      }
+    },
+    "metatranscriptome assembly": {
+      "name": "metatranscriptome assembly",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slots": [
+        "asm_score",
+        "scaffolds",
+        "scaf_logsum",
+        "scaf_powsum",
+        "scaf_max",
+        "scaf_bp",
+        "scaf_N50",
+        "scaf_N90",
+        "scaf_L50",
+        "scaf_L90",
+        "scaf_n_gt50K",
+        "scaf_l_gt50K",
+        "scaf_pct_gt50K",
+        "contigs",
+        "contig_bp",
+        "ctg_N50",
+        "ctg_L50",
+        "ctg_N90",
+        "ctg_L90",
+        "ctg_logsum",
+        "ctg_powsum",
+        "ctg_max",
+        "gap_pct",
+        "gc_std",
+        "gc_avg",
+        "num_input_reads",
+        "num_aligned_reads",
+        "INSDC assembly identifiers"
+      ],
+      "attributes": {
+        "asm_score": {
+          "name": "asm_score",
+          "description": "A score for comparing metagenomic assembly quality from same sample.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "asm_score",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaffolds": {
+          "name": "scaffolds",
+          "description": "Total sequence count of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaffolds",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_logsum": {
+          "name": "scaf_logsum",
+          "description": "The sum of the (length*log(length)) of all scaffolds, times some constant.  Increase the contiguity, the score will increase",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_logsum",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_powsum": {
+          "name": "scaf_powsum",
+          "description": "Powersum of all scaffolds is the same as logsum except that it uses the sum of (length*(length^P)) for some power P (default P=0.25).",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_powsum",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_max": {
+          "name": "scaf_max",
+          "description": "Maximum scaffold length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_max",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_bp": {
+          "name": "scaf_bp",
+          "description": "Total size in bp of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_bp",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_N50": {
+          "name": "scaf_N50",
+          "description": "Given a set of scaffolds, each with its own length, the N50 count is defined as the smallest number of scaffolds whose length sum makes up half of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_N50",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_N90": {
+          "name": "scaf_N90",
+          "description": "Given a set of scaffolds, each with its own length, the N90 count is defined as the smallest number of scaffolds whose length sum makes up 90% of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_N90",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_L50": {
+          "name": "scaf_L50",
+          "description": "Given a set of scaffolds, the L50 is defined as the sequence length of the shortest scaffold at 50% of the total genome length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_L50",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_L90": {
+          "name": "scaf_L90",
+          "description": "The L90 statistic is less than or equal to the L50 statistic; it is the length for which the collection of all scaffolds of that length or longer contains at least 90% of the sum of the lengths of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_L90",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_n_gt50K": {
+          "name": "scaf_n_gt50K",
+          "description": "Total sequence count of scaffolds greater than 50 KB.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_n_gt50K",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_l_gt50K": {
+          "name": "scaf_l_gt50K",
+          "description": "Total size in bp of all scaffolds greater than 50 KB.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_l_gt50K",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "scaf_pct_gt50K": {
+          "name": "scaf_pct_gt50K",
+          "description": "Total sequence size percentage of scaffolds greater than 50 KB.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "scaf_pct_gt50K",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "contigs": {
+          "name": "contigs",
+          "description": "The sum of the (length*log(length)) of all contigs, times some constant.  Increase the contiguity, the score will increase",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "contigs",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "contig_bp": {
+          "name": "contig_bp",
+          "description": "Total size in bp of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "contig_bp",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_N50": {
+          "name": "ctg_N50",
+          "description": "Given a set of contigs, each with its own length, the N50 count is defined as the smallest number of contigs whose length sum makes up half of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_N50",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_L50": {
+          "name": "ctg_L50",
+          "description": "Given a set of contigs, the L50 is defined as the sequence length of the shortest contig at 50% of the total genome length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_L50",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_N90": {
+          "name": "ctg_N90",
+          "description": "Given a set of contigs, each with its own length, the N90 count is defined as the smallest number of contigs whose length sum makes up 90% of genome size.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_N90",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_L90": {
+          "name": "ctg_L90",
+          "description": "The L90 statistic is less than or equal to the L50 statistic; it is the length for which the collection of all contigs of that length or longer contains at least 90% of the sum of the lengths of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_L90",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_logsum": {
+          "name": "ctg_logsum",
+          "description": "Maximum contig length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_logsum",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_powsum": {
+          "name": "ctg_powsum",
+          "description": "Powersum of all contigs is the same as logsum except that it uses the sum of (length*(length^P)) for some power P (default P=0.25).",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_powsum",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "ctg_max": {
+          "name": "ctg_max",
+          "description": "Maximum contig length.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "ctg_max",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "gap_pct": {
+          "name": "gap_pct",
+          "description": "The gap size percentage of all scaffolds.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "gap_pct",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "gc_std": {
+          "name": "gc_std",
+          "description": "Standard deviation of GC content of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "gc_std",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "gc_avg": {
+          "name": "gc_avg",
+          "description": "Average of GC content of all contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "gc_avg",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "num_input_reads": {
+          "name": "num_input_reads",
+          "description": "The sequence count number of input reads for assembly.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "num_input_reads",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "num_aligned_reads": {
+          "name": "num_aligned_reads",
+          "description": "The sequence count number of input reads aligned to assembled contigs.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "metagenome assembly parameter",
+          "alias": "num_aligned_reads",
+          "owner": "metatranscriptome assembly",
+          "range": "float"
+        },
+        "INSDC assembly identifiers": {
+          "name": "INSDC assembly identifiers",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "assembly identifiers",
+          "mixins": [
+            "INSDC identifiers"
+          ],
+          "alias": "INSDC_assembly_identifiers",
+          "owner": "metatranscriptome assembly",
+          "range": "string",
+          "pattern": "^insdc.sra:[A-Z]+[0-9]+(\\.[0-9]+)?$"
+        },
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metatranscriptome assembly",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metatranscriptome assembly",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metatranscriptome assembly",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metatranscriptome assembly",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metatranscriptome assembly",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metatranscriptome assembly",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metatranscriptome assembly",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metatranscriptome assembly",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metatranscriptome assembly",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metatranscriptome assembly",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metatranscriptome assembly",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metatranscriptome assembly",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "metatranscriptome assembly",
+          "range": "string"
+        }
+      }
+    },
+    "metagenome annotation activity": {
+      "name": "metagenome annotation activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metagenome annotation activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metagenome annotation activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metagenome annotation activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metagenome annotation activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metagenome annotation activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metagenome annotation activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metagenome annotation activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metagenome annotation activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metagenome annotation activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metagenome annotation activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metagenome annotation activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metagenome annotation activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "metagenome annotation activity",
+          "range": "string"
+        }
+      }
+    },
+    "metatranscriptome annotation activity": {
+      "name": "metatranscriptome annotation activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metatranscriptome annotation activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metatranscriptome annotation activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metatranscriptome annotation activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metatranscriptome annotation activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metatranscriptome annotation activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metatranscriptome annotation activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metatranscriptome annotation activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metatranscriptome annotation activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metatranscriptome annotation activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metatranscriptome annotation activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metatranscriptome annotation activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metatranscriptome annotation activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "metatranscriptome annotation activity",
+          "range": "string"
+        }
+      }
+    },
+    "metatranscriptome activity": {
+      "name": "metatranscriptome activity",
+      "description": "A metatranscriptome activity that e.g. pools assembly and annotation activity.",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metatranscriptome activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metatranscriptome activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metatranscriptome activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metatranscriptome activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metatranscriptome activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metatranscriptome activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metatranscriptome activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metatranscriptome activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metatranscriptome activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metatranscriptome activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metatranscriptome activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metatranscriptome activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "metatranscriptome activity",
+          "range": "string"
+        }
+      }
+    },
+    "MAGs analysis activity": {
+      "name": "MAGs analysis activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slots": [
+        "input contig num",
+        "binned contig num",
+        "too short contig num",
+        "lowDepth contig num",
+        "unbinned contig num",
+        "mags list"
+      ],
+      "attributes": {
+        "input contig num": {
+          "name": "input contig num",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "input_contig_num",
+          "owner": "MAGs analysis activity",
+          "range": "integer"
+        },
+        "binned contig num": {
+          "name": "binned contig num",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "binned_contig_num",
+          "owner": "MAGs analysis activity",
+          "range": "integer"
+        },
+        "too short contig num": {
+          "name": "too short contig num",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "too_short_contig_num",
+          "owner": "MAGs analysis activity",
+          "range": "integer"
+        },
+        "lowDepth contig num": {
+          "name": "lowDepth contig num",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "lowDepth_contig_num",
+          "owner": "MAGs analysis activity",
+          "range": "integer"
+        },
+        "unbinned contig num": {
+          "name": "unbinned contig num",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "unbinned_contig_num",
+          "owner": "MAGs analysis activity",
+          "range": "integer"
+        },
+        "mags list": {
+          "name": "mags list",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": true,
+          "alias": "mags_list",
+          "owner": "MAGs analysis activity",
+          "range": "MAG bin"
+        },
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "MAGs analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "MAGs analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "MAGs analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "MAGs analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "MAGs analysis activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "MAGs analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "MAGs analysis activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "MAGs analysis activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "MAGs analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "MAGs analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "MAGs analysis activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "MAGs analysis activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "MAGs analysis activity",
+          "range": "string"
+        }
+      }
+    },
+    "read QC analysis activity": {
+      "name": "read QC analysis activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slots": [
+        "input read count",
+        "input base count",
+        "output read count",
+        "output base count"
+      ],
+      "slot_usage": {
+        "input_read_bases": {
+          "name": "input_read_bases",
+          "description": "TODO",
+          "range": "float"
+        },
+        "output_read_bases": {
+          "name": "output_read_bases",
+          "description": "TODO",
+          "range": "float"
+        },
+        "has input": {
+          "name": "has input",
+          "inlined": false
+        },
+        "has output": {
+          "name": "has output",
+          "inlined": false
+        }
+      },
+      "attributes": {
+        "input read count": {
+          "name": "input read count",
+          "description": "The sequence count number of input reads for QC analysis.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "read QC analysis statistic",
+          "alias": "input_read_count",
+          "owner": "read QC analysis activity",
+          "range": "float"
+        },
+        "input base count": {
+          "name": "input base count",
+          "description": "The nucleotide base count number of input reads for QC analysis.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "read QC analysis statistic",
+          "alias": "input_base_count",
+          "owner": "read QC analysis activity",
+          "range": "float"
+        },
+        "output read count": {
+          "name": "output read count",
+          "description": "After QC analysis sequence count number. ",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "read QC analysis statistic",
+          "alias": "output_read_count",
+          "owner": "read QC analysis activity",
+          "range": "float"
+        },
+        "output base count": {
+          "name": "output base count",
+          "description": "After QC analysis nucleotide base count number.",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "read QC analysis statistic",
+          "alias": "output_base_count",
+          "owner": "read QC analysis activity",
+          "range": "float"
+        },
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "read QC analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "read QC analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "inlined": false,
+          "alias": "has_input",
+          "owner": "read QC analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "inlined": false,
+          "alias": "has_output",
+          "owner": "read QC analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "read QC analysis activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "read QC analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "read QC analysis activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "read QC analysis activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "read QC analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "read QC analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "read QC analysis activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "read QC analysis activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "read QC analysis activity",
+          "range": "string"
+        }
+      }
+    },
+    "read based analysis activity": {
+      "name": "read based analysis activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "read based analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "read based analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "read based analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "read based analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "read based analysis activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "read based analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "read based analysis activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "read based analysis activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "read based analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "read based analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "read based analysis activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "read based analysis activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "mappings": [
+            "prov:used"
+          ],
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "alias": "used",
+          "owner": "read based analysis activity",
+          "range": "string"
+        }
+      }
+    },
+    "metabolomics analysis activity": {
+      "name": "metabolomics analysis activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slot_usage": {
+        "used": {
+          "name": "used",
+          "description": "The instrument used to collect the data used in the analysis",
+          "multivalued": false,
+          "range": "instrument"
+        },
+        "has metabolite quantifications": {
+          "name": "has metabolite quantifications",
+          "multivalued": true,
+          "range": "metabolite quantification"
+        },
+        "has calibration": {
+          "name": "has calibration",
+          "description": "TODO: Yuri to fill in"
+        }
+      },
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metabolomics analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metabolomics analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metabolomics analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metabolomics analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metabolomics analysis activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metabolomics analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metabolomics analysis activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metabolomics analysis activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metabolomics analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metabolomics analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metabolomics analysis activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metabolomics analysis activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "description": "The instrument used to collect the data used in the analysis",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "multivalued": false,
+          "alias": "used",
+          "owner": "metabolomics analysis activity",
+          "range": "instrument"
+        }
+      }
+    },
+    "metaproteomics analysis activity": {
+      "name": "metaproteomics analysis activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slot_usage": {
+        "used": {
+          "name": "used",
+          "description": "The instrument used to collect the data used in the analysis",
+          "multivalued": false,
+          "range": "instrument"
+        },
+        "has peptide quantifications": {
+          "name": "has peptide quantifications",
+          "multivalued": true,
+          "range": "peptide quantification"
+        }
+      },
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "metaproteomics analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "metaproteomics analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "metaproteomics analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "metaproteomics analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "metaproteomics analysis activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "metaproteomics analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "metaproteomics analysis activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "metaproteomics analysis activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "metaproteomics analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "metaproteomics analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "metaproteomics analysis activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "metaproteomics analysis activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "description": "The instrument used to collect the data used in the analysis",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "multivalued": false,
+          "alias": "used",
+          "owner": "metaproteomics analysis activity",
+          "range": "instrument"
+        }
+      }
+    },
+    "nom analysis activity": {
+      "name": "nom analysis activity",
+      "in_subset": [
+        "workflow subset"
+      ],
+      "from_schema": "https://microbiomedata/schema",
+      "is_a": "workflow execution activity",
+      "slot_usage": {
+        "used": {
+          "name": "used",
+          "description": "The instrument used to collect the data used in the analysis",
+          "multivalued": false,
+          "range": "instrument"
+        },
+        "has calibration": {
+          "name": "has calibration",
+          "description": "A reference to a file that holds calibration information.",
+          "range": "string"
+        }
+      },
+      "attributes": {
+        "execution resource": {
+          "name": "execution resource",
+          "description": "Example: NERSC-Cori",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "execution_resource",
+          "owner": "nom analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "git url": {
+          "name": "git url",
+          "description": "Example: https://github.com/microbiomedata/mg_annotation/releases/tag/0.1",
+          "from_schema": "https://microbiomedata/schema",
+          "is_a": "attribute",
+          "alias": "git_url",
+          "owner": "nom analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "has input": {
+          "name": "has input",
+          "description": "An input to a process.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_input",
+          "owner": "nom analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "has output": {
+          "name": "has output",
+          "description": "An output biosample to a processing step",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "multivalued": true,
+          "alias": "has_output",
+          "owner": "nom analysis activity",
+          "range": "named thing",
+          "required": true
+        },
+        "part of": {
+          "name": "part of",
+          "aliases": [
+            "is part of"
+          ],
+          "description": "Links a resource to another resource that either logically or physically includes it.",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "named thing",
+          "slot_uri": "dcterms:isPartOf",
+          "multivalued": true,
+          "alias": "part_of",
+          "owner": "nom analysis activity",
+          "range": "named thing"
+        },
+        "type": {
+          "name": "type",
+          "description": "An optional string that specifies the type object.  This is used to allow for searches for different kinds of objects.",
+          "deprecated": "Due to confusion about what values are used for this slot, it is best not to use this slot. See https://github.com/microbiomedata/nmdc-schema/issues/248.",
+          "from_schema": "https://microbiomedata/schema",
+          "designates_type": true,
+          "alias": "type",
+          "owner": "nom analysis activity",
+          "range": "string",
+          "required": true
+        },
+        "id": {
+          "name": "id",
+          "description": "A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "identifier": true,
+          "alias": "id",
+          "owner": "nom analysis activity",
+          "range": "string"
+        },
+        "name": {
+          "name": "name",
+          "description": "A human readable label for an entity",
+          "from_schema": "https://microbiomedata/schema",
+          "multivalued": false,
+          "alias": "name",
+          "owner": "nom analysis activity",
+          "range": "string"
+        },
+        "started at time": {
+          "name": "started at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "started_at_time",
+          "owner": "nom analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "ended at time": {
+          "name": "ended at time",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "ended_at_time",
+          "owner": "nom analysis activity",
+          "range": "datetime",
+          "required": true,
+          "pattern": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+        },
+        "was informed by": {
+          "name": "was informed by",
+          "from_schema": "https://microbiomedata/schema",
+          "alias": "was_informed_by",
+          "owner": "nom analysis activity",
+          "range": "activity",
+          "required": true
+        },
+        "was associated with": {
+          "name": "was associated with",
+          "description": "the agent/entity associated with the generation of the file",
+          "from_schema": "https://microbiomedata/schema",
+          "inlined": false,
+          "alias": "was_associated_with",
+          "owner": "nom analysis activity",
+          "range": "workflow execution activity",
+          "required": false
+        },
+        "used": {
+          "name": "used",
+          "description": "The instrument used to collect the data used in the analysis",
+          "from_schema": "https://microbiomedata/schema",
+          "domain": "activity",
+          "multivalued": false,
+          "alias": "used",
+          "owner": "nom analysis activity",
+          "range": "instrument"
+        }
+      }
+    }
+  },
+  "source_file": "src/schema/nmdc.yaml",
+  "@type": "SchemaDefinition"
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1365,7 +1365,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "11144dc4f2729cdf851f54cad9fdc3f5f55d2cacf6e1e6e2c6ad8e810db3481a"
+content-hash = "8a88480bffd827d4c07e81d720b57df242c4165cade2b455521a019e03540b61"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -70,7 +70,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 colorama = {version = "*", markers = "os_name == \"nt\""}
-importlib-metadata = {version = ">=0.22", markers = "python_version < \"3.8\""}
 packaging = ">=19.0"
 pep517 = ">=0.9.1"
 tomli = ">=1.0.0"
@@ -120,6 +119,14 @@ python-versions = "*"
 rdflib = ">=0.4.2"
 
 [[package]]
+name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -132,11 +139,14 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "7.1.2"
+version = "8.0.4"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
@@ -282,28 +292,12 @@ optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
-
-[[package]]
-name = "importlib-resources"
-version = "5.4.0"
-description = "Read resources from Python packages"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "isodate"
@@ -426,10 +420,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=17.4.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
@@ -455,7 +446,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "linkml"
-version = "1.1.15"
+version = "1.2.0.0rc7"
 description = "Linked Open Data Modeling Language"
 category = "main"
 optional = false
@@ -463,15 +454,15 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 argparse = ">=1.4.0"
-click = ">=7.0,<8.0"
+click = ">=7.0"
 graphviz = ">=0.10.1"
 hbreader = "*"
 isodate = ">=0.6.0"
 jinja2 = "*"
 jsonasobj2 = ">=1.0.3,<2.0"
 jsonschema = ">=3.0.1"
-linkml-runtime = ">=1.1.9"
-linkml-runtime-api = "*"
+linkml-dataops = "*"
+linkml-runtime = ">=1.1.26"
 myst-parser = "*"
 openpyxl = "*"
 pandas = "*"
@@ -493,37 +484,13 @@ requests = ">=2.22"
 sphinx = "*"
 sphinx-click = "*"
 sphinx-rtd-theme = "*"
-sqlalchemy = "*"
+sqlalchemy = ">=1.4.31"
 watchdog = ">=0.9.0"
 
 [[package]]
-name = "linkml-runtime"
-version = "1.1.9"
-description = "LinkML Runtime Environment"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-click = "*"
-deprecated = "*"
-hbreader = "*"
-json-flattener = ">=0.1.7"
-jsonasobj2 = ">=1.0.4,<2.0"
-jsonschema = ">=3.2.0"
-prefixcommons = "*"
-pyldmod = "*"
-pyyaml = ">=5.1,<6.0"
-rdflib = ">=5.0,<6.0"
-rdflib-jsonld = ">=0.5.0,<=0.6.1"
-rdflib-pyldmod-compat = "*"
-requests = "*"
-shexjsg = ">=0.7,<1.0"
-
-[[package]]
-name = "linkml-runtime-api"
-version = "0.0.6"
-description = "LinkML Runtime Environment API"
+name = "linkml-dataops"
+version = "0.1.0"
+description = "LinkML Data Operations API"
 category = "main"
 optional = false
 python-versions = ">=3.7"
@@ -534,6 +501,26 @@ jsonpatch = "*"
 jsonpath-ng = "*"
 linkml-runtime = ">=1.1.6"
 "ruamel.yaml" = "*"
+
+[[package]]
+name = "linkml-runtime"
+version = "1.2.0rc6"
+description = "Runtime environment for LinkML, the Linked open data modeling language"
+category = "main"
+optional = false
+python-versions = ">=3.7.1,<4.0.0"
+
+[package.dependencies]
+click = "*"
+deprecated = "*"
+hbreader = "*"
+json-flattener = ">=0.1.9"
+jsonasobj2 = ">=1.0.4,<2.0.0"
+jsonschema = ">=3.2.0"
+prefixcommons = "*"
+pyyaml = ">=5.1.0,<6.0.0"
+rdflib = ">=6.0.0"
+requests = "*"
 
 [[package]]
 name = "lxml"
@@ -574,7 +561,6 @@ python-versions = "~=3.6"
 [package.dependencies]
 attrs = ">=19,<22"
 mdurl = ">=0.1,<1.0"
-typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 benchmarking = ["psutil", "pytest", "pytest-benchmark (>=3.2,<4.0)"]
@@ -673,11 +659,11 @@ testing = ["beautifulsoup4", "coverage", "docutils (>=0.17.0,<0.18.0)", "pytest 
 
 [[package]]
 name = "numpy"
-version = "1.21.1"
+version = "1.22.3"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [[package]]
 name = "openpyxl"
@@ -703,19 +689,24 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pandas"
-version = "1.1.5"
+version = "1.4.1"
 description = "Powerful data structures for data analysis, time series, and statistics"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.8"
 
 [package.dependencies]
-numpy = ">=1.15.4"
-python-dateutil = ">=2.7.3"
-pytz = ">=2017.2"
+numpy = [
+    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+]
+python-dateutil = ">=2.8.1"
+pytz = ">=2020.1"
 
 [package.extras]
-test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "pandoc"
@@ -746,9 +737,7 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-importlib_metadata = {version = "*", markers = "python_version < \"3.8\""}
 tomli = {version = ">=1.1.0", markers = "python_version >= \"3.6\""}
-zipp = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "pkginfo"
@@ -891,7 +880,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "pyshex"
-version = "0.7.20"
+version = "0.8.0"
 description = "Python ShEx Implementation"
 category = "main"
 optional = false
@@ -899,18 +888,19 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 cfgraph = ">=0.2.1"
-pyshexc = "0.8.3"
-rdflib = ">=5.0,<6.0"
-rdflib-jsonld = ">=0.5,<1.0"
+chardet = "*"
+pyshexc = "0.9.0"
+rdflib = ">=5.0.0"
+rdflib-shim = "*"
 requests = ">=2.22.0"
-shexjsg = ">=0.7.1"
-sparqlslurper = ">=0.4,<1.0"
+shexjsg = ">=0.8.1"
+sparqlslurper = ">=0.5.1"
 sparqlwrapper = ">=1.8.5"
 urllib3 = "*"
 
 [[package]]
 name = "pyshexc"
-version = "0.8.3"
+version = "0.9.0"
 description = "PyShExC - Python ShEx compiler"
 category = "main"
 optional = false
@@ -918,11 +908,12 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 antlr4-python3-runtime = ">=4.9,<5.0"
+chardet = "*"
 jsonasobj = ">=1.2.1"
-pyjsg = ">=0.11.6"
-rdflib = ">=5.0,<6.0"
-rdflib-jsonld = ">=0.5,<1.0"
-shexjsg = ">=0.7.1"
+pyjsg = ">=0.11.9"
+rdflib = ">=5.0.0"
+rdflib-shim = "*"
+shexjsg = ">=0.8.1"
 
 [[package]]
 name = "python-dateutil"
@@ -980,22 +971,20 @@ pyyaml = "*"
 
 [[package]]
 name = "rdflib"
-version = "5.0.0"
+version = "6.1.1"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
 isodate = "*"
 pyparsing = "*"
-six = "*"
 
 [package.extras]
-docs = ["sphinx (<3)", "sphinxcontrib-apidoc"]
+docs = ["sphinx (<5)", "sphinxcontrib-apidoc"]
 html = ["html5lib"]
-sparql = ["requests"]
-tests = ["html5lib", "networkx", "nose", "doctest-ignore-unicode"]
+tests = ["berkeleydb", "html5lib", "networkx", "pytest", "pytest-cov", "pytest-subtests"]
 
 [[package]]
 name = "rdflib-jsonld"
@@ -1035,7 +1024,7 @@ rdflib-jsonld = "0.6.1"
 
 [[package]]
 name = "readme-renderer"
-version = "32.0"
+version = "33.0"
 description = "readme_renderer is a library for rendering \"readme\" descriptions for Warehouse"
 category = "dev"
 optional = false
@@ -1047,7 +1036,7 @@ docutils = ">=0.13.1"
 Pygments = ">=2.5.1"
 
 [package.extras]
-md = ["cmarkgfm (>=0.5.0,<0.7.0)"]
+md = ["cmarkgfm (>=0.8.0)"]
 
 [[package]]
 name = "requests"
@@ -1153,14 +1142,15 @@ python-versions = "*"
 
 [[package]]
 name = "sparqlslurper"
-version = "0.4.1"
+version = "0.5.1"
 description = "SPARQL Slurper for rdflib"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7.4"
 
 [package.dependencies]
-rdflib = ">=5.0,<6.0"
+rdflib = ">=5.0.0"
+rdflib-shim = "*"
 sparqlwrapper = ">=1.8.2"
 
 [[package]]
@@ -1310,7 +1300,7 @@ test = ["pytest"]
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.31"
+version = "1.4.32"
 description = "Database Abstraction Library"
 category = "main"
 optional = false
@@ -1318,7 +1308,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 
 [package.dependencies]
 greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platform_machine == \"aarch64\" or platform_machine == \"ppc64le\" or platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"win32\" or platform_machine == \"WIN32\")"}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
@@ -1460,8 +1449,8 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.7"
-content-hash = "88c69a9559fc5c474174fdf45f4b26f35468688de0ab96290d97261d01270322"
+python-versions = "^3.9"
+content-hash = "11144dc4f2729cdf851f54cad9fdc3f5f55d2cacf6e1e6e2c6ad8e810db3481a"
 
 [metadata.files]
 alabaster = [
@@ -1554,13 +1543,17 @@ cffi = [
 cfgraph = [
     {file = "CFGraph-0.2.1.tar.gz", hash = "sha256:b57fe7044a10b8ff65aa3a8a8ddc7d4cd77bf511b42e57289cd52cbc29f8fe74"},
 ]
+chardet = [
+    {file = "chardet-4.0.0-py2.py3-none-any.whl", hash = "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"},
+    {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
     {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
+    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -1704,10 +1697,6 @@ importlib-metadata = [
     {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
     {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
 ]
-importlib-resources = [
-    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
-    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
-]
 isodate = [
     {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
     {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
@@ -1800,16 +1789,16 @@ keyring = [
     {file = "keyring-23.5.0.tar.gz", hash = "sha256:9012508e141a80bd1c0b6778d5c610dd9f8c464d75ac6774248500503f972fb9"},
 ]
 linkml = [
-    {file = "linkml-1.1.15-py3-none-any.whl", hash = "sha256:b6b2b91bafabc4c42d326f4df8f8d2d66d2c15ee890174061bc413a7b56d15b6"},
-    {file = "linkml-1.1.15.tar.gz", hash = "sha256:76a2497e64c814e0eb4507a22754659d2cf0781993f8274e67d00df5878c3ec7"},
+    {file = "linkml-1.2.0.0rc7-py3-none-any.whl", hash = "sha256:370decd0701dcf46260d127d2aad9ac76ac1b816c1760c710bcc7bb9a5e578d2"},
+    {file = "linkml-1.2.0.0rc7.tar.gz", hash = "sha256:2f945bb2337e3112d4a276070e286c80fa1c46f55825082527885307d5edd887"},
+]
+linkml-dataops = [
+    {file = "linkml_dataops-0.1.0-py3-none-any.whl", hash = "sha256:193cf7f659e5f07946d2c2761896910d5f7151d91282543b1363801f68307f4c"},
+    {file = "linkml_dataops-0.1.0.tar.gz", hash = "sha256:4550eab65e78b70dc3b9c651724a94ac2b1d1edb2fbe576465f1d6951a54ed04"},
 ]
 linkml-runtime = [
-    {file = "linkml_runtime-1.1.9-py3-none-any.whl", hash = "sha256:855056f3381e805a728f348b0db55cb5ee7a0c1f247336afe1b9830dc3a95502"},
-    {file = "linkml_runtime-1.1.9.tar.gz", hash = "sha256:9b4717c79e8d43f3d03ea26145205449728b62d284b3ad44fcb4a1fc208a64f1"},
-]
-linkml-runtime-api = [
-    {file = "linkml_runtime_api-0.0.6-py3-none-any.whl", hash = "sha256:b567a8f678f96fa723f0ba2f225712ab989930f023f5bb84df2ae2ea19db04f5"},
-    {file = "linkml_runtime_api-0.0.6.tar.gz", hash = "sha256:298d446cc4e5875d4622f6be794a521f1a67bbb1743902dd36b5917ea12c34d3"},
+    {file = "linkml_runtime-1.2.0rc6-py3-none-any.whl", hash = "sha256:3088d3d188bd77cb18975f39d3d319d28ee1f251ce62021dd450d8d1cf5a7212"},
+    {file = "linkml_runtime-1.2.0rc6.tar.gz", hash = "sha256:995dafa13da1da29249fc6391d7fab3f4fba36ffeb45b6b17600c5d23e84eb64"},
 ]
 lxml = [
     {file = "lxml-4.8.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e1ab2fac607842ac36864e358c42feb0960ae62c34aa4caaf12ada0a1fb5d99b"},
@@ -1945,34 +1934,25 @@ myst-parser = [
     {file = "myst_parser-0.17.0-py3-none-any.whl", hash = "sha256:555ec2950aba5ae5dac5c162c7e9a43ad4a7291cfac644d8f5f84da8efa6f356"},
 ]
 numpy = [
-    {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
-    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"},
-    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062"},
-    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1"},
-    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671"},
-    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e"},
-    {file = "numpy-1.21.1-cp37-cp37m-win32.whl", hash = "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172"},
-    {file = "numpy-1.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8"},
-    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16"},
-    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267"},
-    {file = "numpy-1.21.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6"},
-    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63"},
-    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af"},
-    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5"},
-    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68"},
-    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8"},
-    {file = "numpy-1.21.1-cp38-cp38-win32.whl", hash = "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd"},
-    {file = "numpy-1.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214"},
-    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f"},
-    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b"},
-    {file = "numpy-1.21.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac"},
-    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1"},
-    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1"},
-    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a"},
-    {file = "numpy-1.21.1-cp39-cp39-win32.whl", hash = "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2"},
-    {file = "numpy-1.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33"},
-    {file = "numpy-1.21.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4"},
-    {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1"},
+    {file = "numpy-1.22.3-cp38-cp38-win32.whl", hash = "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62"},
+    {file = "numpy-1.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168"},
+    {file = "numpy-1.22.3-cp39-cp39-win32.whl", hash = "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"},
+    {file = "numpy-1.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a"},
+    {file = "numpy-1.22.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f"},
+    {file = "numpy-1.22.3.zip", hash = "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"},
 ]
 openpyxl = [
     {file = "openpyxl-3.0.7-py2.py3-none-any.whl", hash = "sha256:46af4eaf201a89b610fcca177eed957635f88770a5462fb6aae4a2a52b0ff516"},
@@ -1983,30 +1963,27 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pandas = [
-    {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814"},
-    {file = "pandas-1.1.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f"},
-    {file = "pandas-1.1.5-cp36-cp36m-win32.whl", hash = "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5"},
-    {file = "pandas-1.1.5-cp36-cp36m-win_amd64.whl", hash = "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648"},
-    {file = "pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae"},
-    {file = "pandas-1.1.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788"},
-    {file = "pandas-1.1.5-cp37-cp37m-win32.whl", hash = "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb"},
-    {file = "pandas-1.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98"},
-    {file = "pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e"},
-    {file = "pandas-1.1.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b"},
-    {file = "pandas-1.1.5-cp38-cp38-win32.whl", hash = "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b"},
-    {file = "pandas-1.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d"},
-    {file = "pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a"},
-    {file = "pandas-1.1.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a"},
-    {file = "pandas-1.1.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a"},
-    {file = "pandas-1.1.5-cp39-cp39-win32.whl", hash = "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb"},
-    {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
-    {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
+    {file = "pandas-1.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3dfb32ed50122fe8c5e7f2b8d97387edd742cc78f9ec36f007ee126cd3720907"},
+    {file = "pandas-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0259cd11e7e6125aaea3af823b80444f3adad6149ff4c97fef760093598b3e34"},
+    {file = "pandas-1.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:96e9ece5759f9b47ae43794b6359bbc54805d76e573b161ae770c1ea59393106"},
+    {file = "pandas-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:508c99debccd15790d526ce6b1624b97a5e1e4ca5b871319fb0ebfd46b8f4dad"},
+    {file = "pandas-1.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6a7bbbb7950063bfc942f8794bc3e31697c020a14f1cd8905fc1d28ec674a01"},
+    {file = "pandas-1.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:c614001129b2a5add5e3677c3a213a9e6fd376204cb8d17c04e84ff7dfc02a73"},
+    {file = "pandas-1.4.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:4e1176f45981c8ccc8161bc036916c004ca51037a7ed73f2d2a9857e6dbe654f"},
+    {file = "pandas-1.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bbb15ad79050e8b8d39ec40dd96a30cd09b886a2ae8848d0df1abba4d5502a67"},
+    {file = "pandas-1.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6d6ad1da00c7cc7d8dd1559a6ba59ba3973be6b15722d49738b2be0977eb8a0c"},
+    {file = "pandas-1.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:358b0bc98a5ff067132d23bf7a2242ee95db9ea5b7bbc401cf79205f11502fd3"},
+    {file = "pandas-1.4.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6105af6533f8b63a43ea9f08a2ede04e8f43e49daef0209ab0d30352bcf08bee"},
+    {file = "pandas-1.4.1-cp38-cp38-win32.whl", hash = "sha256:04dd15d9db538470900c851498e532ef28d4e56bfe72c9523acb32042de43dfb"},
+    {file = "pandas-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b384516dbb4e6aae30e3464c2e77c563da5980440fbdfbd0968e3942f8f9d70"},
+    {file = "pandas-1.4.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f02e85e6d832be37d7f16cf6ac8bb26b519ace3e5f3235564a91c7f658ab2a43"},
+    {file = "pandas-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0b1a13f647e4209ed7dbb5da3497891d0045da9785327530ab696417ef478f84"},
+    {file = "pandas-1.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:19f7c632436b1b4f84615c3b127bbd7bc603db95e3d4332ed259dc815c9aaa26"},
+    {file = "pandas-1.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ea47ba1d6f359680130bd29af497333be6110de8f4c35b9211eec5a5a9630fa"},
+    {file = "pandas-1.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e5a7a1e0ecaac652326af627a3eca84886da9e667d68286866d4e33f6547caf"},
+    {file = "pandas-1.4.1-cp39-cp39-win32.whl", hash = "sha256:1d85d5f6be66dfd6d1d8d13b9535e342a2214260f1852654b19fa4d7b8d1218b"},
+    {file = "pandas-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3129a35d9dad1d80c234dd78f8f03141b914395d23f97cf92a366dcd19f8f8bf"},
+    {file = "pandas-1.4.1.tar.gz", hash = "sha256:8db93ec98ac7cb5f8ac1420c10f5e3c43533153f253fe7fb6d891cf5aa2b80d2"},
 ]
 pandoc = [
     {file = "pandoc-2.1.tar.gz", hash = "sha256:5385d81a2176237e3c48e9719ab661c7046ec5b24db5f138332f189cd7793b87"},
@@ -2119,12 +2096,12 @@ pyrsistent = [
     {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 pyshex = [
-    {file = "PyShEx-0.7.20-py3-none-any.whl", hash = "sha256:6c9cecd7726461c2105330a9b2d5fd054f0e7966bfc9e3a73e7136b8be63d089"},
-    {file = "PyShEx-0.7.20.tar.gz", hash = "sha256:3ea61c2a3f7436bac725bd5001072ba08d2dff5b836d5388ce9ff6f5251c2707"},
+    {file = "PyShEx-0.8.0-py3-none-any.whl", hash = "sha256:e1edc64806c88f8341a6358aa342315704f36ab528af6c28ec29bc14b90a0818"},
+    {file = "PyShEx-0.8.0.tar.gz", hash = "sha256:1e158a55b6a5d375aeff86becb2a177ec37586677a9f0f5297fef3bfebaf05ce"},
 ]
 pyshexc = [
-    {file = "PyShExC-0.8.3-py2.py3-none-any.whl", hash = "sha256:6f75e26dfda605c994031a72ca74b2b0079e1f7b12ab713e030078d8fa05dc3a"},
-    {file = "PyShExC-0.8.3.tar.gz", hash = "sha256:ad83bb2a645f64becbf946d4bd170e35fd9b903616c7ee25d5a4ed188cf2d1dd"},
+    {file = "PyShExC-0.9.0-py2.py3-none-any.whl", hash = "sha256:238d30bf5c395d66f07557f7b9c1bac9c4782ef5ad495a2fbc6399347f1bd2d9"},
+    {file = "PyShExC-0.9.0.tar.gz", hash = "sha256:86fbd322248dd89b984163227fa81da8d7bceec0c58b49cdac3c21c920c8cafa"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -2188,8 +2165,8 @@ pyyaml-env-tag = [
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
 ]
 rdflib = [
-    {file = "rdflib-5.0.0-py3-none-any.whl", hash = "sha256:88208ea971a87886d60ae2b1a4b2cdc263527af0454c422118d43fe64b357877"},
-    {file = "rdflib-5.0.0.tar.gz", hash = "sha256:78149dd49d385efec3b3adfbd61c87afaf1281c30d3fcaf1b323b34f603fb155"},
+    {file = "rdflib-6.1.1-py3-none-any.whl", hash = "sha256:fc81cef513cd552d471f2926141396b633207109d0154c8e77926222c70367fe"},
+    {file = "rdflib-6.1.1.tar.gz", hash = "sha256:8dbfa0af2990b98471dacbc936d6494c997ede92fd8ed693fb84ee700ef6f754"},
 ]
 rdflib-jsonld = [
     {file = "rdflib-jsonld-0.6.1.tar.gz", hash = "sha256:eda5a42a2e09f80d4da78e32b5c684bccdf275368f1541e6b7bcddfb1382a0e0"},
@@ -2204,8 +2181,8 @@ rdflib-shim = [
     {file = "rdflib_shim-1.0.3.tar.gz", hash = "sha256:d955d11e2986aab42b6830ca56ac6bc9c893abd1d049a161c6de2f1b99d4fc0d"},
 ]
 readme-renderer = [
-    {file = "readme_renderer-32.0-py3-none-any.whl", hash = "sha256:a50a0f2123a4c1145ac6f420e1a348aafefcc9211c846e3d51df05fe3d865b7d"},
-    {file = "readme_renderer-32.0.tar.gz", hash = "sha256:b512beafa6798260c7d5af3e1b1f097e58bfcd9a575da7c4ddd5e037490a5b85"},
+    {file = "readme_renderer-33.0-py3-none-any.whl", hash = "sha256:f02cee0c4de9636b5a62b6be50c9742427ba1b956aad1d938bfb087d0d72ccdf"},
+    {file = "readme_renderer-33.0.tar.gz", hash = "sha256:e3b53bc84bd6af054e4cc1fe3567dc1ae19f554134221043a3f8c674e22209db"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
@@ -2267,8 +2244,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 sparqlslurper = [
-    {file = "sparqlslurper-0.4.1-py3-none-any.whl", hash = "sha256:e1decb006837c5b8f1f404710d86a36a6cd09301910c79165094a1354ddae487"},
-    {file = "sparqlslurper-0.4.1.tar.gz", hash = "sha256:0808cf53923c9ffbf069f80310c73a41d3ae170c266d805b56b6978a066f63e3"},
+    {file = "sparqlslurper-0.5.1-py3-none-any.whl", hash = "sha256:ae49b2d8ce3dd38df7a40465b228ad5d33fb7e11b3f248d195f9cadfc9cfff87"},
+    {file = "sparqlslurper-0.5.1.tar.gz", hash = "sha256:9282ebb064fc6152a58269d194cb1e7b275b0f095425a578d75b96dcc851f546"},
 ]
 sparqlwrapper = [
     {file = "SPARQLWrapper-1.8.5-py2-none-any.whl", hash = "sha256:357ee8a27bc910ea13d77836dbddd0b914991495b8cc1bf70676578155e962a8"},
@@ -2314,42 +2291,41 @@ sphinxcontrib-serializinghtml = [
     {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.4.31-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:c3abc34fed19fdeaead0ced8cf56dd121f08198008c033596aa6aae7cc58f59f"},
-    {file = "SQLAlchemy-1.4.31-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8d0949b11681380b4a50ac3cd075e4816afe9fa4a8c8ae006c1ca26f0fa40ad8"},
-    {file = "SQLAlchemy-1.4.31-cp27-cp27m-win32.whl", hash = "sha256:f3b7ec97e68b68cb1f9ddb82eda17b418f19a034fa8380a0ac04e8fe01532875"},
-    {file = "SQLAlchemy-1.4.31-cp27-cp27m-win_amd64.whl", hash = "sha256:81f2dd355b57770fdf292b54f3e0a9823ec27a543f947fa2eb4ec0df44f35f0d"},
-    {file = "SQLAlchemy-1.4.31-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4ad31cec8b49fd718470328ad9711f4dc703507d434fd45461096da0a7135ee0"},
-    {file = "SQLAlchemy-1.4.31-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:05fa14f279d43df68964ad066f653193187909950aa0163320b728edfc400167"},
-    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dccff41478050e823271642837b904d5f9bda3f5cf7d371ce163f00a694118d6"},
-    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57205844f246bab9b666a32f59b046add8995c665d9ecb2b7b837b087df90639"},
-    {file = "SQLAlchemy-1.4.31-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea8210090a816d48a4291a47462bac750e3bc5c2442e6d64f7b8137a7c3f9ac5"},
-    {file = "SQLAlchemy-1.4.31-cp310-cp310-win32.whl", hash = "sha256:2e216c13ecc7fcdcbb86bb3225425b3ed338e43a8810c7089ddb472676124b9b"},
-    {file = "SQLAlchemy-1.4.31-cp310-cp310-win_amd64.whl", hash = "sha256:e3a86b59b6227ef72ffc10d4b23f0fe994bef64d4667eab4fb8cd43de4223bec"},
-    {file = "SQLAlchemy-1.4.31-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:2fd4d3ca64c41dae31228b80556ab55b6489275fb204827f6560b65f95692cf3"},
-    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f22c040d196f841168b1456e77c30a18a3dc16b336ddbc5a24ce01ab4e95ae0"},
-    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c0c7171aa5a57e522a04a31b84798b6c926234cb559c0939840c3235cf068813"},
-    {file = "SQLAlchemy-1.4.31-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d046a9aeba9bc53e88a41e58beb72b6205abb9a20f6c136161adf9128e589db5"},
-    {file = "SQLAlchemy-1.4.31-cp36-cp36m-win32.whl", hash = "sha256:d86132922531f0dc5a4f424c7580a472a924dd737602638e704841c9cb24aea2"},
-    {file = "SQLAlchemy-1.4.31-cp36-cp36m-win_amd64.whl", hash = "sha256:ca68c52e3cae491ace2bf39b35fef4ce26c192fd70b4cd90f040d419f70893b5"},
-    {file = "SQLAlchemy-1.4.31-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:cf2cd387409b12d0a8b801610d6336ee7d24043b6dd965950eaec09b73e7262f"},
-    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb4b15fb1f0aafa65cbdc62d3c2078bea1ceecbfccc9a1f23a2113c9ac1191fa"},
-    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c317ddd7c586af350a6aef22b891e84b16bff1a27886ed5b30f15c1ed59caeaa"},
-    {file = "SQLAlchemy-1.4.31-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c7ed6c69debaf6198fadb1c16ae1253a29a7670bbf0646f92582eb465a0b999"},
-    {file = "SQLAlchemy-1.4.31-cp37-cp37m-win32.whl", hash = "sha256:6a01ec49ca54ce03bc14e10de55dfc64187a2194b3b0e5ac0fdbe9b24767e79e"},
-    {file = "SQLAlchemy-1.4.31-cp37-cp37m-win_amd64.whl", hash = "sha256:330eb45395874cc7787214fdd4489e2afb931bc49e0a7a8f9cd56d6e9c5b1639"},
-    {file = "SQLAlchemy-1.4.31-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5e9c7b3567edbc2183607f7d9f3e7e89355b8f8984eec4d2cd1e1513c8f7b43f"},
-    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de85c26a5a1c72e695ab0454e92f60213b4459b8d7c502e0be7a6369690eeb1a"},
-    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:975f5c0793892c634c4920057da0de3a48bbbbd0a5c86f5fcf2f2fedf41b76da"},
-    {file = "SQLAlchemy-1.4.31-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5c20c8415173b119762b6110af64448adccd4d11f273fb9f718a9865b88a99c"},
-    {file = "SQLAlchemy-1.4.31-cp38-cp38-win32.whl", hash = "sha256:b35dca159c1c9fa8a5f9005e42133eed82705bf8e243da371a5e5826440e65ca"},
-    {file = "SQLAlchemy-1.4.31-cp38-cp38-win_amd64.whl", hash = "sha256:b7b20c88873675903d6438d8b33fba027997193e274b9367421e610d9da76c08"},
-    {file = "SQLAlchemy-1.4.31-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:85e4c244e1de056d48dae466e9baf9437980c19fcde493e0db1a0a986e6d75b4"},
-    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e79e73d5ee24196d3057340e356e6254af4d10e1fc22d3207ea8342fc5ffb977"},
-    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:15a03261aa1e68f208e71ae3cd845b00063d242cbf8c87348a0c2c0fc6e1f2ac"},
-    {file = "SQLAlchemy-1.4.31-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ddc5e5ccc0160e7ad190e5c61eb57560f38559e22586955f205e537cda26034"},
-    {file = "SQLAlchemy-1.4.31-cp39-cp39-win32.whl", hash = "sha256:289465162b1fa1e7a982f8abe59d26a8331211cad4942e8031d2b7db1f75e649"},
-    {file = "SQLAlchemy-1.4.31-cp39-cp39-win_amd64.whl", hash = "sha256:9e4fb2895b83993831ba2401b6404de953fdbfa9d7d4fa6a4756294a83bbc94f"},
-    {file = "SQLAlchemy-1.4.31.tar.gz", hash = "sha256:582b59d1e5780a447aada22b461e50b404a9dc05768da1d87368ad8190468418"},
+    {file = "SQLAlchemy-1.4.32-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:4b2bcab3a914715d332ca783e9bda13bc570d8b9ef087563210ba63082c18c16"},
+    {file = "SQLAlchemy-1.4.32-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:159c2f69dd6efd28e894f261ffca1100690f28210f34cfcd70b895e0ea7a64f3"},
+    {file = "SQLAlchemy-1.4.32-cp27-cp27m-win_amd64.whl", hash = "sha256:d7e483f4791fbda60e23926b098702340504f7684ce7e1fd2c1bf02029288423"},
+    {file = "SQLAlchemy-1.4.32-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4aa96e957141006181ca58e792e900ee511085b8dae06c2d08c00f108280fb8a"},
+    {file = "SQLAlchemy-1.4.32-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:576684771456d02e24078047c2567025f2011977aa342063468577d94e194b00"},
+    {file = "SQLAlchemy-1.4.32-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff677fa4522dafb5a5e2c0cf909790d5d367326321aeabc0dffc9047cb235bd"},
+    {file = "SQLAlchemy-1.4.32-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8679f9aba5ac22e7bce54ccd8a77641d3aea3e2d96e73e4356c887ebf8ff1082"},
+    {file = "SQLAlchemy-1.4.32-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7046f7aa2db445daccc8424f50b47a66c4039c9f058246b43796aa818f8b751"},
+    {file = "SQLAlchemy-1.4.32-cp310-cp310-win32.whl", hash = "sha256:bedd89c34ab62565d44745212814e4b57ef1c24ad4af9b29c504ce40f0dc6558"},
+    {file = "SQLAlchemy-1.4.32-cp310-cp310-win_amd64.whl", hash = "sha256:199dc6d0068753b6a8c0bd3aceb86a3e782df118260ebc1fa981ea31ee054674"},
+    {file = "SQLAlchemy-1.4.32-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:8e1e5d96b744a4f91163290b01045430f3f32579e46d87282449e5b14d27d4ac"},
+    {file = "SQLAlchemy-1.4.32-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edfcf93fd92e2f9eef640b3a7a40db20fe3c1d7c2c74faa41424c63dead61b76"},
+    {file = "SQLAlchemy-1.4.32-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04164e0063feb7aedd9d073db0fd496edb244be40d46ea1f0d8990815e4b8c34"},
+    {file = "SQLAlchemy-1.4.32-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ba59761c19b800bc2e1c9324da04d35ef51e4ee9621ff37534bc2290d258f71"},
+    {file = "SQLAlchemy-1.4.32-cp36-cp36m-win32.whl", hash = "sha256:708973b5d9e1e441188124aaf13c121e5b03b6054c2df59b32219175a25aa13e"},
+    {file = "SQLAlchemy-1.4.32-cp36-cp36m-win_amd64.whl", hash = "sha256:316270e5867566376e69a0ac738b863d41396e2b63274616817e1d34156dff0e"},
+    {file = "SQLAlchemy-1.4.32-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:9a0195af6b9050c9322a97cf07514f66fe511968e623ca87b2df5e3cf6349615"},
+    {file = "SQLAlchemy-1.4.32-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e4a3c0c3c596296b37f8427c467c8e4336dc8d50f8ed38042e8ba79507b2c9"},
+    {file = "SQLAlchemy-1.4.32-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bca714d831e5b8860c3ab134c93aec63d1a4f493bed20084f54e3ce9f0a3bf99"},
+    {file = "SQLAlchemy-1.4.32-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9a680d9665f88346ed339888781f5236347933906c5a56348abb8261282ec48"},
+    {file = "SQLAlchemy-1.4.32-cp37-cp37m-win32.whl", hash = "sha256:9cb5698c896fa72f88e7ef04ef62572faf56809093180771d9be8d9f2e264a13"},
+    {file = "SQLAlchemy-1.4.32-cp37-cp37m-win_amd64.whl", hash = "sha256:8b9a395122770a6f08ebfd0321546d7379f43505882c7419d7886856a07caa13"},
+    {file = "SQLAlchemy-1.4.32-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:3f88a4ee192142eeed3fe173f673ea6ab1f5a863810a9d85dbf6c67a9bd08f97"},
+    {file = "SQLAlchemy-1.4.32-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dd93162615870c976dba43963a24bb418b28448fef584f30755990c134a06a55"},
+    {file = "SQLAlchemy-1.4.32-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5a2e73508f939175363d8a4be9dcdc84cf16a92578d7fa86e6e4ca0e6b3667b2"},
+    {file = "SQLAlchemy-1.4.32-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfec934aac7f9fa95fc82147a4ba5db0a8bdc4ebf1e33b585ab8860beb10232f"},
+    {file = "SQLAlchemy-1.4.32-cp38-cp38-win32.whl", hash = "sha256:bb42f9b259c33662c6a9b866012f6908a91731a419e69304e1261ba3ab87b8d1"},
+    {file = "SQLAlchemy-1.4.32-cp38-cp38-win_amd64.whl", hash = "sha256:7ff72b3cc9242d1a1c9b84bd945907bf174d74fc2519efe6184d6390a8df478b"},
+    {file = "SQLAlchemy-1.4.32-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:5dc9801ae9884e822ba942ca493642fb50f049c06b6dbe3178691fce48ceb089"},
+    {file = "SQLAlchemy-1.4.32-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4607d2d16330757818c9d6fba322c2e80b4b112ff24295d1343a80b876eb0ed"},
+    {file = "SQLAlchemy-1.4.32-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:20e9eba7fd86ef52e0df25bea83b8b518dfdf0bce09b336cfe51671f52aaaa3f"},
+    {file = "SQLAlchemy-1.4.32-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:290cbdf19129ae520d4bdce392648c6fcdbee763bc8f750b53a5ab51880cb9c9"},
+    {file = "SQLAlchemy-1.4.32-cp39-cp39-win32.whl", hash = "sha256:1bbac3e8293b34c4403d297e21e8f10d2a57756b75cff101dc62186adec725f5"},
+    {file = "SQLAlchemy-1.4.32-cp39-cp39-win_amd64.whl", hash = "sha256:b3f1d9b3aa09ab9adc7f8c4b40fc3e081eb903054c9a6f9ae1633fe15ae503b4"},
+    {file = "SQLAlchemy-1.4.32.tar.gz", hash = "sha256:6fdd2dc5931daab778c2b65b03df6ae68376e028a3098eb624d0909d999885bc"},
 ]
 testfixtures = [
     {file = "testfixtures-6.18.5-py2.py3-none-any.whl", hash = "sha256:7de200e24f50a4a5d6da7019fb1197aaf5abd475efb2ec2422fdcf2f2eb98c1d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -81,14 +81,6 @@ typing = ["importlib-metadata (>=4.6.4)", "mypy (==0.910)", "typing-extensions (
 virtualenv = ["virtualenv (>=20.0.35)"]
 
 [[package]]
-name = "cachetools"
-version = "5.0.0"
-description = "Extensible memoizing collections and decorators"
-category = "main"
-optional = false
-python-versions = "~=3.7"
-
-[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -214,14 +206,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "frozendict"
-version = "2.3.0"
-description = "A simple immutable dictionary"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "ghp-import"
 version = "2.0.2"
 description = "Copy your docs directly to the gh-pages branch."
@@ -285,7 +269,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.2"
+version = "4.11.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -446,7 +430,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [[package]]
 name = "linkml"
-version = "1.2.0.0rc7"
+version = "1.2.1"
 description = "Linked Open Data Modeling Language"
 category = "main"
 optional = false
@@ -462,24 +446,19 @@ jinja2 = "*"
 jsonasobj2 = ">=1.0.3,<2.0"
 jsonschema = ">=3.0.1"
 linkml-dataops = "*"
-linkml-runtime = ">=1.1.26"
+linkml-runtime = ">=1.2.0"
 myst-parser = "*"
 openpyxl = "*"
 pandas = "*"
 parse = "*"
 prefixcommons = ">=0.1.7"
-prologterms = ">=0.0.6"
 pydantic = "*"
 pyjsg = ">=0.11.6"
-pyldmod = ">=2.0.5"
 pyshex = ">=0.7.20"
 pyshexc = ">=0.8.3"
 python-dateutil = "*"
 pyyaml = ">=5.1,<6.0"
-rdflib = ">=5.0.0"
-rdflib-jsonld = "0.6.1"
-rdflib-pyldmod-compat = ">=0.1.2c"
-rdflib-shim = "*"
+rdflib = ">=6.0.0"
 requests = ">=2.22"
 sphinx = "*"
 sphinx-click = "*"
@@ -504,7 +483,7 @@ linkml-runtime = ">=1.1.6"
 
 [[package]]
 name = "linkml-runtime"
-version = "1.2.0rc6"
+version = "1.2.2"
 description = "Runtime environment for LinkML, the Linked open data modeling language"
 category = "main"
 optional = false
@@ -518,23 +497,9 @@ json-flattener = ">=0.1.9"
 jsonasobj2 = ">=1.0.4,<2.0.0"
 jsonschema = ">=3.2.0"
 prefixcommons = "*"
-pyyaml = ">=5.1.0,<6.0.0"
+pyyaml = ">=5.1.0"
 rdflib = ">=6.0.0"
 requests = "*"
-
-[[package]]
-name = "lxml"
-version = "4.8.0"
-description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
-
-[package.extras]
-cssselect = ["cssselect (>=0.7)"]
-html5 = ["html5lib"]
-htmlsoup = ["beautifulsoup4"]
-source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "markdown"
@@ -790,14 +755,6 @@ requests = "*"
 test = ["pytest"]
 
 [[package]]
-name = "prologterms"
-version = "0.0.6"
-description = "A simple python library for generating prolog terms"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -839,25 +796,6 @@ python-versions = "*"
 [package.dependencies]
 antlr4-python3-runtime = ">=4.9,<5.0"
 jsonasobj = ">=1.2.1"
-
-[[package]]
-name = "pyldmod"
-version = "2.0.5"
-description = "modified Python implementation of the JSON-LD API"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-cachetools = "*"
-frozendict = "*"
-lxml = "*"
-
-[package.extras]
-aiohttp = ["aiohttp"]
-cachetools = ["cachetools"]
-frozendict = ["frozendict"]
-requests = ["requests"]
 
 [[package]]
 name = "pyparsing"
@@ -998,19 +936,6 @@ python-versions = "*"
 rdflib = ">=5.0.0"
 
 [[package]]
-name = "rdflib-pyldmod-compat"
-version = "0.1.2"
-description = "Conversion between rdflib and PyLD data formats for compatibility"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-pyldmod = "*"
-rdflib = ">=4.2.0"
-testfixtures = "*"
-
-[[package]]
 name = "rdflib-shim"
 version = "1.0.3"
 description = "Shim for rdflib 5 and 6 incompatibilities"
@@ -1024,7 +949,7 @@ rdflib-jsonld = "0.6.1"
 
 [[package]]
 name = "readme-renderer"
-version = "33.0"
+version = "34.0"
 description = "readme_renderer is a library for rendering \"readme\" descriptions for Warehouse"
 category = "dev"
 optional = false
@@ -1155,17 +1080,20 @@ sparqlwrapper = ">=1.8.2"
 
 [[package]]
 name = "sparqlwrapper"
-version = "1.8.5"
+version = "2.0.0"
 description = "SPARQL Endpoint interface to Python"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
-rdflib = ">=4.0"
+rdflib = ">=6.1.1"
 
 [package.extras]
+dev = ["setuptools (>=3.7.1)", "mypy (>=0.931)", "pandas (>=1.3.5)", "pandas-stubs (>=1.2.0.48)"]
+docs = ["sphinx (<5)", "sphinx-rtd-theme"]
 keepalive = ["keepalive (>=0.5)"]
+pandas = ["pandas (>=1.3.5)"]
 
 [[package]]
 name = "sphinx"
@@ -1331,19 +1259,6 @@ pymysql = ["pymysql (<1)", "pymysql"]
 sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
-name = "testfixtures"
-version = "6.18.5"
-description = "A collection of helpers and mock objects for unit tests and doc tests."
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-build = ["setuptools-git", "wheel", "twine"]
-docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
-test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1429,7 +1344,7 @@ python-versions = "*"
 
 [[package]]
 name = "wrapt"
-version = "1.13.3"
+version = "1.14.0"
 description = "Module for decorators, wrappers and monkey patching."
 category = "main"
 optional = false
@@ -1479,10 +1394,6 @@ bleach = [
 build = [
     {file = "build-0.7.0-py3-none-any.whl", hash = "sha256:21b7ebbd1b22499c4dac536abc7606696ea4d909fd755e00f09f3c0f2c05e3c8"},
     {file = "build-0.7.0.tar.gz", hash = "sha256:1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f"},
-]
-cachetools = [
-    {file = "cachetools-5.0.0-py3-none-any.whl", hash = "sha256:8fecd4203a38af17928be7b90689d8083603073622229ca7077b72d8e5a976e4"},
-    {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1597,25 +1508,6 @@ et-xmlfile = [
     {file = "et_xmlfile-1.1.0-py3-none-any.whl", hash = "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"},
     {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
 ]
-frozendict = [
-    {file = "frozendict-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e18e2abd144a9433b0a8334582843b2aa0d3b9ac8b209aaa912ad365115fe2e1"},
-    {file = "frozendict-2.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96dc7a02e78da5725e5e642269bb7ae792e0c9f13f10f2e02689175ebbfedb35"},
-    {file = "frozendict-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:752a6dcfaf9bb20a7ecab24980e4dbe041f154509c989207caf185522ef85461"},
-    {file = "frozendict-2.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:5346d9fc1c936c76d33975a9a9f1a067342963105d9a403a99e787c939cc2bb2"},
-    {file = "frozendict-2.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60dd2253f1bacb63a7c486ec541a968af4f985ffb06602ee8954a3d39ec6bd2e"},
-    {file = "frozendict-2.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:b2e044602ce17e5cd86724add46660fb9d80169545164e763300a3b839cb1b79"},
-    {file = "frozendict-2.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a27a69b1ac3591e4258325108aee62b53c0eeb6ad0a993ae68d3c7eaea980420"},
-    {file = "frozendict-2.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f45ef5f6b184d84744fff97b61f6b9a855e24d36b713ea2352fc723a047afa5"},
-    {file = "frozendict-2.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2d3f5016650c0e9a192f5024e68fb4d63f670d0ee58b099ed3f5b4c62ea30ecb"},
-    {file = "frozendict-2.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6cf605916f50aabaaba5624c81eb270200f6c2c466c46960237a125ec8fe3ae0"},
-    {file = "frozendict-2.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6da06e44904beae4412199d7e49be4f85c6cc168ab06b77c735ea7da5ce3454"},
-    {file = "frozendict-2.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:1f34793fb409c4fa70ffd25bea87b01f3bd305fb1c6b09e7dff085b126302206"},
-    {file = "frozendict-2.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fd72494a559bdcd28aa71f4aa81860269cd0b7c45fff3e2614a0a053ecfd2a13"},
-    {file = "frozendict-2.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00ea9166aa68cc5feed05986206fdbf35e838a09cb3feef998cf35978ff8a803"},
-    {file = "frozendict-2.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9ffaf440648b44e0bc694c1a4701801941378ba3ba6541e17750ae4b4aeeb116"},
-    {file = "frozendict-2.3.0-py3-none-any.whl", hash = "sha256:8578fe06815fcdcc672bd5603eebc98361a5317c1c3a13b28c6c810f6ea3b323"},
-    {file = "frozendict-2.3.0.tar.gz", hash = "sha256:da4231adefc5928e7810da2732269d3ad7b5616295b3e693746392a8205ea0b5"},
-]
 ghp-import = [
     {file = "ghp-import-2.0.2.tar.gz", hash = "sha256:947b3771f11be850c852c64b561c600fdddf794bab363060854c1ee7ad05e071"},
     {file = "ghp_import-2.0.2-py3-none-any.whl", hash = "sha256:5f8962b30b20652cdffa9c5a9812f7de6bcb56ec475acac579807719bf242c46"},
@@ -1694,8 +1586,8 @@ imagesize = [
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
-    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 isodate = [
     {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
@@ -1789,79 +1681,16 @@ keyring = [
     {file = "keyring-23.5.0.tar.gz", hash = "sha256:9012508e141a80bd1c0b6778d5c610dd9f8c464d75ac6774248500503f972fb9"},
 ]
 linkml = [
-    {file = "linkml-1.2.0.0rc7-py3-none-any.whl", hash = "sha256:370decd0701dcf46260d127d2aad9ac76ac1b816c1760c710bcc7bb9a5e578d2"},
-    {file = "linkml-1.2.0.0rc7.tar.gz", hash = "sha256:2f945bb2337e3112d4a276070e286c80fa1c46f55825082527885307d5edd887"},
+    {file = "linkml-1.2.1-py3-none-any.whl", hash = "sha256:ff8deb34d26798e5f5a49284d6fb7b5132ca1c7a14acd0f08989e457cb39ad8d"},
+    {file = "linkml-1.2.1.tar.gz", hash = "sha256:332dd73b7bca5f04f8ccec5721ad3ff3f19653b19a3714310ad57201f89d5139"},
 ]
 linkml-dataops = [
     {file = "linkml_dataops-0.1.0-py3-none-any.whl", hash = "sha256:193cf7f659e5f07946d2c2761896910d5f7151d91282543b1363801f68307f4c"},
     {file = "linkml_dataops-0.1.0.tar.gz", hash = "sha256:4550eab65e78b70dc3b9c651724a94ac2b1d1edb2fbe576465f1d6951a54ed04"},
 ]
 linkml-runtime = [
-    {file = "linkml_runtime-1.2.0rc6-py3-none-any.whl", hash = "sha256:3088d3d188bd77cb18975f39d3d319d28ee1f251ce62021dd450d8d1cf5a7212"},
-    {file = "linkml_runtime-1.2.0rc6.tar.gz", hash = "sha256:995dafa13da1da29249fc6391d7fab3f4fba36ffeb45b6b17600c5d23e84eb64"},
-]
-lxml = [
-    {file = "lxml-4.8.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e1ab2fac607842ac36864e358c42feb0960ae62c34aa4caaf12ada0a1fb5d99b"},
-    {file = "lxml-4.8.0-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28d1af847786f68bec57961f31221125c29d6f52d9187c01cd34dc14e2b29430"},
-    {file = "lxml-4.8.0-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b92d40121dcbd74831b690a75533da703750f7041b4bf951befc657c37e5695a"},
-    {file = "lxml-4.8.0-cp27-cp27m-win32.whl", hash = "sha256:e01f9531ba5420838c801c21c1b0f45dbc9607cb22ea2cf132844453bec863a5"},
-    {file = "lxml-4.8.0-cp27-cp27m-win_amd64.whl", hash = "sha256:6259b511b0f2527e6d55ad87acc1c07b3cbffc3d5e050d7e7bcfa151b8202df9"},
-    {file = "lxml-4.8.0-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1010042bfcac2b2dc6098260a2ed022968dbdfaf285fc65a3acf8e4eb1ffd1bc"},
-    {file = "lxml-4.8.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fa56bb08b3dd8eac3a8c5b7d075c94e74f755fd9d8a04543ae8d37b1612dd170"},
-    {file = "lxml-4.8.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:31ba2cbc64516dcdd6c24418daa7abff989ddf3ba6d3ea6f6ce6f2ed6e754ec9"},
-    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:31499847fc5f73ee17dbe1b8e24c6dafc4e8d5b48803d17d22988976b0171f03"},
-    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5f7d7d9afc7b293147e2d506a4596641d60181a35279ef3aa5778d0d9d9123fe"},
-    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a3c5f1a719aa11866ffc530d54ad965063a8cbbecae6515acbd5f0fae8f48eaa"},
-    {file = "lxml-4.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6268e27873a3d191849204d00d03f65c0e343b3bcb518a6eaae05677c95621d1"},
-    {file = "lxml-4.8.0-cp310-cp310-win32.whl", hash = "sha256:330bff92c26d4aee79c5bc4d9967858bdbe73fdbdbacb5daf623a03a914fe05b"},
-    {file = "lxml-4.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:b2582b238e1658c4061ebe1b4df53c435190d22457642377fd0cb30685cdfb76"},
-    {file = "lxml-4.8.0-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a2bfc7e2a0601b475477c954bf167dee6d0f55cb167e3f3e7cefad906e7759f6"},
-    {file = "lxml-4.8.0-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a1547ff4b8a833511eeaceacbcd17b043214fcdb385148f9c1bc5556ca9623e2"},
-    {file = "lxml-4.8.0-cp35-cp35m-win32.whl", hash = "sha256:a9f1c3489736ff8e1c7652e9dc39f80cff820f23624f23d9eab6e122ac99b150"},
-    {file = "lxml-4.8.0-cp35-cp35m-win_amd64.whl", hash = "sha256:530f278849031b0eb12f46cca0e5db01cfe5177ab13bd6878c6e739319bae654"},
-    {file = "lxml-4.8.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:078306d19a33920004addeb5f4630781aaeabb6a8d01398045fcde085091a169"},
-    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:86545e351e879d0b72b620db6a3b96346921fa87b3d366d6c074e5a9a0b8dadb"},
-    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24f5c5ae618395ed871b3d8ebfcbb36e3f1091fd847bf54c4de623f9107942f3"},
-    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:bbab6faf6568484707acc052f4dfc3802bdb0cafe079383fbaa23f1cdae9ecd4"},
-    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7993232bd4044392c47779a3c7e8889fea6883be46281d45a81451acfd704d7e"},
-    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d6483b1229470e1d8835e52e0ff3c6973b9b97b24cd1c116dca90b57a2cc613"},
-    {file = "lxml-4.8.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ad4332a532e2d5acb231a2e5d33f943750091ee435daffca3fec0a53224e7e33"},
-    {file = "lxml-4.8.0-cp36-cp36m-win32.whl", hash = "sha256:db3535733f59e5605a88a706824dfcb9bd06725e709ecb017e165fc1d6e7d429"},
-    {file = "lxml-4.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5f148b0c6133fb928503cfcdfdba395010f997aa44bcf6474fcdd0c5398d9b63"},
-    {file = "lxml-4.8.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:8a31f24e2a0b6317f33aafbb2f0895c0bce772980ae60c2c640d82caac49628a"},
-    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:719544565c2937c21a6f76d520e6e52b726d132815adb3447ccffbe9f44203c4"},
-    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:c0b88ed1ae66777a798dc54f627e32d3b81c8009967c63993c450ee4cbcbec15"},
-    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fa9b7c450be85bfc6cd39f6df8c5b8cbd76b5d6fc1f69efec80203f9894b885f"},
-    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e9f84ed9f4d50b74fbc77298ee5c870f67cb7e91dcdc1a6915cb1ff6a317476c"},
-    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1d650812b52d98679ed6c6b3b55cbb8fe5a5460a0aef29aeb08dc0b44577df85"},
-    {file = "lxml-4.8.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:80bbaddf2baab7e6de4bc47405e34948e694a9efe0861c61cdc23aa774fcb141"},
-    {file = "lxml-4.8.0-cp37-cp37m-win32.whl", hash = "sha256:6f7b82934c08e28a2d537d870293236b1000d94d0b4583825ab9649aef7ddf63"},
-    {file = "lxml-4.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e1fd7d2fe11f1cb63d3336d147c852f6d07de0d0020d704c6031b46a30b02ca8"},
-    {file = "lxml-4.8.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5045ee1ccd45a89c4daec1160217d363fcd23811e26734688007c26f28c9e9e7"},
-    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0c1978ff1fd81ed9dcbba4f91cf09faf1f8082c9d72eb122e92294716c605428"},
-    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cbf2ff155b19dc4d4100f7442f6a697938bf4493f8d3b0c51d45568d5666b5"},
-    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ce13d6291a5f47c1c8dbd375baa78551053bc6b5e5c0e9bb8e39c0a8359fd52f"},
-    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e11527dc23d5ef44d76fef11213215c34f36af1608074561fcc561d983aeb870"},
-    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:60d2f60bd5a2a979df28ab309352cdcf8181bda0cca4529769a945f09aba06f9"},
-    {file = "lxml-4.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:62f93eac69ec0f4be98d1b96f4d6b964855b8255c345c17ff12c20b93f247b68"},
-    {file = "lxml-4.8.0-cp38-cp38-win32.whl", hash = "sha256:20b8a746a026017acf07da39fdb10aa80ad9877046c9182442bf80c84a1c4696"},
-    {file = "lxml-4.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:891dc8f522d7059ff0024cd3ae79fd224752676447f9c678f2a5c14b84d9a939"},
-    {file = "lxml-4.8.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b6fc2e2fb6f532cf48b5fed57567ef286addcef38c28874458a41b7837a57807"},
-    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:74eb65ec61e3c7c019d7169387d1b6ffcfea1b9ec5894d116a9a903636e4a0b1"},
-    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:627e79894770783c129cc5e89b947e52aa26e8e0557c7e205368a809da4b7939"},
-    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:545bd39c9481f2e3f2727c78c169425efbfb3fbba6e7db4f46a80ebb249819ca"},
-    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5a58d0b12f5053e270510bf12f753a76aaf3d74c453c00942ed7d2c804ca845c"},
-    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ec4b4e75fc68da9dc0ed73dcdb431c25c57775383fec325d23a770a64e7ebc87"},
-    {file = "lxml-4.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5804e04feb4e61babf3911c2a974a5b86f66ee227cc5006230b00ac6d285b3a9"},
-    {file = "lxml-4.8.0-cp39-cp39-win32.whl", hash = "sha256:aa0cf4922da7a3c905d000b35065df6184c0dc1d866dd3b86fd961905bbad2ea"},
-    {file = "lxml-4.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:dd10383f1d6b7edf247d0960a3db274c07e96cf3a3fc7c41c8448f93eac3fb1c"},
-    {file = "lxml-4.8.0-pp37-pypy37_pp73-macosx_10_14_x86_64.whl", hash = "sha256:2403a6d6fb61c285969b71f4a3527873fe93fd0abe0832d858a17fe68c8fa507"},
-    {file = "lxml-4.8.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:986b7a96228c9b4942ec420eff37556c5777bfba6758edcb95421e4a614b57f9"},
-    {file = "lxml-4.8.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6fe4ef4402df0250b75ba876c3795510d782def5c1e63890bde02d622570d39e"},
-    {file = "lxml-4.8.0-pp38-pypy38_pp73-macosx_10_14_x86_64.whl", hash = "sha256:f10ce66fcdeb3543df51d423ede7e238be98412232fca5daec3e54bcd16b8da0"},
-    {file = "lxml-4.8.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:730766072fd5dcb219dd2b95c4c49752a54f00157f322bc6d71f7d2a31fecd79"},
-    {file = "lxml-4.8.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8b99ec73073b37f9ebe8caf399001848fced9c08064effdbfc4da2b5a8d07b93"},
-    {file = "lxml-4.8.0.tar.gz", hash = "sha256:f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23"},
+    {file = "linkml_runtime-1.2.2-py3-none-any.whl", hash = "sha256:4df6f91e7256bb9b05bc79c9e5dca3757433ea19577e50df6f57baafb1a1b050"},
+    {file = "linkml_runtime-1.2.2.tar.gz", hash = "sha256:dc01bf5965df1d8266aa5cb1ba39a9679ce66eedebbb1a83f4764596dbb11f47"},
 ]
 markdown = [
     {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},
@@ -2012,10 +1841,6 @@ prefixcommons = [
     {file = "prefixcommons-0.1.9-py3.8.egg", hash = "sha256:f820dc69f0eba1f6fd80bdb2e78420e4970f20dfb4c307fed77c607198ca69f2"},
     {file = "prefixcommons-0.1.9.tar.gz", hash = "sha256:a4a6decd6c1a2497b2b10193fa4ed69ed91cea20deb3a9781815b6bf3f3e1003"},
 ]
-prologterms = [
-    {file = "prologterms-0.0.6-py3-none-any.whl", hash = "sha256:9b8f6272dcae5a0a9257daa41cd455d5b060147486cea36623f91a3226a656e9"},
-    {file = "prologterms-0.0.6.tar.gz", hash = "sha256:c63cfc291ccfa3e2eeea89eed93bc7fc0214a1f2d748a200de0a5fdd90e0426a"},
-]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
@@ -2064,9 +1889,6 @@ pygments = [
 pyjsg = [
     {file = "PyJSG-0.11.9-py3-none-any.whl", hash = "sha256:b9bf406c87aab4ff62f9372e38b4fcda5cffc0c12385c46a4b01eb83dafd7850"},
     {file = "PyJSG-0.11.9.tar.gz", hash = "sha256:8679a81c00e2ccb12618adcc2ce5e9a7bef542f4f940ef18e5b7751f5c5a42a4"},
-]
-pyldmod = [
-    {file = "PyLDmod-2.0.5.tar.gz", hash = "sha256:afe7515a4c2b53bbff436c93af128599b4f52791cc71e34baecb7662c694feed"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
@@ -2172,17 +1994,13 @@ rdflib-jsonld = [
     {file = "rdflib-jsonld-0.6.1.tar.gz", hash = "sha256:eda5a42a2e09f80d4da78e32b5c684bccdf275368f1541e6b7bcddfb1382a0e0"},
     {file = "rdflib_jsonld-0.6.1-py2.py3-none-any.whl", hash = "sha256:bcf84317e947a661bae0a3f2aee1eced697075fc4ac4db6065a3340ea0f10fc2"},
 ]
-rdflib-pyldmod-compat = [
-    {file = "rdflib-pyldmod-compat-0.1.2.tar.gz", hash = "sha256:bfba0064d8b2584afdbef5d54bac3ac1dd4c13b64aaeba7a43812c2f35ca13c6"},
-    {file = "rdflib_pyldmod_compat-0.1.2-py3-none-any.whl", hash = "sha256:68aa05d4f4d8f46241e0c37e631b4747f18a356d8accc5bae204350d2f314196"},
-]
 rdflib-shim = [
     {file = "rdflib_shim-1.0.3-py3-none-any.whl", hash = "sha256:7a853e7750ef1e9bf4e35dea27d54e02d4ed087de5a9e0c329c4a6d82d647081"},
     {file = "rdflib_shim-1.0.3.tar.gz", hash = "sha256:d955d11e2986aab42b6830ca56ac6bc9c893abd1d049a161c6de2f1b99d4fc0d"},
 ]
 readme-renderer = [
-    {file = "readme_renderer-33.0-py3-none-any.whl", hash = "sha256:f02cee0c4de9636b5a62b6be50c9742427ba1b956aad1d938bfb087d0d72ccdf"},
-    {file = "readme_renderer-33.0.tar.gz", hash = "sha256:e3b53bc84bd6af054e4cc1fe3567dc1ae19f554134221043a3f8c674e22209db"},
+    {file = "readme_renderer-34.0-py3-none-any.whl", hash = "sha256:262510fe6aae81ed4e94d8b169077f325614c0b1a45916a80442c6576264a9c2"},
+    {file = "readme_renderer-34.0.tar.gz", hash = "sha256:dfb4d17f21706d145f7473e0b61ca245ba58e810cf9b2209a48239677f82e5b0"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
@@ -2248,11 +2066,8 @@ sparqlslurper = [
     {file = "sparqlslurper-0.5.1.tar.gz", hash = "sha256:9282ebb064fc6152a58269d194cb1e7b275b0f095425a578d75b96dcc851f546"},
 ]
 sparqlwrapper = [
-    {file = "SPARQLWrapper-1.8.5-py2-none-any.whl", hash = "sha256:357ee8a27bc910ea13d77836dbddd0b914991495b8cc1bf70676578155e962a8"},
-    {file = "SPARQLWrapper-1.8.5-py2.7.egg", hash = "sha256:17ec44b08b8ae2888c801066249f74fe328eec25d90203ce7eadaf82e64484c7"},
-    {file = "SPARQLWrapper-1.8.5-py3-none-any.whl", hash = "sha256:c7f9c9d8ebb13428771bc3b6dee54197422507dcc3dea34e30d5dcfc53478dec"},
-    {file = "SPARQLWrapper-1.8.5-py3.4.egg", hash = "sha256:8cf6c21126ed76edc85c5c232fd6f77b9f61f8ad1db90a7147cdde2104aff145"},
-    {file = "SPARQLWrapper-1.8.5.tar.gz", hash = "sha256:d6a66b5b8cda141660e07aeb00472db077a98d22cb588c973209c7336850fb3c"},
+    {file = "SPARQLWrapper-2.0.0-py3-none-any.whl", hash = "sha256:c99a7204fff676ee28e6acef327dc1ff8451c6f7217dcd8d49e8872f324a8a20"},
+    {file = "SPARQLWrapper-2.0.0.tar.gz", hash = "sha256:3fed3ebcc77617a4a74d2644b86fd88e0f32e7f7003ac7b2b334c026201731f1"},
 ]
 sphinx = [
     {file = "Sphinx-4.4.0-py3-none-any.whl", hash = "sha256:5da895959511473857b6d0200f56865ed62c31e8f82dd338063b84ec022701fe"},
@@ -2327,10 +2142,6 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.32-cp39-cp39-win_amd64.whl", hash = "sha256:b3f1d9b3aa09ab9adc7f8c4b40fc3e081eb903054c9a6f9ae1633fe15ae503b4"},
     {file = "SQLAlchemy-1.4.32.tar.gz", hash = "sha256:6fdd2dc5931daab778c2b65b03df6ae68376e028a3098eb624d0909d999885bc"},
 ]
-testfixtures = [
-    {file = "testfixtures-6.18.5-py2.py3-none-any.whl", hash = "sha256:7de200e24f50a4a5d6da7019fb1197aaf5abd475efb2ec2422fdcf2f2eb98c1d"},
-    {file = "testfixtures-6.18.5.tar.gz", hash = "sha256:02dae883f567f5b70fd3ad3c9eefb95912e78ac90be6c7444b5e2f46bf572c84"},
-]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
@@ -2381,57 +2192,70 @@ webencodings = [
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
 ]
 wrapt = [
-    {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229"},
-    {file = "wrapt-1.13.3-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80"},
-    {file = "wrapt-1.13.3-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca"},
-    {file = "wrapt-1.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44"},
-    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056"},
-    {file = "wrapt-1.13.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785"},
-    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096"},
-    {file = "wrapt-1.13.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33"},
-    {file = "wrapt-1.13.3-cp310-cp310-win32.whl", hash = "sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f"},
-    {file = "wrapt-1.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3"},
-    {file = "wrapt-1.13.3-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755"},
-    {file = "wrapt-1.13.3-cp35-cp35m-win32.whl", hash = "sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851"},
-    {file = "wrapt-1.13.3-cp35-cp35m-win_amd64.whl", hash = "sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13"},
-    {file = "wrapt-1.13.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918"},
-    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade"},
-    {file = "wrapt-1.13.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc"},
-    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf"},
-    {file = "wrapt-1.13.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125"},
-    {file = "wrapt-1.13.3-cp36-cp36m-win32.whl", hash = "sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36"},
-    {file = "wrapt-1.13.3-cp36-cp36m-win_amd64.whl", hash = "sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10"},
-    {file = "wrapt-1.13.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068"},
-    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709"},
-    {file = "wrapt-1.13.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df"},
-    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2"},
-    {file = "wrapt-1.13.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b"},
-    {file = "wrapt-1.13.3-cp37-cp37m-win32.whl", hash = "sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829"},
-    {file = "wrapt-1.13.3-cp37-cp37m-win_amd64.whl", hash = "sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea"},
-    {file = "wrapt-1.13.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9"},
-    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554"},
-    {file = "wrapt-1.13.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c"},
-    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b"},
-    {file = "wrapt-1.13.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce"},
-    {file = "wrapt-1.13.3-cp38-cp38-win32.whl", hash = "sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79"},
-    {file = "wrapt-1.13.3-cp38-cp38-win_amd64.whl", hash = "sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb"},
-    {file = "wrapt-1.13.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb"},
-    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32"},
-    {file = "wrapt-1.13.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7"},
-    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e"},
-    {file = "wrapt-1.13.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640"},
-    {file = "wrapt-1.13.3-cp39-cp39-win32.whl", hash = "sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374"},
-    {file = "wrapt-1.13.3-cp39-cp39-win_amd64.whl", hash = "sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb"},
-    {file = "wrapt-1.13.3.tar.gz", hash = "sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185"},
+    {file = "wrapt-1.14.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7"},
+    {file = "wrapt-1.14.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c"},
+    {file = "wrapt-1.14.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb"},
+    {file = "wrapt-1.14.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd"},
+    {file = "wrapt-1.14.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291"},
+    {file = "wrapt-1.14.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33"},
+    {file = "wrapt-1.14.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6"},
+    {file = "wrapt-1.14.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b"},
+    {file = "wrapt-1.14.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5"},
+    {file = "wrapt-1.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330"},
+    {file = "wrapt-1.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c"},
+    {file = "wrapt-1.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561"},
+    {file = "wrapt-1.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa"},
+    {file = "wrapt-1.14.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a"},
+    {file = "wrapt-1.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131"},
+    {file = "wrapt-1.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8"},
+    {file = "wrapt-1.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763"},
+    {file = "wrapt-1.14.0-cp310-cp310-win32.whl", hash = "sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff"},
+    {file = "wrapt-1.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d"},
+    {file = "wrapt-1.14.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627"},
+    {file = "wrapt-1.14.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775"},
+    {file = "wrapt-1.14.0-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23"},
+    {file = "wrapt-1.14.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3"},
+    {file = "wrapt-1.14.0-cp35-cp35m-win32.whl", hash = "sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0"},
+    {file = "wrapt-1.14.0-cp35-cp35m-win_amd64.whl", hash = "sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425"},
+    {file = "wrapt-1.14.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48"},
+    {file = "wrapt-1.14.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb"},
+    {file = "wrapt-1.14.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e"},
+    {file = "wrapt-1.14.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3"},
+    {file = "wrapt-1.14.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8"},
+    {file = "wrapt-1.14.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd"},
+    {file = "wrapt-1.14.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036"},
+    {file = "wrapt-1.14.0-cp36-cp36m-win32.whl", hash = "sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8"},
+    {file = "wrapt-1.14.0-cp36-cp36m-win_amd64.whl", hash = "sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06"},
+    {file = "wrapt-1.14.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4"},
+    {file = "wrapt-1.14.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80"},
+    {file = "wrapt-1.14.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce"},
+    {file = "wrapt-1.14.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279"},
+    {file = "wrapt-1.14.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653"},
+    {file = "wrapt-1.14.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0"},
+    {file = "wrapt-1.14.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9"},
+    {file = "wrapt-1.14.0-cp37-cp37m-win32.whl", hash = "sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68"},
+    {file = "wrapt-1.14.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3"},
+    {file = "wrapt-1.14.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d"},
+    {file = "wrapt-1.14.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38"},
+    {file = "wrapt-1.14.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7"},
+    {file = "wrapt-1.14.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1"},
+    {file = "wrapt-1.14.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8"},
+    {file = "wrapt-1.14.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd"},
+    {file = "wrapt-1.14.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe"},
+    {file = "wrapt-1.14.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0"},
+    {file = "wrapt-1.14.0-cp38-cp38-win32.whl", hash = "sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f"},
+    {file = "wrapt-1.14.0-cp38-cp38-win_amd64.whl", hash = "sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e"},
+    {file = "wrapt-1.14.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1"},
+    {file = "wrapt-1.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4"},
+    {file = "wrapt-1.14.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758"},
+    {file = "wrapt-1.14.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d"},
+    {file = "wrapt-1.14.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b"},
+    {file = "wrapt-1.14.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6"},
+    {file = "wrapt-1.14.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0"},
+    {file = "wrapt-1.14.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c"},
+    {file = "wrapt-1.14.0-cp39-cp39-win32.whl", hash = "sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350"},
+    {file = "wrapt-1.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc"},
+    {file = "wrapt-1.14.0.tar.gz", hash = "sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311"},
 ]
 zipp = [
     {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ nmdc-data = "nmdc_schema.nmdc_data:cli"
 [tool.poetry.dependencies]
 python = "^3.9"
 
-linkml = ">=1.2.0rc6"
-linkml-runtime = ">=1.2.0rc6"
+linkml = "*"
+linkml-runtime = "*"
 openpyxl = "==3.0.7"
 pandoc = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ nmdc-version = "nmdc_schema.nmdc_version:cli"
 nmdc-data = "nmdc_schema.nmdc_data:cli"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.9"
 
-linkml = ">=1.1.13"
-linkml-runtime = ">=1.1.6"
+linkml = ">=1.2.0rc6"
+linkml-runtime = ">=1.2.0rc6"
 openpyxl = "==3.0.7"
 pandoc = "*"
 


### PR DESCRIPTION
Modeling based on other generator targets in the Makefile, add a `gen-json` target to the Makefile that uses `gen-linkml` from the linkml library to generate a JSON artifact that has the LinkML model with slots for all classes materialized as attributes.