### PR TITLE
add test case to check if unit is enforced on depth schema element

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,8 @@ SCHEMA_TEST_EXAMPLES_INVALID := \
 	biosample_missing_required_field \
 	biosample_single_multi_value_mixup \
 	biosample_undeclared_slot \
-	study_credit_enum_mangle
+	study_credit_enum_mangle \
+	depth_unit_required
 
 # 	functional_annotation_set_invalid has invalid ID pattern but regex tests aren't applied yet? MAM 2021-06-24
 

--- a/test/data/invalid_schemas/depth_unit_required.json
+++ b/test/data/invalid_schemas/depth_unit_required.json
@@ -1,0 +1,124 @@
+{
+    "biosample_set": [
+      {
+        "id": "gold:Gb0101224",
+        "name": "Lithgow State Coal Mine Calcium nutrients (early)",
+        "description": "Bulk Aqueous phase filtered water",
+        "type": "nmdc:Biosample",
+        "part_of": [
+          "gold:Gs0128849"
+        ],
+        "depth": {
+            "has_numeric_value": 0.05
+        },
+        "env_broad_scale": {
+          "has_raw_value": "ENVO:00002030"
+        },
+        "env_local_scale": {
+          "has_raw_value": "ENVO:00002169"
+        },
+        "env_medium": {
+          "has_raw_value": "ENVO:00005792"
+        },
+        "geo_loc_name": {
+          "has_raw_value": "Lithgow"
+        },
+        "lat_lon": {
+          "has_raw_value": "-33.460524 150.168149",
+          "latitude": -33.460524,
+          "longitude": 150.168149
+        },
+        "ecosystem": "Environmental",
+        "ecosystem_category": "Aquatic",
+        "ecosystem_type": "Freshwater",
+        "ecosystem_subtype": "Groundwater",
+        "specific_ecosystem": "Coalbed water",
+        "add_date": "28-JUL-14 12.00.00.000000000 AM",
+        "community": "microbial communities",
+        "habitat": "Coalbed water",
+        "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+        "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+        "ncbi_taxonomy_name": "coal metagenome",
+        "sample_collection_site": "Lithgow State Coal Mine"
+      },
+      {
+        "id": "gold:Gb0101225",
+        "name": "Lithgow State Coal Mine Calcium nutrients Extra",
+        "description": "Bulk Aqueous phase filtered water",
+        "type": "nmdc:Biosample",
+        "part_of": [
+          "gold:Gs0128849"
+        ],
+        "env_broad_scale": {
+          "has_raw_value": "ENVO:00002030"
+        },
+        "env_local_scale": {
+          "has_raw_value": "ENVO:00002169"
+        },
+        "env_medium": {
+          "has_raw_value": "ENVO:00005792"
+        },
+        "geo_loc_name": {
+          "has_raw_value": "Lithgow"
+        },
+        "lat_lon": {
+          "has_raw_value": "-33.460524 150.168149",
+          "latitude": -33.460524,
+          "longitude": 150.168149
+        },
+        "ecosystem": "Environmental",
+        "ecosystem_category": "Aquatic",
+        "ecosystem_type": "Freshwater",
+        "ecosystem_subtype": "Groundwater",
+        "specific_ecosystem": "Coalbed water",
+        "add_date": "28-JUL-14 12.00.00.000000000 AM",
+        "community": "microbial communities",
+        "habitat": "Coalbed water",
+        "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+        "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+        "ncbi_taxonomy_name": "coal metagenome",
+        "sample_collection_site": "Lithgow State Coal Mine"
+      },
+      {
+        "id": "gold:Gb0101226",
+        "name": "Lithgow State Coal Mine Calcium nutrients",
+        "description": "Bulk Aqueous phase filtered water",
+        "type": "nmdc:Biosample",
+        "part_of": [
+          "gold:Gs0128849"
+        ],
+        "depth": {
+            "has_numeric_value": 1.52
+        },
+        "env_broad_scale": {
+          "has_raw_value": "ENVO:00002030"
+        },
+        "env_local_scale": {
+          "has_raw_value": "ENVO:00002169"
+        },
+        "env_medium": {
+          "has_raw_value": "ENVO:00005792"
+        },
+        "geo_loc_name": {
+          "has_raw_value": "Lithgow"
+        },
+        "lat_lon": {
+          "has_raw_value": "-33.460524 150.168149",
+          "latitude": -33.460524,
+          "longitude": 150.168149
+        },
+        "ecosystem": "Environmental",
+        "ecosystem_category": "Aquatic",
+        "ecosystem_type": "Freshwater",
+        "ecosystem_subtype": "Groundwater",
+        "specific_ecosystem": "Coalbed water",
+        "add_date": "28-JUL-14 12.00.00.000000000 AM",
+        "community": "microbial communities",
+        "habitat": "Coalbed water",
+        "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
+        "mod_date": "26-AUG-16 01.50.27.000000000 PM",
+        "ncbi_taxonomy_name": "coal metagenome",
+        "sample_collection_site": "Lithgow State Coal Mine"
+      }
+    ]
+}


### PR DESCRIPTION
Adding a test case to check if adding a depth field without a `has_unit` attribute results in a validation error. But apparently it does not. The way the schema is currently, it accepts `depth` without the `unit`, which we need to change.

CC: @cmungall @wdduncan 