### PR TITLE
reformat identifiers doc for mkdocs

### DIFF
--- a/src/docs/identifiers.md
+++ b/src/docs/identifiers.md
@@ -123,27 +123,27 @@ There are four parts to the above identifier:
 
 2. `<type-code>`: An alphabetical code that is part of a recognized and controlled set. Type codes help us answer the question about what kind of entities we are identifying. All type codes should be three character alphabetical codes that follow the regular expression: `[a-z]{3}`.
 
-The type codes that have been agreed upon currently:
-
-  * `bsm`: biosample
-  * `sty`: study
-
-Proposed type codes for some other entities:
-
-  * `omp`: omics processing
-  * `dao`: data object
-  * `opa`: omics processing activity
-  * `oma`: omics analysis
-  * `oaa`: omics analysis activity
-
-
 3. `<shoulder>`: A string designed to serve as usernames for ID minting authorities. These authorities are typically organizations like EMSL, or JGI and hence shoulders would be assigned to organizations only. The shoulder helps us answer the question about who is minting the NMDC identifier. All Shoulders should be two numbers with zero or more alphabetical characters between them, and follow the regular expression `[0-9][a-z]*[0-9]`.
 
 4. `<blade>`: The fully unique part of the identifier under a given type code and shoulder namespace. It is a base32 encoding of a 64-bit integer value and a checksum. The _shoulder_ and _blade_ together make up the _key_ of the identifier.
 
 **In the context of the schema, all classes will use an NMDC minted ID.**
 
-Note: The reason why we would want to have shoulders uniquely identifying minting authorities is to accommodate a decentralized, or distributed ID minting service implementation. Meaning, one organization, say LBL which hosts the central ID minting serive which is assigned a type code of `00` generates some NMDC IDs. In a similar fashion, another organization, say JGI, might want to have an offline ID minting service within their organization that also generates NMDC IDs. So organizations like the JGI, would be assigned a shoulder, say, `01` to identify the organization. Similarly, we can generate different shoulder ids for different organizations that want to use offline NMDC ID minting services.
+Notes: 
+
+* The reason why we would want to have shoulders uniquely identifying minting authorities is to accommodate a decentralized, or distributed ID minting service implementation. Meaning, one organization, say LBL which hosts the central ID minting serive which is assigned a type code of `00` generates some NMDC IDs. In a similar fashion, another organization, say JGI, might want to have an offline ID minting service within their organization that also generates NMDC IDs. So organizations like the JGI, would be assigned a shoulder, say, `01` to identify the organization. Similarly, we can generate different shoulder ids for different organizations that want to use offline NMDC ID minting services.
+
+* The type codes that have been agreed upon currently:
+    * `bsm`: biosample
+    * `sty`: study
+
+* Proposed type codes for some other entities:
+    * `omp`: omics processing
+    * `dao`: data object
+    * `opa`: omics processing activity
+    * `oma`: omics analysis
+    * `oaa`: omics analysis activity
+
 
 ## Reuse vs minting new IDs
 


### PR DESCRIPTION
reformat NMDC minted identifiers structure section for proper mkdocs rendering.