### PR TITLE
has credit association inlined as list

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -722,7 +722,8 @@ slots:
     domain: study
     range: credit association
     multivalued: true
-    inlined: true
+    # was just "inlined: true"
+    inlined_as_list: true
     description: 'This slot links a study to a credit association.  The credit association
       will be linked to a person value and to a CRediT Contributor Roles term. Overall
       semantics: person should get credit X for their participation in the study'

--- a/test/test_credit_associations.py
+++ b/test/test_credit_associations.py
@@ -1,0 +1,47 @@
+import logging
+import traceback
+import unittest
+
+from linkml.validators.jsonschemavalidator import JsonSchemaDataValidator
+
+from python.nmdc import PersonValue, CreditAssociation, Study
+
+
+# from linkml_runtime.dumpers import yaml_dumper
+
+# todo reimplement with methods?
+
+
+class TestCA(unittest.TestCase):
+
+    def test_sum(self):
+
+        # nmdc_schema = "https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/nmdc.yaml"
+        nmdc_schema = "../src/schema/nmdc.yaml"
+
+        validator = JsonSchemaDataValidator(nmdc_schema)
+
+        pv1 = PersonValue(has_raw_value="GW Carver")
+        pv2 = PersonValue(has_raw_value="L Pasteur")
+
+        ca1 = CreditAssociation(applies_to_person=pv1, applied_roles=["Supervision", "Validation"])
+        ca2 = CreditAssociation(applies_to_person=pv2, applied_roles=["Investigation"])
+
+        s = Study(id="abc")
+
+        # # why is schema loaded each time?
+        validator.validate_object(ca1, target_class=CreditAssociation)
+        validator.validate_object(ca2, target_class=CreditAssociation)
+
+        try:
+            s.has_credit_associations.append(ca1)
+            s.has_credit_associations.append(ca2)
+            validator.validate_object(s, target_class=Study)
+        except Exception as e:
+            logging.error(traceback.format_exc())
+
+        self.assertEqual(type(s), Study)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
fixes #345

```yaml
has credit associations:
  domain: study
  range: credit association
  multivalued: true
  # was just "inlined: true"
  inlined_as_list: true
  description: 'This slot links a study to a credit association.  The credit association
    will be linked to a person value and to a CRediT Contributor Roles term. Overall
    semantics: person should get credit X for their participation in the study'
  slot_uri: prov:qualifiedAssociation
  annotations:
    display_hint:
      tag: display_hint
      value: Other researchers associated with this study.
```