### PR TITLE
bytes slot rage: xsd:int to xsd:long

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -45,7 +45,7 @@ types:
     description: >-
       An integer value that corresponds to a size in bytes
     base: int
-    uri: xsd:int
+    uri: xsd:long
     see_also:
       - UO:0000233
   


### PR DESCRIPTION
Some data objects in the NMDC metadata have file_size_bytes > 2GB, e.g. https://api.dev.microbiomedata.org/data_objects/jgi:55a9caff0d87852b2150891e