### PR TITLE
removed identifier slot form Biosample class

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1050,8 +1050,6 @@ slots:
     range: string
   sample_collection_site:
     range: string
-  identifier:
-    range: string
   sample_collection_year:
     range: integer
   sample_collection_month:


### PR DESCRIPTION
may break GH action validation; def incompatible with current MongoDB contents