### PR TITLE
schema and test data changes for v7 migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ gen: $(patsubst %,gen-%,$(TGTS))
 
 clean: clean-artifacts clean-docs
 
+squeaky-clean: clean clean-package from_mongo_cleanup # NOT mixs_clean
+squeaky-all: squeaky-clean  test
+
 clean-artifacts:
 	rm -rf target/
 
@@ -71,7 +74,7 @@ target/docs/%.md: $(SCHEMA_SRC) tdir-docs
 
 gen-doc:
 	mkdir -p target/doc
-	echo 'long story' > target/doc/placeholder.txt
+	echo 'forces retention of this directory after rm -rf target/*' > target/doc/placeholder.txt
 	$(RUN) gen-doc $(SCHEMA_SRC) --template-directory $(SRC_DIR)/doc-templates -d $(DOCS_DIR)
 	cp $(SRC_DIR)/$(DOCS_DIR)/*.md $(DOCS_DIR)
 	mkdir -p $(DOCS_DIR)/images

--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -38,7 +38,6 @@ default_prefix: nmdc
 imports:
   - basic_slots
   - core
-  - linkml:types
   - prov
   - workflow_execution_activity
 

--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -13,6 +13,9 @@ default_curi_maps:
   - obo_context
   - idot_context
 
+notes:
+  - Removed slot_uri of rdf:type from type slot. Is OntologyClass an appropriate range?
+
 
 prefixes:
   COG: https://unknown.to.linter.org/
@@ -28,7 +31,6 @@ prefixes:
   biolink: https://w3id.org/biolink/vocab/
   linkml: https://w3id.org/linkml/
   nmdc: https://w3id.org/nmdc/
-  #  KEGG_ORTHOLOGY: http://unknown.to.linter.org/
   KEGG.ORTHOLOGY: http://identifiers.org/kegg.orthology/
 
 default_prefix: nmdc
@@ -51,13 +53,12 @@ classes:
     slot_usage:
       seqid:
         description: The ID of the landmark used to establish the coordinate system for the current feature.
-        range: string ## make this an object
+        range: string
         required: true
-      raw_type:
+      type:
         range: OntologyClass
         description: >-
           A type from the sequence ontology
-      #        slot_uri: rdf:type
       start:
         is_a: gff_coordinate
         description: The start of the feature in positive 1-based integer coordinates
@@ -74,7 +75,6 @@ classes:
         close_mappings:
           - biolink:end_interbase_coordinate
       strand:
-        ## TODO: enum
         description: >-
           The strand on which a feature is located. Has a value of '+' (sense strand or forward strand) or '-' (anti-sense strand or reverse strand).
         exact_mappings:
@@ -188,20 +188,22 @@ classes:
     id_prefixes:
       - CATH
       - EGGNOG
-      - KEGG.ORTHOLOGY ## KO number
+      - KEGG.ORTHOLOGY
       - PANTHER.FAMILY
       - PFAM
       - SUPFAM
       - TIGRFAM
     exact_mappings:
       - biolink:GeneFamily
+    notes:
+      - KEGG.ORTHOLOGY prefix is used for KO numbers
 
   FunctionalAnnotation:
     description: >-
       An assignment of a function term (e.g. reaction or pathway) that is executed by a gene product, or which the gene product plays an active role in.
       Functional annotations can be assigned manually by curators, or automatically in workflows. In the context of NMDC, all function annotation is performed
       automatically, typically using HMM or Blast type methods
-    comments:
+    notes:
       - "move id slot usage patterns to has_function slot usage?"
     see_also:
       - https://img.jgi.doe.gov/docs/functional-annotation.pdf
@@ -211,12 +213,13 @@ classes:
       - subject
       - has_function
     slot_usage:
-      has_function: # was: id
+      has_function:
         pattern: "^(KEGG_PATHWAY:\\w{2,4}\\d{5}|KEGG.REACTION:R\\d+|RHEA:\\d{5}|MetaCyc:[A-Za-z0-9+_.%-:]+|EC:\\d{1,2}(\\.\\d{0,3}){0,3}|GO:\\d{7}|MetaNetX:(MNXR\\d+|EMPTY)|SEED:\\w+|KEGG\\.ORTHOLOGY:K\\d+|EGGNOG:\\w+|PFAM:PF\\d{5}|TIGRFAM:TIGR\\d+|SUPFAM:\\w+|CATH:[1-6]\\.[0-9]+\\.[0-9]+\\.[0-9]+|PANTHER.FAMILY:PTHR\\d{5}(\\:SF\\d{1,3})?)$"
-        comments:
+        notes:
+          - this slot had been called id
           - "Still missing patterns for COG and RetroRules."
           - "These patterns aren't tied to the listed prefixes. A discussion about that possibility had been started, including the question of whether these lists are intended to be open examples or closed"
-      raw_type:
+      type:
         range: OntologyClass
         description: >-
           TODO
@@ -242,10 +245,10 @@ slots:
     range: GeneProduct
 
   has_function:
-    range: string # was: FunctionalAnnotationTerm
-    comments:
-      - "the range for has_function was asserted as functional_annotation_term,"
-      - "but is actually taking string arguments in the Polyneme MongoDB,"
+    range: string
+    notes:
+      - "the range for has_function was asserted as functional_annotation_term/FunctionalAnnotationTerm,"
+      - "but is actually taking string arguments in MongoDB,"
       - "and those are frequently fulltext, not CURIEs. MAM 2021-06-23"
 
   has_participants:
@@ -273,6 +276,10 @@ slots:
   phase:
   right_participants:
   seqid:
+    todos:
+      - "change range from string to object"
   smarts_string:
   start:
   strand:
+    todos:
+      - "set the range to an enum?"

--- a/src/schema/annotation.yaml
+++ b/src/schema/annotation.yaml
@@ -34,6 +34,7 @@ prefixes:
 default_prefix: nmdc
 
 imports:
+  - basic_slots
   - core
   - linkml:types
   - prov
@@ -52,11 +53,11 @@ classes:
         description: The ID of the landmark used to establish the coordinate system for the current feature.
         range: string ## make this an object
         required: true
-      type:
+      raw_type:
         range: OntologyClass
         description: >-
           A type from the sequence ontology
-        slot_uri: rdf:type
+      #        slot_uri: rdf:type
       start:
         is_a: gff_coordinate
         description: The start of the feature in positive 1-based integer coordinates
@@ -215,7 +216,7 @@ classes:
         comments:
           - "Still missing patterns for COG and RetroRules."
           - "These patterns aren't tied to the listed prefixes. A discussion about that possibility had been started, including the question of whether these lists are intended to be open examples or closed"
-      type:
+      raw_type:
         range: OntologyClass
         description: >-
           TODO

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -21,7 +21,6 @@ default_curi_maps:
 
 
 imports:
-  - linkml:types
   - core
 
 slots:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -11,7 +11,7 @@ prefixes:
   linkml: https://w3id.org/linkml/
   nmdc: https://w3id.org/nmdc/
   skos: http://www.w3.org/2004/02/skos/core#
-    
+
 default_prefix: nmdc
 default_range: string
 
@@ -22,8 +22,15 @@ default_curi_maps:
 
 imports:
   - linkml:types
+  - core
 
 slots:
+
+  raw_type:
+    description: a placeholder for the contents of legacy, free-text type slots
+    comments:
+      - does not retain the rdf:type slot URI
+
 
   id:
     identifier: true
@@ -45,7 +52,7 @@ slots:
     description: >-
       a human-readable description of a thing
     slot_uri: dcterms:description
-    
+
   type:
     deprecated: >-
       Due to confusion about what values are used for this slot, it is best not to use this slot.

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -26,19 +26,14 @@ imports:
 
 slots:
 
-  raw_type:
-    description: a placeholder for the contents of legacy, free-text type slots
-    comments:
-      - does not retain the rdf:type slot URI
-
-
   id:
     identifier: true
     multivalued: false
     description: >-
       A unique identifier for a thing.
       Must be either a CURIE shorthand for a URI or a complete URI
-    #required: false # for now we are setting this to false until we develop an id template
+    notes:
+      - for now we are setting this to false until we develop an id template
 
   name:
     multivalued: false
@@ -57,11 +52,11 @@ slots:
     deprecated: >-
       Due to confusion about what values are used for this slot, it is best not to use this slot.
       See https://github.com/microbiomedata/nmdc-schema/issues/248.
+      MAM removed designates_type and rdf:type slot uri 2022-11-30
     range: string
     description: >-
       An optional string that specifies the type object. 
       This is used to allow for searches for different kinds of objects.
-    designates_type: true
     examples:
       - value: nmdc:Biosample
       - value: nmdc:Study

--- a/src/schema/bioscales.yaml
+++ b/src/schema/bioscales.yaml
@@ -5,9 +5,12 @@ description: >-
   NMDC Schema support for Bioscales analytes
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
+notes:
+  - "removed MS: http://purl.obolibrary.org/obo/MS_ prefix assignment"
+  - "should https://www.ornl.gov/content/bio-scales-0 be the 'source' for some of theses slots?"
+
 prefixes:
   mixs: https://w3id.org/mixs/
-  #  MS: http://purl.obolibrary.org/obo/MS_
   dcterms: http://purl.org/dc/terms/
   igsnvoc: https://igsn.org/voc/v1/
   linkml: https://w3id.org/linkml/
@@ -51,10 +54,11 @@ slots:
     title: zinc
     examples:
       - value: 2.5 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
     is_a: attribute
     multivalued: false
     range: QuantityValue
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
   manganese:
     name: manganese
     aliases:
@@ -73,7 +77,8 @@ slots:
     title: manganese
     examples:
       - value: 24.7 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -97,7 +102,8 @@ slots:
     title: ammonium nitrogen
     examples:
       - value: 2.3 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -107,7 +113,7 @@ slots:
     aliases:
       - nitrate_nitrogen
       - NO3-N
-    notes:
+    comments:
       - often below some specified limit of detection
     annotations:
       expected_value:
@@ -123,7 +129,8 @@ slots:
     title: nitrate_nitrogen
     examples:
       - value: 0.29 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -147,7 +154,8 @@ slots:
     title: nitrite_nitrogen
     examples:
       - value: 1.2 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -155,7 +163,7 @@ slots:
 
   lbc_thirty:
     name: lbc_thirty
-    notes:
+    comments:
       - This is the mass of lime, in mg, needed to raise the pH of one kg of soil by one pH unit
     aliases:
       - lbc_thirty
@@ -175,7 +183,8 @@ slots:
     title: lime buffer capacity (at 30 minutes)
     examples:
       - value: 543 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -184,7 +193,7 @@ slots:
 
   lbceq:
     name: lbceq
-    notes:
+    comments:
       - This is the mass of lime, in mg, needed to raise the pH of one kg of soil by one pH unit
     aliases:
       - lbceq
@@ -203,7 +212,8 @@ slots:
     title: lime buffer capacity (after 5 day incubation)
     examples:
       - value: 1575 mg/kg
-    #    source: https://www.ornl.gov/content/bio-scales-0
+    notes:
+      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
     is_a: attribute
     multivalued: false
     range: QuantityValue

--- a/src/schema/bioscales.yaml
+++ b/src/schema/bioscales.yaml
@@ -32,8 +32,6 @@ default_curi_maps:
 
 imports:
   - basic_slots
-  - core
-  - linkml:types
 
 slots:
   zinc:

--- a/src/schema/bioscales.yaml
+++ b/src/schema/bioscales.yaml
@@ -28,8 +28,10 @@ default_curi_maps:
 
 
 imports:
-  - linkml:types
+  - basic_slots
   - core
+  - linkml:types
+
 slots:
   zinc:
     name: zinc

--- a/src/schema/bioscales.yaml
+++ b/src/schema/bioscales.yaml
@@ -57,8 +57,8 @@ slots:
     is_a: attribute
     multivalued: false
     range: QuantityValue
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
   manganese:
     name: manganese
     aliases:
@@ -77,8 +77,8 @@ slots:
     title: manganese
     examples:
       - value: 24.7 mg/kg
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -102,8 +102,8 @@ slots:
     title: ammonium nitrogen
     examples:
       - value: 2.3 mg/kg
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -129,8 +129,8 @@ slots:
     title: nitrate_nitrogen
     examples:
       - value: 0.29 mg/kg
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -154,8 +154,8 @@ slots:
     title: nitrite_nitrogen
     examples:
       - value: 1.2 mg/kg
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
     is_a: attribute
     multivalued: false
     range: QuantityValue
@@ -183,12 +183,12 @@ slots:
     title: lime buffer capacity (at 30 minutes)
     examples:
       - value: 543 mg/kg
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
+      - https://secure.caes.uga.edu/extension/publications/files/pdf/C%20874_5.PDF
     is_a: attribute
     multivalued: false
     range: QuantityValue
-    see_also: https://secure.caes.uga.edu/extension/publications/files/pdf/C%20874_5.PDF
 
 
   lbceq:
@@ -212,8 +212,8 @@ slots:
     title: lime buffer capacity (after 5 day incubation)
     examples:
       - value: 1575 mg/kg
-    notes:
-      - see https://www.ornl.gov/content/bio-scales-0. could that be the "source"?
+    see_also:
+      - https://www.ornl.gov/content/bio-scales-0
     is_a: attribute
     multivalued: false
     range: QuantityValue

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -5,16 +5,19 @@ description: >-
   Schema for National Microbiome Data Collaborative (NMDC), Core Types
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
+notes:
+  - "removed MS: http://purl.obolibrary.org/obo/MS_ prefix assignment"
+  - "removed PR: http://identifiers.org/pr/ prefix assignment"
+
 prefixes:
-  mixs: https://w3id.org/mixs/
-  #  MS: http://purl.obolibrary.org/obo/MS_
-  #  PR: http://identifiers.org/pr/
+  KEGG.COMPOUND: http://identifiers.org/kegg.compound/
   UniProtKB: https://identifiers.org/uniprot/
   biolink: https://w3id.org/biolink/vocab/
   dcterms: http://purl.org/dc/terms/
   gtpo: https://unknown.to.linter.org/
   igsnvoc: https://igsn.org/voc/v1/
   linkml: https://w3id.org/linkml/
+  mixs: https://w3id.org/mixs/
   nmdc: https://w3id.org/nmdc/
   qud: http://qudt.org/1.1/schema/qudt#
   rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
@@ -22,8 +25,6 @@ prefixes:
   sio: http://semanticscience.org/resource/SIO_
   skos: http://www.w3.org/2004/02/skos/core#
   wgs84: http://www.w3.org/2003/01/geo/wgs84_pos#
-  #  KEGG_COMPOUND: http://unknown.to.linter.org/
-  KEGG.COMPOUND: http://identifiers.org/kegg.compound/
 
 default_prefix: nmdc
 default_range: string
@@ -186,7 +187,7 @@ classes:
     is_a: NamedThing
     description: >-
       represents a person, such as a researcher
-    comments:
+    notes:
       - "not yet in use"
     slot_usage:
       id:
@@ -195,7 +196,7 @@ classes:
   
   MagBin:
     slots:
-      - type  # custom slot that specifies object type
+      - type
     attributes:
       bin_name:
         range: string
@@ -335,7 +336,7 @@ classes:
         multivalued: false
         range: string
       inchi_key:
-        key: false # rare; Pletnev I, Erin A, McNaught A, Blinov K, Tchekhovskoi D, Heller S (2012) InChIKey collision resistance: an experimental testing. J Cheminform. 4:12
+        key: false
         multivalued: false
         range: string
       smiles:
@@ -367,7 +368,7 @@ classes:
     is_a: NamedThing
     description: >-
       A molecule encoded by a gene that has an evolved function
-    comments:
+    notes:
       - we may include a more general gene product class in future to allow for ncRNA annotation
     id_prefixes:
       - PR
@@ -392,10 +393,8 @@ classes:
     is_a: AttributeValue
     description: >-
       A value that is a timestamp. The range should be ISO-8601
-    #slots:
-    #  - year
-    #  - month
-    #  - day
+    notes:
+      - "removed the following slots: year, month, day"
 
   IntegerValue:
     is_a: AttributeValue
@@ -417,11 +416,12 @@ classes:
       A controlled term or class from an ontology
     slots:
       - term
-    # TODO: add fields for ontology, branch
+    todos:
+      - add fields for ontology, branch
 
   ControlledIdentifiedTermValue:
     description: A controlled term or class from an ontology, requiring the presence of term with an id
-    comments:
+    notes:
       - To be used for slots like env_broad_scale
     is_a: ControlledTermValue
     slot_usage:
@@ -435,11 +435,12 @@ classes:
     slots:
       - latitude
       - longitude
+    notes:
+      - "what did 'to_str: {latitude} {longitude}' mean?"
     slot_usage:
       has_raw_value:
         description: >-
           The raw value for a  geolocation should follow {lat} {long}
-        # to_str: {latitude} {longitude}
     mappings:
       - schema:GeoCoordinates
 
@@ -523,8 +524,9 @@ slots:
     range: OntologyClass
     description: >-
       pointer to an ontology class
-    #    slot_uri: rdf:type
     inlined: true
+    notes:
+      - "removed 'slot_uri: rdf:type'"
 
   orcid:
     description: >-
@@ -651,6 +653,8 @@ slots:
   best_protein:
   chemical_formula:
   inchi_key:
+    notes:
+      - "key set to false due to rare collisions: Pletnev I, Erin A, McNaught A, Blinov K, Tchekhovskoi D, Heller S (2012) InChIKey collision resistance: an experimental testing. J Cheminform. 4:12"
   inchi:
   min_q_value:
   peptide_sequence:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -419,6 +419,15 @@ classes:
       - term
     # TODO: add fields for ontology, branch
 
+  ControlledIdentifiedTermValue:
+    description: A controlled term or class from an ontology, requiring the presence of term with an id
+    comments:
+      - To be used for slots like env_broad_scale
+    is_a: ControlledTermValue
+    slot_usage:
+      term:
+        required: true
+
   GeolocationValue:
     is_a: AttributeValue
     description: >-
@@ -514,7 +523,7 @@ slots:
     range: OntologyClass
     description: >-
       pointer to an ontology class
-    slot_uri: rdf:type
+    #    slot_uri: rdf:type
     inlined: true
 
   orcid:

--- a/src/schema/external_identifiers.yaml
+++ b/src/schema/external_identifiers.yaml
@@ -143,12 +143,12 @@ slots:
 
   ## samples
 
-  sample_identifiers:
+  biosample_identifiers:
     abstract: true
     is_a: external_database_identifiers
   
   gold_biosample_identifiers:
-    is_a: sample_identifiers
+    is_a: biosample_identifiers
     mixins:
       - gold_identifiers
     pattern: "^GOLD:Gb[0-9]+$"
@@ -159,7 +159,7 @@ slots:
 
 
   insdc_biosample_identifiers:
-    is_a: sample_identifiers
+    is_a: biosample_identifiers
     mixins:
       - insdc_identifiers
     aliases:
@@ -180,7 +180,7 @@ slots:
       - https://www.ddbj.nig.ac.jp/biosample/index-e.html
 
   insdc_secondary_sample_identifiers:
-    is_a: sample_identifiers
+    is_a: biosample_identifiers
     mixins:
       - insdc_identifiers
     pattern: "^biosample:(E|D|S)RS[0-9]{6,}$"

--- a/src/schema/external_identifiers.yaml
+++ b/src/schema/external_identifiers.yaml
@@ -5,6 +5,9 @@ description: >-
   External identifiers
 license: https://creativecommons.org/publicdomain/zero/1.0/
 
+todos:
+  - "## section delimiters should be subsets"
+
 prefixes:
   GOLD: http://identifiers.org/gold/
   linkml: https://w3id.org/linkml/
@@ -39,12 +42,11 @@ slots:
     is_a: alternative_identifiers
     abstract: true
     multivalued: true
-    description:
-      Link to corresponding identifier in external database
+    description: Link to corresponding identifier in external database
     comments:
-      The value of this field is always a registered CURIE
-    #    range: external identifier
-    #    range: string
+      - The value of this field is always a registered CURIE
+    notes:
+      - "had tried ranges of  external identifier and string"
     range: uriorcurie
     close_mappings:
       - skos:closeMatch
@@ -69,7 +71,7 @@ slots:
       Any identifier covered by the International Nucleotide Sequence Database Collaboration
     comments:
       - note that we deliberately abstract over which of the partner databases accepted the initial submission
-      - the first letter of the accession indicates which partner accepted the initial submission: E for ENA, D for DDBJ, or S or N for NCBI.
+      - "the first letter of the accession indicates which partner accepted the initial submission: E for ENA, D for DDBJ, or S or N for NCBI."
     see_also:
       - https://www.insdc.org/
       - https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html
@@ -145,7 +147,7 @@ slots:
     abstract: true
     is_a: external_database_identifiers
   
-  gold_sample_identifiers:
+  gold_biosample_identifiers:
     is_a: sample_identifiers
     mixins:
       - gold_identifiers
@@ -184,7 +186,7 @@ slots:
     pattern: "^biosample:(E|D|S)RS[0-9]{6,}$"
     description: secondary identifiers for corresponding sample in INSDC
     comments:
-      - ENA redirects these to primary IDs, e.g. https://www.ebi.ac.uk/ena/browser/view/DRS166340 -> SAMD00212331
+      - "ENA redirects these to primary IDs, e.g. https://www.ebi.ac.uk/ena/browser/view/DRS166340 -> SAMD00212331"
       - MGnify uses these as their primary sample IDs
     examples:
       - value: https://identifiers.org/insdc.sra:DRS166340
@@ -244,7 +246,8 @@ slots:
 
   mgnify_analysis_identifiers:
     is_a: analysis_identifiers
-    #pattern: "^mgnify:MGYA[0-9]+$" ## TODO https://github.com/bioregistry/bioregistry/issues/109
+    notes:
+      - 'removed pattern: "^mgnify:MGYA[0-9]+$" ## TODO https://github.com/bioregistry/bioregistry/issues/109'
     mixins:
       - mgnify_identifiers
     examples:

--- a/src/schema/external_identifiers.yaml
+++ b/src/schema/external_identifiers.yaml
@@ -24,8 +24,6 @@ default_curi_maps:
 
 imports:
   - basic_slots
-  - core
-  - linkml:types
 
 types:
   

--- a/src/schema/external_identifiers.yaml
+++ b/src/schema/external_identifiers.yaml
@@ -20,6 +20,7 @@ default_curi_maps:
   - idot_context
 
 imports:
+  - basic_slots
   - core
   - linkml:types
 
@@ -42,7 +43,9 @@ slots:
       Link to corresponding identifier in external database
     comments:
       The value of this field is always a registered CURIE
-    range: external identifier
+    #    range: external identifier
+    #    range: string
+    range: uriorcurie
     close_mappings:
       - skos:closeMatch
 

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -8,6 +8,9 @@ imports:
   - core
   - basic_slots
 
+notes:
+  - "commented out sever MIxS terms/slots that were sharing slot uris"
+
 
 prefixes:
   nmdc: https://w3id.org/nmdc/
@@ -1842,9 +1845,8 @@ enums:
         text: crows feet
       crows-foot stomp:
         text: crows-foot stomp
-      #      ? ''
-      #        :
-      #        text: ''
+        notes:
+          - "removed '?' and '' as PVs"
       double skip:
         text: double skip
       hawk and trowel:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -6,6 +6,7 @@ default_range: string
 
 imports:
   - core
+  - basic_slots
 
 
 prefixes:
@@ -4994,7 +4995,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0000012
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   env_local_scale:
     name: env_local_scale
     aliases:
@@ -5024,7 +5025,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0000013
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   env_medium:
     name: env_medium
     aliases:
@@ -5054,7 +5055,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0000014
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   escalator:
     name: escalator
     aliases:
@@ -6432,29 +6433,29 @@ slots:
     slot_uri: mixs:0000561
     multivalued: false
     range: QuantityValue
-  horizon:
-    name: horizon
-    aliases:
-      - horizon
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Specific layer in the land area which measures parallel to the soil
-      surface and possesses physical characteristics which differ from the layers
-      above and beneath
-    title: horizon
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: attribute
-    slot_uri: mixs:0001082
-    multivalued: false
-    range: TextValue
+#  horizon:
+#    name: horizon
+#    aliases:
+#      - horizon
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: enumeration
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Specific layer in the land area which measures parallel to the soil
+#      surface and possesses physical characteristics which differ from the layers
+#      above and beneath
+#    title: horizon
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: attribute
+#    slot_uri: mixs:0001082
+#    multivalued: false
+#    range: TextValue
   horizon_meth:
     name: horizon_meth
     aliases:
@@ -6554,7 +6555,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0000888
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   host_body_site:
     name: host_body_site
     aliases:
@@ -6581,7 +6582,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0000867
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   host_body_temp:
     name: host_body_temp
     aliases:
@@ -6904,7 +6905,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0000874
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   host_sex:
     name: host_sex
     aliases:
@@ -7815,28 +7816,28 @@ slots:
     slot_uri: mixs:0000101
     multivalued: false
     range: QuantityValue
-  micro_biomass_meth:
-    name: micro_biomass_meth
-    aliases:
-      - microbial biomass method
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Reference or method used in determining microbial biomass
-    title: microbial biomass method
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: core_field
-    string_serialization: '{PMID}|{DOI}|{URL}'
-    slot_uri: mixs:0000339
-    multivalued: false
-    range: string
+#  micro_biomass_meth:
+#    name: micro_biomass_meth
+#    aliases:
+#      - microbial biomass method
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: PMID,DOI or url
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Reference or method used in determining microbial biomass
+#    title: microbial biomass method
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: core_field
+#    string_serialization: '{PMID}|{DOI}|{URL}'
+#    slot_uri: mixs:0000339
+#    multivalued: false
+#    range: string
   microbial_biomass:
     name: microbial_biomass
     aliases:
@@ -7863,28 +7864,28 @@ slots:
     slot_uri: mixs:0000650
     multivalued: false
     range: QuantityValue
-  microbial_biomass_meth:
-    name: microbial_biomass_meth
-    aliases:
-      - microbial biomass method
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Reference or method used in determining microbial biomass
-    title: microbial biomass method
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: attribute
-    string_serialization: '{PMID|DOI|URL}'
-    slot_uri: mixs:0000339
-    multivalued: false
-    range: TextValue
+#  microbial_biomass_meth:
+#    name: microbial_biomass_meth
+#    aliases:
+#      - microbial biomass method
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: PMID,DOI or url
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Reference or method used in determining microbial biomass
+#    title: microbial biomass method
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: attribute
+#    string_serialization: '{PMID|DOI|URL}'
+#    slot_uri: mixs:0000339
+#    multivalued: false
+#    range: TextValue
   mineral_nutr_regm:
     name: mineral_nutr_regm
     aliases:
@@ -9011,7 +9012,7 @@ slots:
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: mixs:0001060
     multivalued: false
-    range: ControlledTermValue
+    range: ControlledIdentifiedTermValue
   pollutants:
     name: pollutants
     aliases:
@@ -9219,28 +9220,28 @@ slots:
     slot_uri: mixs:0000412
     multivalued: false
     range: QuantityValue
-  prev_land_use_meth:
-    name: prev_land_use_meth
-    aliases:
-      - history/previous land use method
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Reference or method used in determining previous land use and dates
-    title: history/previous land use method
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: core_field
-    string_serialization: '{PMID}|{DOI}|{URL}'
-    slot_uri: mixs:0000316
-    multivalued: false
-    range: string
+#  prev_land_use_meth:
+#    name: prev_land_use_meth
+#    aliases:
+#      - history/previous land use method
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: PMID,DOI or url
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Reference or method used in determining previous land use and dates
+#    title: history/previous land use method
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: core_field
+#    string_serialization: '{PMID}|{DOI}|{URL}'
+#    slot_uri: mixs:0000316
+#    multivalued: false
+#    range: string
   previous_land_use:
     name: previous_land_use
     aliases:
@@ -9263,28 +9264,28 @@ slots:
     slot_uri: mixs:0000315
     multivalued: false
     range: TextValue
-  previous_land_use_meth:
-    name: previous_land_use_meth
-    aliases:
-      - history/previous land use method
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Reference or method used in determining previous land use and dates
-    title: history/previous land use method
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: attribute
-    string_serialization: '{PMID|DOI|URL}'
-    slot_uri: mixs:0000316
-    multivalued: false
-    range: TextValue
+#  previous_land_use_meth:
+#    name: previous_land_use_meth
+#    aliases:
+#      - history/previous land use method
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: PMID,DOI or url
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Reference or method used in determining previous land use and dates
+#    title: history/previous land use method
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: attribute
+#    string_serialization: '{PMID|DOI|URL}'
+#    slot_uri: mixs:0000316
+#    multivalued: false
+#    range: TextValue
   primary_prod:
     name: primary_prod
     aliases:
@@ -10430,29 +10431,29 @@ slots:
     slot_uri: mixs:0000860
     multivalued: false
     range: TextValue
-  samp_collec_device:
-    name: samp_collec_device
-    aliases:
-      - sample collection device
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: device name
-    description: The device used to collect an environmental sample. This field accepts
-      terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
-      This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094).
-    title: sample collection device
-    examples:
-      - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: nucleic_acid_sequence_source_field
-    string_serialization: '{termLabel} {[termID]}|{text}'
-    slot_uri: mixs:0000002
-    multivalued: false
-    range: string
+#  samp_collec_device:
+#    name: samp_collec_device
+#    aliases:
+#      - sample collection device
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: device name
+#    description: The device used to collect an environmental sample. This field accepts
+#      terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
+#      This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094).
+#    title: sample collection device
+#    examples:
+#      - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: nucleic_acid_sequence_source_field
+#    string_serialization: '{termLabel} {[termID]}|{text}'
+#    slot_uri: mixs:0000002
+#    multivalued: false
+#    range: string
   samp_collec_method:
     name: samp_collec_method
     aliases:
@@ -10474,32 +10475,32 @@ slots:
     slot_uri: mixs:0001225
     multivalued: false
     range: string
-  samp_collect_device:
-    name: samp_collect_device
-    aliases:
-      - sample collection device
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: device name
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: The device used to collect an environmental sample. This field accepts
-      terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
-      This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094).
-    title: sample collection device
-    examples:
-      - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: attribute
-    string_serialization: '{termLabel} {[termID]}|{text}'
-    slot_uri: mixs:0000002
-    multivalued: false
-    range: TextValue
+#  samp_collect_device:
+#    name: samp_collect_device
+#    aliases:
+#      - sample collection device
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: device name
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: The device used to collect an environmental sample. This field accepts
+#      terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO).
+#      This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094).
+#    title: sample collection device
+#    examples:
+#      - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: attribute
+#    string_serialization: '{termLabel} {[termID]}|{text}'
+#    slot_uri: mixs:0000002
+#    multivalued: false
+#    range: TextValue
   samp_collect_point:
     name: samp_collect_point
     aliases:
@@ -11671,77 +11672,77 @@ slots:
     slot_uri: mixs:0000428
     multivalued: false
     range: QuantityValue
-  soil_horizon:
-    name: soil_horizon
-    aliases:
-      - soil horizon
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Specific layer in the land area which measures parallel to the soil
-      surface and possesses physical characteristics which differ from the layers
-      above and beneath
-    title: soil horizon
-    examples:
-      - value: A horizon
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: core_field
-    slot_uri: mixs:0001082
-    multivalued: false
-    range: soil_horizon_enum
-  soil_text_measure:
-    name: soil_text_measure
-    aliases:
-      - soil texture measurement
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: The relative proportion of different grain sizes of mineral particles
-      in a soil, as described using a standard system; express as % sand (50 um to
-      2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty
-      clay loam) optional.
-    title: soil texture measurement
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: core_field
-    slot_uri: mixs:0000335
-    multivalued: false
-    range: QuantityValue
-  soil_texture_meth:
-    name: soil_texture_meth
-    aliases:
-      - soil texture method
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Reference or method used in determining soil texture
-    title: soil texture method
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: core_field
-    string_serialization: '{PMID}|{DOI}|{URL}'
-    slot_uri: mixs:0000336
-    multivalued: false
-    range: string
+#  soil_horizon:
+#    name: soil_horizon
+#    aliases:
+#      - soil horizon
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: enumeration
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Specific layer in the land area which measures parallel to the soil
+#      surface and possesses physical characteristics which differ from the layers
+#      above and beneath
+#    title: soil horizon
+#    examples:
+#      - value: A horizon
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: core_field
+#    slot_uri: mixs:0001082
+#    multivalued: false
+#    range: soil_horizon_enum
+#  soil_text_measure:
+#    name: soil_text_measure
+#    aliases:
+#      - soil texture measurement
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: measurement value
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: The relative proportion of different grain sizes of mineral particles
+#      in a soil, as described using a standard system; express as % sand (50 um to
+#      2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty
+#      clay loam) optional.
+#    title: soil texture measurement
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: core_field
+#    slot_uri: mixs:0000335
+#    multivalued: false
+#    range: QuantityValue
+#  soil_texture_meth:
+#    name: soil_texture_meth
+#    aliases:
+#      - soil texture method
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: PMID,DOI or url
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Reference or method used in determining soil texture
+#    title: soil texture method
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: core_field
+#    string_serialization: '{PMID}|{DOI}|{URL}'
+#    slot_uri: mixs:0000336
+#    multivalued: false
+#    range: string
   soil_type:
     name: soil_type
     aliases:
@@ -12599,52 +12600,52 @@ slots:
     slot_uri: mixs:0000352
     multivalued: false
     range: TextValue
-  texture:
-    name: texture
-    aliases:
-      - texture
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: The relative proportion of different grain sizes of mineral particles
-      in a soil, as described using a standard system; express as % sand (50 um to
-      2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty
-      clay loam) optional.
-    title: texture
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: attribute
-    slot_uri: mixs:0000335
-    multivalued: false
-    range: QuantityValue
-  texture_meth:
-    name: texture_meth
-    aliases:
-      - texture method
-    annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
-    description: Reference or method used in determining soil texture.
-    title: texture method
-    from_schema: http://w3id.org/mixs/terms
-    source: http://w3id.org/mixs/terms
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
-    is_a: attribute
-    string_serialization: '{PMID}|{DOI}|{URL}'
-    slot_uri: mixs:0000336
-    multivalued: false
-    range: TextValue
+#  texture:
+#    name: texture
+#    aliases:
+#      - texture
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: measurement value
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: The relative proportion of different grain sizes of mineral particles
+#      in a soil, as described using a standard system; express as % sand (50 um to
+#      2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty
+#      clay loam) optional.
+#    title: texture
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: attribute
+#    slot_uri: mixs:0000335
+#    multivalued: false
+#    range: QuantityValue
+#  texture_meth:
+#    name: texture_meth
+#    aliases:
+#      - texture method
+#    annotations:
+#      expected_value:
+#        tag: expected_value
+#        value: PMID,DOI or url
+#      occurrence:
+#        tag: occurrence
+#        value: '1'
+#    description: Reference or method used in determining soil texture.
+#    title: texture method
+#    from_schema: http://w3id.org/mixs/terms
+#    source: http://w3id.org/mixs/terms
+#    see_also:
+#      - https://github.com/microbiomedata/nmdc-schema/blob/issue-291-mixs-submod/util/rebuild_mixs_yaml.py
+#    is_a: attribute
+#    string_serialization: '{PMID}|{DOI}|{URL}'
+#    slot_uri: mixs:0000336
+#    multivalued: false
+#    range: TextValue
   tidal_stage:
     name: tidal_stage
     aliases:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -5,7 +5,6 @@ id: https://microbiomedata/schema/mixs
 default_range: string
 
 imports:
-  - core
   - basic_slots
 
 notes:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -19,6 +19,7 @@ prefixes:
   EC: https://unknown.to.linter.org/
   EFO: http://identifiers.org/efo/
   GOLD: http://identifiers.org/gold/
+  IMG.TAXON: http://identifiers.org/img.taxon/
   ISA: https://unknown.to.linter.org/
   MS: http://purl.obolibrary.org/obo/MS_
   MetaCyc: https://identifiers.org/metacyc.reaction/ # assuming we're talking about metacyc reactions and not genes, compounds etc.
@@ -27,19 +28,27 @@ prefixes:
   OBI: http://purl.obolibrary.org/obo/OBI_
   RetroRules: https://unknown.to.linter.org/
   UniProtKB: https://identifiers.org/uniprot/
+  bare: https://unknown.to.linter.org/
   biolink: https://w3id.org/biolink/vocab/
   dcterms: http://purl.org/dc/terms/
+  emsl: https://unknown.to.linter.org/
   gtpo: https://unknown.to.linter.org/
   igsn: https://app.geosamples.org/sample/igsn/
-  IMG.TAXON: http://identifiers.org/img.taxon/
   insdc.srs: https://unknown.to.linter.org/
+  jgi: https://unknown.to.linter.org/
   linkml: https://w3id.org/linkml/
   mgnify: https://unknown.to.linter.org/
   mixs: https://w3id.org/mixs/
   nmdc: https://w3id.org/nmdc/
+  prov: http://www.w3.org/ns/prov#
   qud: http://qudt.org/1.1/schema/qudt#
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
   rdfs: http://www.w3.org/2000/01/rdf-schema#
+  schema: http://schema.org/
+  skos: http://www.w3.org/2004/02/skos/core#
   wgs84: http://www.w3.org/2003/01/geo/wgs84_pos#
+  xsd: http://www.w3.org/2001/XMLSchema#
+
 
 default_prefix: nmdc
 default_range: string
@@ -53,8 +62,10 @@ emit_prefixes:
   - rdfs
   - skos
   - xsd
+
 imports:
   - annotation
+  - basic_slots
   - bioscales
   - core
   - external_identifiers
@@ -135,7 +146,7 @@ classes:
       - compression_type
       - was_generated_by
       - url
-      - type
+      - raw_type
     slot_usage:
       name:
         required: true
@@ -162,10 +173,12 @@ classes:
         Samples are associated with checklists, which define the fields used to annotate
         the samples. Samples are always associated with a taxon.
     slots:
+      - raw_type
+      - img_identifiers
+      - samp_name
       - biosample_categories
-      - type  # custom slot that specifies object type
+      - raw_type  # custom slot that specifies object type
       - part_of
-      #      - canary
 
       # Identifiers
       - id
@@ -175,6 +188,8 @@ classes:
       - gold_sample_identifiers
 #      - insdc_biosample_identifiers
 #      - insdc_secondary_sample_identifiers
+      - emsl_biosample_identifiers
+      - igsn_biosample_identifiers
 
       # MIXS slots
       - agrochem_addition
@@ -224,8 +239,8 @@ classes:
       - glucosidase_act
       - heavy_metals
       - heavy_metals_meth
-      - horizon
-      - horizon_meth
+#      - horizon
+#      - horizon_meth
       - lat_lon
       - link_addit_analys
       - link_class_info
@@ -235,8 +250,8 @@ classes:
       - magnesium
       - mean_frict_vel
       - mean_peak_frict_vel
-      - microbial_biomass
-      - microbial_biomass_meth
+#      - microbial_biomass
+#      - microbial_biomass_meth
       - misc_param
       - n_alkanes
       - nitrate
@@ -255,13 +270,13 @@ classes:
       - pool_dna_extracts
       - potassium
       - pressure
-      - previous_land_use
-      - previous_land_use_meth
+#      - previous_land_use
+#      - previous_land_use_meth
       - profile_position
       - redox_potential
       - salinity
       - salinity_meth
-      - samp_collect_device
+#      - samp_collect_device
       - samp_mat_process
       - samp_store_dur
       - samp_store_loc
@@ -281,8 +296,8 @@ classes:
       - sulfate
       - sulfide
       - temp
-      - texture
-      - texture_meth
+#      - texture
+#      - texture_meth
       - tillage
       - tidal_stage
       - tot_carb
@@ -306,10 +321,10 @@ classes:
       # GOLD specific fields
       - add_date
       - community
-      - depth2
+#      - depth2
       - habitat
       - host_name
-      - identifier
+#      - identifier
       - location
       - mod_date
       - ncbi_taxonomy_name
@@ -318,7 +333,7 @@ classes:
       - sample_collection_site
       - soluble_iron_micromol
       - subsurface_depth
-      - subsurface_depth2
+#      - subsurface_depth2
 
       # MIxS terms initially used in
       # sample metadata submission portal (aka DataHarmonizer)
@@ -331,13 +346,13 @@ classes:
       - growth_facil
       - humidity_regm
       - light_regm
-      - micro_biomass_meth
+#      - micro_biomass_meth
       - phosphate
       - rel_to_oxygen
       - samp_collec_method
       - samp_size
-      - soil_text_measure
-      - soil_texture_meth
+#      - soil_text_measure
+#      - soil_texture_meth
       - source_mat_id
       - watering_regm
 
@@ -435,6 +450,7 @@ classes:
       id:
         description: An NMDC assigned unique identifier for a biosample submitted to NMDC.
         required: true
+        pattern: '^nmdc:'
 
       lat_lon:
         required: false
@@ -510,7 +526,7 @@ classes:
       - websites
       - publications
       - ess_dive_datasets
-      - type
+      - raw_type
       - relevant_protocols
       - funding_sources
       - has_credit_associations
@@ -638,7 +654,7 @@ classes:
       - part_of
       - principal_investigator
       - processing_institution
-      - type
+      - raw_type
       - gold_sequencing_project_identifiers
       - insdc_experiment_identifiers
       - samp_vol_we_dna_ext
@@ -669,7 +685,7 @@ classes:
       - applies_to_person
       - applied_role
       - applied_roles
-      - type
+      - raw_type
     class_uri: prov:Association
 
 enums:
@@ -876,6 +892,35 @@ enums:
           - replaces Environmental Molecular Sciences Lab
 
 slots:
+  img_identifiers:
+    title: IMG Identifiers
+    description: >-
+      A list of identifiers that relate the biosample to records in the IMG database.
+    multivalued: true
+    todos:
+      - add is_a or mixin modeling
+      - what are the class of IMG records?!
+
+  emsl_biosample_identifiers:
+    title: EMSL Biosample Identifiers
+    description: >-
+      A list of identifiers for the biosample from the EMSL database.  This is
+      used to link the biosample, as modeled by NMDC, to the biosample in the planned EMSL NEXUS database.
+    multivalued: true
+    is_a: sample_identifiers
+    todos:
+      - removed "planned" once NEXUS is online
+      - make an emsl identifiers mixin
+      - determine real expansion for emsl prefix
+
+  igsn_biosample_identifiers:
+    title: IGSN Biosample Identifiers
+    description: >-
+      A list of identifiers for the biosample from the IGSN database.
+    multivalued: true
+    is_a: sample_identifiers
+    todos:
+      - make an igsn identifiers mixin
   biosample_categories:
     title: Categories the biosample belongs to
     range: biosample_category_enum
@@ -1216,12 +1261,12 @@ slots:
     range: string
   host_name:
     range: string
-  depth2:
-    range: QuantityValue
+#  depth2:
+#    range: QuantityValue
   subsurface_depth:
     range: QuantityValue
-  subsurface_depth2:
-    range: QuantityValue
+#  subsurface_depth2:
+#    range: QuantityValue
   proport_woa_temperature:
     range: string
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -919,7 +919,7 @@ slots:
       A list of identifiers for the biosample from the EMSL database.  This is
       used to link the biosample, as modeled by NMDC, to the biosample in the planned EMSL NEXUS database.
     multivalued: true
-    is_a: sample_identifiers
+    is_a: biosample_identifiers
     todos:
       - removed "planned" once NEXUS is online
       - make an emsl identifiers mixin
@@ -930,7 +930,7 @@ slots:
     description: >-
       A list of identifiers for the biosample from the IGSN database.
     multivalued: true
-    is_a: sample_identifiers
+    is_a: biosample_identifiers
     todos:
       - make an igsn identifiers mixin
   biosample_categories:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2,6 +2,18 @@ id: https://microbiomedata/schema
 name: NMDC
 title: NMDC Schema
 
+notes:
+  - "MetaCyc expansion assumes we're talking about metacyc reactions and not genes, compounds etc."
+  - "removed/commented out the comfusing 'identifier' slot"
+  - "removed/commented out all mentions and definitions of depth2 and subsurface_depth2"
+  - "depth2 should now be migrated to the has_maximum_value part of depth"
+  - "slots requested for Bioscales, but already available for Biosample: tot_phosp, tot_carb, tot_nitro_content, pH"
+  - "informal ## section delimiters should be replaced with subsets ?"
+  - "commented out insdc_biosample_identifiers insdc_secondary_sample_identifiers... need better understanding of id patterns (at least)"
+  - "commented out several MIxS terms assigned to Biosample because the definitions of those terms were commented out in mixs.yaml dues to shared slot uris"
+  - "resuming use of part_of to link Biosamples to Studies. eg releasing sample_link from that role"
+
+
 description: >-
   Schema for National Microbiome Data Collaborative (NMDC).
   
@@ -22,7 +34,7 @@ prefixes:
   IMG.TAXON: http://identifiers.org/img.taxon/
   ISA: https://unknown.to.linter.org/
   MS: http://purl.obolibrary.org/obo/MS_
-  MetaCyc: https://identifiers.org/metacyc.reaction/ # assuming we're talking about metacyc reactions and not genes, compounds etc.
+  MetaCyc: https://identifiers.org/metacyc.reaction/
   MetaNetX: https://unknown.to.linter.org/
   NCIT: http://purl.obolibrary.org/obo/NCIT_
   OBI: http://purl.obolibrary.org/obo/OBI_
@@ -146,7 +158,7 @@ classes:
       - compression_type
       - was_generated_by
       - url
-      - raw_type
+      - type
     slot_usage:
       name:
         required: true
@@ -173,25 +185,25 @@ classes:
         Samples are associated with checklists, which define the fields used to annotate
         the samples. Samples are always associated with a taxon.
     slots:
-      - raw_type
+      - type
       - img_identifiers
       - samp_name
       - biosample_categories
-      - raw_type  # custom slot that specifies object type
+      - type
       - part_of
 
-      # Identifiers
+      ## Identifiers
       - id
       - alternative_identifiers
 
-      # external IDs, alternate IDs
-      - gold_sample_identifiers
-#      - insdc_biosample_identifiers
-#      - insdc_secondary_sample_identifiers
+      ## external IDs, alternate IDs
+      - gold_biosample_identifiers
+      #      - insdc_biosample_identifiers
+      #      - insdc_secondary_sample_identifiers
       - emsl_biosample_identifiers
       - igsn_biosample_identifiers
 
-      # MIXS slots
+      ## MIXS slots
       - agrochem_addition
       - alkalinity
       - alkalinity_method
@@ -239,8 +251,8 @@ classes:
       - glucosidase_act
       - heavy_metals
       - heavy_metals_meth
-#      - horizon
-#      - horizon_meth
+      #      - horizon
+      #      - horizon_meth
       - lat_lon
       - link_addit_analys
       - link_class_info
@@ -250,8 +262,8 @@ classes:
       - magnesium
       - mean_frict_vel
       - mean_peak_frict_vel
-#      - microbial_biomass
-#      - microbial_biomass_meth
+      #      - microbial_biomass
+      #      - microbial_biomass_meth
       - misc_param
       - n_alkanes
       - nitrate
@@ -270,13 +282,13 @@ classes:
       - pool_dna_extracts
       - potassium
       - pressure
-#      - previous_land_use
-#      - previous_land_use_meth
+      #      - previous_land_use
+      #      - previous_land_use_meth
       - profile_position
       - redox_potential
       - salinity
       - salinity_meth
-#      - samp_collect_device
+      #      - samp_collect_device
       - samp_mat_process
       - samp_store_dur
       - samp_store_loc
@@ -296,8 +308,8 @@ classes:
       - sulfate
       - sulfide
       - temp
-#      - texture
-#      - texture_meth
+      #      - texture
+      #      - texture_meth
       - tillage
       - tidal_stage
       - tot_carb
@@ -311,32 +323,30 @@ classes:
       - water_content
       - water_cont_soil_meth
 
-      # GOLD path fields
+      ## GOLD path fields
       - ecosystem
       - ecosystem_category
       - ecosystem_type
       - ecosystem_subtype
       - specific_ecosystem
 
-      # GOLD specific fields
+      ## GOLD specific fields
       - add_date
       - community
-#      - depth2
       - habitat
       - host_name
-#      - identifier
       - location
       - mod_date
       - ncbi_taxonomy_name
       - proport_woa_temperature
-      - salinity_category # note: maps to gold:salinity
+      - salinity_category
       - sample_collection_site
       - soluble_iron_micromol
       - subsurface_depth
-#      - subsurface_depth2
 
-      # MIxS terms initially used in
-      # sample metadata submission portal (aka DataHarmonizer)
+
+      ## MIxS terms initially used in
+      ## sample metadata submission portal (aka DataHarmonizer)
       - air_temp_regm
       - biotic_regm
       - biotic_relationship
@@ -346,18 +356,18 @@ classes:
       - growth_facil
       - humidity_regm
       - light_regm
-#      - micro_biomass_meth
+      #      - micro_biomass_meth
       - phosphate
       - rel_to_oxygen
       - samp_collec_method
       - samp_size
-#      - soil_text_measure
-#      - soil_texture_meth
+      #      - soil_text_measure
+      #      - soil_texture_meth
       - source_mat_id
       - watering_regm
 
-      # sample metadata submission portal (aka DataHarmonizer) terms (EMSL, JGI, etc.)
-      # JGI fields
+      ## sample metadata submission portal (aka DataHarmonizer) terms (EMSL, JGI, etc.)
+      ## JGI fields
       - dna_absorb1
       - dna_absorb2
       - dna_collect_site
@@ -422,10 +432,9 @@ classes:
       - analysis_type
       - sample_link
 
-      # EMSL fields
+      ## EMSL slots
 
-      # bioscales
-      # tot_phosp, tot_carb, tot_nitro_content, pH already associated with biosamples
+      ## bioscales slots
       - zinc
       - manganese
       - ammonium_nitrogen
@@ -435,7 +444,7 @@ classes:
       - lbceq
 
     slot_usage:
-      gold_sample_identifiers:
+      gold_biosample_identifiers:
         description: Unique identifier for a biosample submitted to GOLD that matches the NMDC submitted biosample
         comments: This is the ID provided by GOLD that starts with 'GB'
         annotations:
@@ -445,8 +454,8 @@ classes:
               Provide the GOLD biosample IDs associated with this biosample.
 
       alternative_identifiers:
-          description: Unique identifier for a biosample submitted to additional resources. Matches the entity that has been submitted to NMDC
-          required: false
+        description: Unique identifier for a biosample submitted to additional resources. Matches the entity that has been submitted to NMDC
+        required: false
       id:
         description: An NMDC assigned unique identifier for a biosample submitted to NMDC.
         required: true
@@ -463,12 +472,10 @@ classes:
       env_medium:
         required: true
       sample_link:
-        description:
+        description: { }
+        required: false
+      part_of:
         required: true
-    #      canary:
-    #        required: true
-    #      part_of:
-    #        required: false
 
     id_prefixes:
       - GOLD
@@ -495,13 +502,13 @@ classes:
         controls its release date. A study accession is typically used when citing
         data submitted to ENA
     slots:
-      # Identifiers
+      ## Identifiers
       - id
 
-      # Alternative IDs
+      ## Alternative IDs
       - alternative_identifiers
 
-      # Related IDs
+      ## Related IDs
       - related_identifiers
       - emsl_proposal_identifier
       - emsl_proposal_doi
@@ -526,7 +533,7 @@ classes:
       - websites
       - publications
       - ess_dive_datasets
-      - raw_type
+      - type
       - relevant_protocols
       - funding_sources
       - has_credit_associations
@@ -541,7 +548,7 @@ classes:
         annotations:
           display_hint:
             tag: display_hint
-            value: >- 
+            value: >-
               DOI associated with the data in this study. This is required when data is already generated.
       name:
         description:
@@ -583,7 +590,7 @@ classes:
               Project, study, or sample set names the are also associated with this submission 
               or other names / identifiers for this study.
       related_identifiers:
-          description: Unique identifier for a study submitted to additional resources. Similar, but not necessarily identical to that which has been submitted to NMDC
+        description: Unique identifier for a study submitted to additional resources. Similar, but not necessarily identical to that which has been submitted to NMDC
       insdc_bioproject_identifiers:
         description: Unique identifier for a bioproject submitted to INSDC that relates to the NMDC submitted study.
         annotations:
@@ -610,9 +617,13 @@ classes:
         experimental_factor
       - project_name is redundant with name, so excluding it
     id_prefixes:
-      - GOLD ## https://identifiers.org/gold:Gs0110115
-      - insdc.srs ## https://www.ebi.ac.uk/ena/browser/view/PRJEB45055?
-      - mgnify ## https://www.ebi.ac.uk/metagenomics/studies/MGYS00005757
+      - GOLD
+      - insdc.srs
+      - mgnify
+    notes:
+      - "sample GOLD link https://identifiers.org/gold:Gs0110115"
+      - "sample insdc.srs link https://www.ebi.ac.uk/ena/browser/view/PRJEB45055 ?"
+      - "sample mgnify link https://www.ebi.ac.uk/metagenomics/studies/MGYS00005757"
 
   BiosampleProcessing:
     aliases:
@@ -642,7 +653,7 @@ classes:
       embl.ena: An experiment contains information about a sequencing experiment including
         library and instrument details.
     comments:
-      - The IDs for objects coming from GOLD will have prefixes gold:GpNNNN
+      - The ID prefix for objects coming from GOLD will be gold:Gp
     slots:
       - add_date
       - mod_date
@@ -654,7 +665,7 @@ classes:
       - part_of
       - principal_investigator
       - processing_institution
-      - raw_type
+      - type
       - gold_sequencing_project_identifiers
       - insdc_experiment_identifiers
       - samp_vol_we_dna_ext
@@ -685,7 +696,7 @@ classes:
       - applies_to_person
       - applied_role
       - applied_roles
-      - raw_type
+      - type
     class_uri: prov:Association
 
 enums:
@@ -870,7 +881,7 @@ enums:
       - credit enums come from https://casrai.org/credit/
   processing_institution_enum:
     name: processing_institution_enum
-    comments:
+    notes:
       - This will become the range of processing_institution.omics processing
       - use ROR meanings like https://ror.org/0168r3w48 for UCSD
     from_schema: NMDC_enums_roundtrip
@@ -887,11 +898,12 @@ enums:
         text: EMSL
         title: Environmental Molecular Sciences Laboratory
         meaning: https://ror.org/04rc0xn13
-        comments:
+        notes:
           - replaces Environmental Molecular Science Laboratory
           - replaces Environmental Molecular Sciences Lab
 
 slots:
+  emsl_project_identifier: { }
   img_identifiers:
     title: IMG Identifiers
     description: >-
@@ -929,8 +941,6 @@ slots:
     description: from database class
   etl_software_version:
     description: from database class
-  #  metatranscriptome_activity_set:
-  #    description: from database class
   related_identifiers:
     title: Related Identifiers
     description: Identifiers assigned to a thing that is similar to that which is represented in NMDC. Related identifier are not an identical match and may have some variation.
@@ -956,7 +966,8 @@ slots:
     domain: Study
     range: CreditAssociation
     multivalued: true
-    # was just "inlined: true"
+    notes:
+      - 'had just been "inlined: true"'
     inlined_as_list: true
     description: 'This slot links a study to a credit association.  The credit association
       will be linked to a person value and to a CRediT Contributor Roles term. Overall
@@ -1129,6 +1140,8 @@ slots:
     examples:
       - value: metatranscriptome
       - value: metagenome
+    notes:
+      - "was the range string at one point? the values in MongoDB don't look like NMDC classes"
   data_object_type:
     range: file type enum
     description: The type of file represented by the data object.
@@ -1234,13 +1247,13 @@ slots:
     range: string
   sample_collection_site:
     range: string
-  identifier:
-    slot_group: biosample_identifiers
-    range: string
-    todos:
-      - used in MongoDB as of 2022-09-09, which is still on schema 3.?
-      - we will remove this slot form the schema, but make sure to retain the content in MongoDB in a relevant, retained slot
-      - Mark will do the MongoDB migration
+  #  identifier:
+  #    slot_group: biosample_identifiers
+  #    range: string
+  #    todos:
+  #      - used in MongoDB as of 2022-09-09, which is still on schema 3.?
+  #      - we will remove this slot form the schema, but make sure to retain the content in MongoDB in a relevant, retained slot
+  #      - Mark will do the MongoDB migration
   sample_collection_year:
     range: integer
   sample_collection_month:
@@ -1257,16 +1270,16 @@ slots:
     range: string
     see_also:
       - https://github.com/microbiomedata/nmdc-metadata/pull/297
+    notes:
+      - "maps to gold:salinity"
   soluble_iron_micromol:
     range: string
   host_name:
     range: string
-#  depth2:
-#    range: QuantityValue
   subsurface_depth:
     range: QuantityValue
-#  subsurface_depth2:
-#    range: QuantityValue
+  #  subsurface_depth2:
+  #    range: QuantityValue
   proport_woa_temperature:
     range: string
 
@@ -1280,7 +1293,6 @@ slots:
   processing_institution:
     range: processing_institution_enum
     description: The organization that processed the sample.
-  #  omics_type:
-  #    range: string
+
   completion_date:
     range: string

--- a/src/schema/portal/mixs_inspired.yaml
+++ b/src/schema/portal/mixs_inspired.yaml
@@ -21,7 +21,7 @@ slots:
       for incubation samples.
     title: incubation collection date
     notes:
-    - MIxS collection_date accepts (truncated) ISO8601. DH taking arb prec date only
+    - MIxS collection_date accepts (truncated) ISO8601. DH taking arbitrary precision date only
     comments:
     - Date should be formatted as YYYY(-MM(-DD)). Ie, 2021-04-15, 2021-04 and 2021
       are all acceptable.
@@ -207,7 +207,7 @@ slots:
     description: Date the incubation was started. Only relevant for incubation samples.
     title: incubation start date
     notes:
-    - MIxS collection_date accepts (truncated) ISO8601. DH taking arb prec date only
+    - MIxS collection_date accepts (truncated) ISO8601. DH taking arbitrary precision date only
     comments:
     - Date should be formatted as YYYY(-MM(-DD)). Ie, 2021-04-15, 2021-04 and 2021
       are all acceptable.

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -20,7 +20,9 @@ default_curi_maps:
 
 imports:
   - basic_slots
+  - core
   - linkml:types
+
 classes:
 
   Activity:

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -20,8 +20,7 @@ default_curi_maps:
 
 imports:
   - basic_slots
-  - core
-  - linkml:types
+
 
 classes:
 

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -51,7 +51,7 @@ slots:
   started_at_time:
     range: datetime
     pattern: ^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$
-    comments: >-
+    notes: >-
       The regex for ISO-8601 format was taken from here: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
       It may not be complete, but it is good enough for now.
     mappings:
@@ -60,7 +60,7 @@ slots:
   ended_at_time:
     range: datetime
     pattern: ^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$
-    comments: >-
+    notes: >-
       The regex for ISO-8601 format was taken from here: https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/
       It may not be complete, but it is good enough for now.
     mappings:

--- a/src/schema/sample_prep.yaml
+++ b/src/schema/sample_prep.yaml
@@ -27,7 +27,7 @@ imports:
   - basic_slots
   - core
   - linkml:types
-  - nmdc
+  - nmdc # for slot biosample_input with range: Biosample
 
 enums:
   ContainerTypeEnum:

--- a/src/schema/sample_prep.yaml
+++ b/src/schema/sample_prep.yaml
@@ -26,8 +26,6 @@ notes:
   - "circular nmdc import is for slot biosample_input with range: Biosample"
 imports:
   - basic_slots
-  - core
-  - linkml:types
   - nmdc
 
 enums:

--- a/src/schema/sample_prep.yaml
+++ b/src/schema/sample_prep.yaml
@@ -22,12 +22,13 @@ default_curi_maps:
   - obo_context
   - idot_context
 
-
+notes:
+  - "circular nmdc import is for slot biosample_input with range: Biosample"
 imports:
   - basic_slots
   - core
   - linkml:types
-  - nmdc # for slot biosample_input with range: Biosample
+  - nmdc
 
 enums:
   ContainerTypeEnum:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -19,7 +19,6 @@ prefixes:
 
 imports:
   - basic_slots
-  - core
   - external_identifiers
   - prov
 

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -1,9 +1,13 @@
 id: https://microbiomedata/schema/workflow_execution_activity
-name: NMDC-Workflow-Exectution
-title: Workflow Exectution Activities module for NMDC Schema
+name: NMDC-Workflow-Execution
+title: Workflow Execution Activities module for NMDC Schema
 
 default_prefix: nmdc
 default_range: string
+
+notes:
+  - "should type be required for WorkflowExecutionActivity ?"
+  - "changed misspelled schema name and title to 'Execution'"
 
 default_curi_maps:
   - obo_context
@@ -44,15 +48,17 @@ classes:
       - has_input
       - has_output
       - part_of
-      - raw_type # custom slot that specifies object type
+      - type
+    notes:
+      - MAM I don't think this is a reasonable override of the global range of Agent, but commenting that line out does not, on its own, fix the conversion to SQLite
+      - "inlining of was_associated_with values allows for collections (strings?) of WorkflowExecutionActivity id values"
     slot_usage:
       was_associated_with:
         required: false
         description: >-
           the agent/entity associated with the generation of the file
-        range: WorkflowExecutionActivity  # MAM I don't think this is a reasonable override of the global range of Agent
-        # but commenting that line out does not, on its own, fix the conversion to SQLite
-        inlined: false # allow for strings of IDs
+        range: WorkflowExecutionActivity
+        inlined: false
       started_at_time:
         required: true
       ended_at_time:
@@ -67,8 +73,7 @@ classes:
         required: true
       execution_resource:
         required: true
-      raw_type:
-  #        required: true
+      type: { }
 
   MetagenomeAssembly:
     description: A workflow execution activity that converts sequencing reads into an assembled metagenome.
@@ -78,7 +83,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
       - asm_score
       - scaffolds
       - scaf_logsum
@@ -106,7 +111,6 @@ classes:
       - gc_avg
       - num_input_reads
       - num_aligned_reads
-      # external identifiers
       - insdc_assembly_identifiers
 
   MetatranscriptomeAssembly:
@@ -141,14 +145,13 @@ classes:
       - gc_avg
       - num_input_reads
       - num_aligned_reads
-      # external identifiers
       - insdc_assembly_identifiers
 
   MetagenomeAnnotationActivity:
     description: A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
     is_a: WorkflowExecutionActivity
     slots:
-      - raw_type
+      - type
       - gold_analysis_project_identifiers
     in_subset:
       - workflow subset
@@ -156,7 +159,7 @@ classes:
   MetatranscriptomeAnnotationActivity:
     is_a: WorkflowExecutionActivity
     slots:
-      - raw_type
+      - type
       - gold_analysis_project_identifiers
     in_subset:
       - workflow subset
@@ -168,7 +171,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
 
 
   MagsAnalysisActivity:
@@ -178,7 +181,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
       - input_contig_num
       - binned_contig_num
       - too_short_contig_num
@@ -193,7 +196,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
       - input_read_count
       - input_base_count
       - output_read_count
@@ -219,7 +222,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
 
 
   MetabolomicsAnalysisActivity:
@@ -227,7 +230,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
     slot_usage:
       used:
         range: Instrument
@@ -246,7 +249,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
     slot_usage:
       used:
         range: Instrument
@@ -262,7 +265,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
-      - raw_type
+      - type
     slot_usage:
       used:
         range: Instrument
@@ -275,7 +278,7 @@ classes:
           A reference to a file that holds calibration information.
 
 slots:
-  ## Workflow specific slots
+
   metagenome_assembly_parameter: { }
 
   has_peptide_quantifications: { }

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -14,9 +14,10 @@ prefixes:
   linkml: https://w3id.org/linkml/
 
 imports:
-  - prov
+  - basic_slots
   - core
   - external_identifiers
+  - prov
 
 subsets:
   workflow subset:
@@ -43,13 +44,14 @@ classes:
       - has_input
       - has_output
       - part_of
-      - type # custom slot that specifies object type
+      - raw_type # custom slot that specifies object type
     slot_usage:
       was_associated_with:
         required: false
         description: >-
           the agent/entity associated with the generation of the file
-        range: WorkflowExecutionActivity
+        range: WorkflowExecutionActivity  # MAM I don't think this is a reasonable override of the global range of Agent
+        # but commenting that line out does not, on its own, fix the conversion to SQLite
         inlined: false # allow for strings of IDs
       started_at_time:
         required: true
@@ -65,8 +67,8 @@ classes:
         required: true
       execution_resource:
         required: true
-      type:
-        required: true
+      raw_type:
+  #        required: true
 
   MetagenomeAssembly:
     description: A workflow execution activity that converts sequencing reads into an assembled metagenome.
@@ -76,6 +78,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
+      - raw_type
       - asm_score
       - scaffolds
       - scaf_logsum
@@ -145,6 +148,7 @@ classes:
     description: A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
     is_a: WorkflowExecutionActivity
     slots:
+      - raw_type
       - gold_analysis_project_identifiers
     in_subset:
       - workflow subset
@@ -152,6 +156,7 @@ classes:
   MetatranscriptomeAnnotationActivity:
     is_a: WorkflowExecutionActivity
     slots:
+      - raw_type
       - gold_analysis_project_identifiers
     in_subset:
       - workflow subset
@@ -162,6 +167,9 @@ classes:
       A metatranscriptome activity that e.g. pools assembly and annotation activity.
     in_subset:
       - workflow subset
+    slots:
+      - raw_type
+
 
   MagsAnalysisActivity:
     description: A workflow execution activity that uses computational binning tools to group assembled contigs into genomes
@@ -170,6 +178,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
+      - raw_type
       - input_contig_num
       - binned_contig_num
       - too_short_contig_num
@@ -184,6 +193,7 @@ classes:
     in_subset:
       - workflow subset
     slots:
+      - raw_type
       - input_read_count
       - input_base_count
       - output_read_count
@@ -208,11 +218,16 @@ classes:
     is_a: WorkflowExecutionActivity
     in_subset:
       - workflow subset
+    slots:
+      - raw_type
+
 
   MetabolomicsAnalysisActivity:
     is_a: WorkflowExecutionActivity
     in_subset:
       - workflow subset
+    slots:
+      - raw_type
     slot_usage:
       used:
         range: Instrument
@@ -230,6 +245,8 @@ classes:
     is_a: WorkflowExecutionActivity
     in_subset:
       - workflow subset
+    slots:
+      - raw_type
     slot_usage:
       used:
         range: Instrument
@@ -244,6 +261,8 @@ classes:
     is_a: WorkflowExecutionActivity
     in_subset:
       - workflow subset
+    slots:
+      - raw_type
     slot_usage:
       used:
         range: Instrument

--- a/test/data/biosample_test.json
+++ b/test/data/biosample_test.json
@@ -1,21 +1,33 @@
 {
   "biosample_set": [
     {
-      "id": "gold:Gb0101224",
+      "id": "nmdc:6057d02c-664c-41c9-8486-3624ca845747",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101224"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0110115"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -39,25 +51,37 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101224-with-cats",
+      "id": "nmdc:6057d02c-664c-41c9-8486-3624ca845747",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101224"
+      ],
+      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "biosample_categories": [
         "LTER",
         "SIP"
       ],
-      "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0110115"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -81,21 +105,33 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101225",
+      "id": "nmdc:e924072f-98b5-4f88-a796-a7ba1d8ddd92",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101225"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients Extra",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0110115"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -119,21 +155,33 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101226",
+      "id": "nmdc:61c3332d-f654-4db8-8d2f-59475894daa5",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101226"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0110115"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"

--- a/test/data/invalid_schemas/biosample_invalid_range.json
+++ b/test/data/invalid_schemas/biosample_invalid_range.json
@@ -1,7 +1,10 @@
 {
   "biosample_set": [
     {
-      "id": "gold:Gb0101224",
+      "id": "nmdc:6057d02c-664c-41c9-8486-3624ca845747",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101224"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -9,13 +12,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -39,7 +51,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101225",
+      "id": "nmdc:e924072f-98b5-4f88-a796-a7ba1d8ddd92",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101225"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients Extra",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -47,13 +62,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -77,7 +101,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101226",
+      "id": "nmdc:61c3332d-f654-4db8-8d2f-59475894daa5",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101226"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -85,13 +112,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"

--- a/test/data/invalid_schemas/biosample_mismatch_regex.json
+++ b/test/data/invalid_schemas/biosample_mismatch_regex.json
@@ -1,8 +1,10 @@
 {
   "biosample_set": [
     {
-      "GOLD_sample_identifiers": "ABCD:Ab@#",
-      "id": "gold:Gb0101224",
+      "gold_biosample_identifiers": [
+        "ABCD:Ab@#"
+      ],
+      "id": "XXXX:6057d02c-664c-41c9-8486-3624ca845747",
       "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -10,13 +12,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -40,10 +51,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "GOLD_sample_identifiers": [
-        "GOLD:Gb1234"
+      "id": "nmdc:e924072f-98b5-4f88-a796-a7ba1d8ddd92",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101225"
       ],
-      "id": "gold:Gb0101225",
       "name": "Lithgow State Coal Mine Calcium nutrients Extra",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -51,13 +62,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -81,11 +101,11 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "GOLD_sample_identifiers": [
+      "gold_biosample_identifiers": [
         "ABCD:Ab@#@",
         "WXYZ:Wx()"
       ],
-      "id": "gold:Gb0101226",
+      "id": "nmdc:61c3332d-f654-4db8-8d2f-59475894daa5",
       "name": "Lithgow State Coal Mine Calcium nutrients",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -93,13 +113,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"

--- a/test/data/invalid_schemas/biosample_missing_required_field.json
+++ b/test/data/invalid_schemas/biosample_missing_required_field.json
@@ -5,13 +5,22 @@
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -21,7 +30,7 @@
         "latitude": -33.460524,
         "longitude": 150.168149
       },
-      "ecosystem": "Environmental", 
+      "ecosystem": "Environmental",
       "ecosystem_category": "Aquatic",
       "ecosystem_type": "Freshwater",
       "ecosystem_subtype": "Groundwater",
@@ -39,13 +48,22 @@
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -73,13 +91,22 @@
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"

--- a/test/data/invalid_schemas/biosample_single_multi_value_mixup.json
+++ b/test/data/invalid_schemas/biosample_single_multi_value_mixup.json
@@ -15,13 +15,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -45,7 +54,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101225",
+      "id": "nmdc:e924072f-98b5-4f88-a796-a7ba1d8ddd92",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101225"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients Extra",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -53,13 +65,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -83,7 +104,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101226",
+      "id": "nmdc:61c3332d-f654-4db8-8d2f-59475894daa5",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101226"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -91,13 +115,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"

--- a/test/data/invalid_schemas/biosample_undeclared_slot.json
+++ b/test/data/invalid_schemas/biosample_undeclared_slot.json
@@ -2,7 +2,10 @@
   "biosample_set": [
     {
       "foo": "bar",
-      "id": "gold:Gb0101224",
+      "id": "nmdc:6057d02c-664c-41c9-8486-3624ca845747",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101224"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients (early)",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -10,13 +13,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -40,7 +52,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101225",
+      "id": "nmdc:e924072f-98b5-4f88-a796-a7ba1d8ddd92",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101225"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients Extra",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -48,13 +63,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"
@@ -78,7 +102,10 @@
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
-      "id": "gold:Gb0101226",
+      "id": "nmdc:61c3332d-f654-4db8-8d2f-59475894daa5",
+      "gold_biosample_identifiers": [
+        "gold:Gb0101226"
+      ],
       "name": "Lithgow State Coal Mine Calcium nutrients",
       "description": "Bulk Aqueous phase filtered water",
       "type": "nmdc:Biosample",
@@ -86,13 +113,22 @@
         "gold:Gs0128849"
       ],
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00002030"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00002169"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005792"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Lithgow"

--- a/test/data/invalid_schemas/study_credit_enum_mangle.json
+++ b/test/data/invalid_schemas/study_credit_enum_mangle.json
@@ -8,7 +8,6 @@
           "type": "credit association",
           "applied_role": "Value Not In Enum 1",
           "applies_to_person": {
-            "type": "PersonValue",
             "orcid": "orcid:0000-0002-1825-00"
           }
         },
@@ -16,7 +15,6 @@
           "type": "credit association",
           "applied_role": "ValueNotInEnum2",
           "applies_to_person": {
-            "type": "PersonValue",
             "orcid": "orcid:0000-0001-9076-6066"
           }
         }

--- a/test/data/nmdc_example_database.json
+++ b/test/data/nmdc_example_database.json
@@ -122,24 +122,36 @@
   ],
   "biosample_set": [
     {
-      "id": "gold:Gb0150408",
+      "id": "nmdc:c6eb9f01-796b-4bd6-8ed4-74e221eed7c1",
+      "gold_biosample_identifiers": [
+        "gold:Gb0150408"
+      ],
       "name": "Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG",
       "description": "Permafrost microbial communities from Stordalen Mire, Sweden",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0128849"
       ],
       "collection_date": {
         "has_raw_value": "2011-06-15"
       },
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00000446"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00000232"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00000134"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "Sweden: Stordalen"
@@ -157,31 +169,43 @@
       "add_date": "17-MAR-17 04.55.54.717000000 PM",
       "community": "microbial communities",
       "habitat": "Fen",
-      "identifier": "611E1M metaG",
+      "samp_name": "611E1M metaG",
       "location": "Stordalen Mire, Sweden",
       "mod_date": "08-JAN-20 02.49.23.000000000 PM",
       "ncbi_taxonomy_name": "permafrost metagenome",
       "sample_collection_site": "Mire fen"
     },
     {
-      "id": "gold:Gb0157174",
+      "id": "nmdc:87698d0e-13b5-488a-9324-53846a6e332d",
+      "gold_biosample_identifiers": [
+        "gold:Gb0157174"
+      ],
       "name": "Forest soil microbial communities from Barre Woods Harvard Forest LTER site, Petersham, Massachusetts, United States - Inc-BW-C-14-O",
       "description": "Forest soil from Barre Woods Harvard Forest LTER site was incubated at 10C with heavy water. Sample is from a control plot at ambient soil temperature, organic horizon - top 4cm of soil",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0128849"
       ],
       "collection_date": {
         "has_raw_value": "2017-05-24"
       },
       "env_broad_scale": {
-        "has_raw_value": "ENVO:01000174"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:01000159"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00002261"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "USA: Massachusetts"
@@ -199,31 +223,43 @@
       "add_date": "17-AUG-17 05.38.34.719000000 PM",
       "community": "microbial communities",
       "habitat": "soil",
-      "identifier": "Inc-BW-C-14-O",
+      "samp_name": "Inc-BW-C-14-O",
       "location": "Barre Woods Harvard Forest LTER site, Petersham, Massachusetts, United States",
       "mod_date": "08-JAN-20 02.49.23.000000000 PM",
       "ncbi_taxonomy_name": "soil metagenome",
       "sample_collection_site": "forest soil"
     },
     {
-      "id": "gold:Gb0188037",
+      "id": "nmdc:9a4f0882-49b2-46ed-8951-0ee2ea019df7",
+      "gold_biosample_identifiers": [
+        "gold:Gb0188037"
+      ],
       "name": "Rhizosphere microbial communities from Carex aquatilis grown in University of Washington, Seatle, WA, United States - 4-1-23 metaG",
       "description": "Rhizosphere microbial communities from Carex aquatilis grown in submerged peat from a thermokarst bog, University of Washington, Seatle, WA, United States",
       "type": "nmdc:Biosample",
-      "sample_link": [
+      "part_of": [
         "gold:Gs0128849"
       ],
       "collection_date": {
         "has_raw_value": "2018-01-29"
       },
       "env_broad_scale": {
-        "has_raw_value": "ENVO:00000446"
+        "has_raw_value": "ENVO:00002030",
+        "term": {
+          "id": "ENVO:00002030"
+        }
       },
       "env_local_scale": {
-        "has_raw_value": "ENVO:00005801"
+        "has_raw_value": "ENVO:00002169",
+        "term": {
+          "id": "ENVO:00002169"
+        }
       },
       "env_medium": {
-        "has_raw_value": "ENVO:00005774"
+        "has_raw_value": "ENVO:00005792",
+        "term": {
+          "id": "ENVO:00005792"
+        }
       },
       "geo_loc_name": {
         "has_raw_value": "USA: Seattle, Washington"
@@ -242,7 +278,7 @@
       "community": "microbial communities",
       "habitat": "rhizosphere",
       "host_name": "Carex aquatilis",
-      "identifier": "4-1-23 metaG",
+      "samp_name": "4-1-23 metaG",
       "location": "University of Washington, Seatle, WA, United States",
       "mod_date": "08-JAN-20 02.49.25.000000000 PM",
       "ncbi_taxonomy_name": "rhizosphere metagenome",

--- a/test/data/study_credit_test.json
+++ b/test/data/study_credit_test.json
@@ -10,7 +10,6 @@
             "Data curation"
           ],
           "applies_to_person": {
-            "type": "PersonValue",
             "orcid": "orcid:0000-0002-1825-00"
           }
         },
@@ -20,7 +19,6 @@
             "Software"
           ],
           "applies_to_person": {
-            "type": "PersonValue",
             "orcid": "orcid:0000-0001-9076-6066"
           }
         }


### PR DESCRIPTION
#527

Whitespace normalization

Converted many YAML `#` comments to LinkML `comments` or `notes`

- All modules import 
  - basic_slots
  - core

- All `slot_uri` of `rdf:type` removed from NMDC `type` slot

- Created `ControlledIdentifiedTermValue` class in core.yaml
  - And assigned to slots that had a `ControlledTermValue` range in mixs.yaml, as long as '{termLabel} {[termID]}'

```
  ControlledIdentifiedTermValue:
    description: A controlled term or class from an ontology, requiring the presence of term with an id
    comments:
      - To be used for slots like env_broad_scale
    is_a: ControlledTermValue
    slot_usage:
      term:
        required: true
```

- Set `external_database_identifiers`' range to `uriorcurie` in external_identifiers.yaml
  - Want the objects of these relations to appear as IRIs in RDF

- mixs.yaml: commented out several slot definitions when the slot shared a `slot_uri` with other slots, if that slot has not been used in mongodb records 


- nmdc.yaml: added several prefixes
  - Note the addition of the `bare` prefix to account for un-prefixed records in MongoDB
  - Note the assignment of the https://unknown.to.linter.org/ to several prefixes
- Commented out usages of mixs slots for `Biosample` if they were commented out in mixs.yaml
- Added and assigned several new identifier slots
- Assigned pattern: '^nmdc:' to Biosample (should also apply that pattern to other classes)
- Commented out all ...depth2 slots and usages
- Removed `identifier` slot. Replaced with `sample_name` in test data.
- renamed `gold_sample_identifiers` slot to `gold_biosample_identifiers`

Updated test data to pass against updated schema