### PR TITLE
use `gen-doc` in Makefile target and Action

### DIFF
--- a/.github/workflows/build-deploy-documentation.yaml
+++ b/.github/workflows/build-deploy-documentation.yaml
@@ -65,9 +65,9 @@ jobs:
         run: poetry install --no-interaction --no-root     
         
       #----------------------------------------------
-      #             generate markdown files 
+      #             generate markdown files
       #----------------------------------------------
-      - run: make stage-docs
+      - run: make gen-doc
 
       #----------------------------------------------
       #               deploy documentation 

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ docserve:
 
 gh-deploy:
 # deploy documentation (note: requires documentation is in docs dir)
-	$(RUN) mkdocs gh-deploy --remote-branch gh-pages
+	$(RUN) mkdocs gh-deploy
 
 ###  -- PYPI TARGETS
 # Use the build-package target to build a PYPI package locally


### PR DESCRIPTION
Use gen-doc in Github Action to automatically build the documentation that needs to be deployed using mkdocs.