### PR TITLE
show middle layer elements in inheritance tree in mermaid

### DIFF
--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -115,7 +115,7 @@ URI: {{ gen.uri_link(element) }}
 {% endif -%}
 
 
-## LinkML Specification
+## LinkML Source
 
 ### Direct
 

--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -19,11 +19,10 @@ _{{ element.description }}_
 
 URI: {{ gen.uri_link(element) }}
 
-
-
-{% if schemaview.class_parents(element.name) %}
+{% if schemaview.class_parents(element.name) and schemaview.class_children(element.name) %}
 ```mermaid
  classDiagram
+    class {{ gen.name(element) }}
       {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
         {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
       {% endfor %}
@@ -31,14 +30,32 @@ URI: {{ gen.uri_link(element) }}
         {{ gen.name(element) }} : {{gen.name(s)}}
       {% endfor %}
 
-```
-{% elif schemaview.class_children(element.name)  %}
-```mermaid
- classDiagram
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
       {% endfor %}
       {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
+        {{ gen.name(element) }} : {{gen.name(s)}}
+      {% endfor %}
+```
+{% elif schemaview.class_parents(element.name) %}
+```mermaid
+ classDiagram
+    class {{ gen.name(element) }}
+      {% for s in schemaview.class_parents(element.name) -%}
+        {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
+      {% endfor %}
+      {% for s in schemaview.class_induced_slots(element.name) -%}
+        {{ gen.name(element) }} : {{gen.name(s)}}
+      {% endfor %}
+```
+{% elif schemaview.class_children(element.name) %}
+```mermaid
+ classDiagram
+    class {{ gen.name(element) }}
+      {% for s in schemaview.class_children(element.name) -%}
+        {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
+      {% endfor %}
+      {% for s in schemaview.class_induced_slots(element.name) -%}
         {{ gen.name(element) }} : {{gen.name(s)}}
       {% endfor %}
 ```

--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -26,10 +26,6 @@ URI: {{ gen.uri_link(element) }}
       {% for s in schemaview.class_parents(element.name)|sort(attribute='name') -%}
         {{ gen.name(schemaview.get_element(s)) }} <|-- {{ gen.name(element) }}
       {% endfor %}
-      {% for s in schemaview.class_induced_slots(element.name)|sort(attribute='name') -%}
-        {{ gen.name(element) }} : {{gen.name(s)}}
-      {% endfor %}
-
       {% for s in schemaview.class_children(element.name)|sort(attribute='name') -%}
         {{ gen.name(element) }} <|-- {{ gen.name(schemaview.get_element(s)) }}
       {% endfor %}

--- a/src/doc-templates/slot.md.jinja2
+++ b/src/doc-templates/slot.md.jinja2
@@ -63,7 +63,7 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 {% include "common_metadata.md.jinja2" %}
 
-## LinkML Specification
+## LinkML Source
 
 <details>
 ```yaml

--- a/src/doc-templates/slot.md.jinja2
+++ b/src/doc-templates/slot.md.jinja2
@@ -63,7 +63,7 @@ URI: [{{ gen.uri(element) }}]({{ gen.uri(element) }})
 
 {% include "common_metadata.md.jinja2" %}
 
-## LinkML Source
+## LinkML Specification
 
 <details>
 ```yaml


### PR DESCRIPTION
This PR seeks to address one major point, and a minor point.

Major point being, we need to add some jinja code to allow for the better rendering of mermaid diagrams that show inheritance trees summarizing `is_a` relationships for schema classes that have both parents and children.

For example: [BiosampleProcessing](https://microbiomedata.github.io/nmdc-schema/BiosampleProcessing/)
<img width="231" alt="Screen Shot 2022-08-31 at 2 05 31 PM" src="https://user-images.githubusercontent.com/20239224/187782017-1ba3b03b-afae-43ef-8f11-ebeab5540c5e.png">

Minor point is, we need to standardize what we're calling the LinkML source sections on both:

* class pages: https://microbiomedata.github.io/nmdc-schema/BiosampleProcessing/#linkml-specification
* slot pages: https://microbiomedata.github.io/nmdc-schema/has_input/#linkml-source

Q) LinkML source or LinkML specification?