### PR TITLE
step that copies included files from src directory into nmdc_schema

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Build package
       run: |
-        # make build-package
+        make build-nmdc_schema
         poetry version $(git describe --tags --abbrev=0)
         poetry build
                 


### PR DESCRIPTION
The `Build package` step from the pypi-publish.yaml workflow file, didn't include the Makefile step that copies over the necessary source files from the src directory into the nmdc_schema directory.

This PR seeks to make the required modification to that step so that it copies over the files as required, before publishing to PyPI.