### PR TITLE
metabref SQL -> LinkML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,3 +335,6 @@ from_mongo_all: from_mongo_cleanup validate_vs_3_2_0 validate_vs_current
 
 assets/metabref_SQL_table_dump.yaml: assets/metabref_SQL_table_dump.txt
 	$(RUN) schemauto import-sql postgresql+psycopg2://metab_user:metab_pass@localhost:5432/metab > $@
+
+target/nmdc_sqlalchemy.py: src/schema/nmdc.yaml
+	$(RUN) gen-sqla $< > $@

--- a/Makefile
+++ b/Makefile
@@ -333,10 +333,5 @@ from_mongo_cleanup:
 
 from_mongo_all: from_mongo_cleanup validate_vs_3_2_0 validate_vs_current
 
-target/metabref_SQL_table_dump.yaml: assets/metabref_SQL_table_dump.txt
-	cp $< $(subst .txt,,$@).sql
-#	sed -i.back 's/public.//g' $(subst .txt,,$@).sql
-#	sed -i.back 's/ IF EXISTS / /g' $(subst .txt,,$@).sql
-#	sed -i.back 's/ IF NOT EXISTS / /g' $(subst .txt,,$@).sql
-	#sqlite3 $(subst .txt,,$@).db < $(subst .txt,,$@).sql
-	#schemauto import-sql sqlite3 $(subst .txt,,$@).db
+assets/metabref_SQL_table_dump.yaml: assets/metabref_SQL_table_dump.txt
+	$(RUN) schemauto import-sql postgresql+psycopg2://metab_user:metab_pass@localhost:5432/metab > $@

--- a/Makefile
+++ b/Makefile
@@ -332,3 +332,11 @@ from_mongo_cleanup:
 	rm -rf assets/from_mongodb_updated.json
 
 from_mongo_all: from_mongo_cleanup validate_vs_3_2_0 validate_vs_current
+
+target/metabref_SQL_table_dump.yaml: assets/metabref_SQL_table_dump.txt
+	cp $< $(subst .txt,,$@).sql
+#	sed -i.back 's/public.//g' $(subst .txt,,$@).sql
+#	sed -i.back 's/ IF EXISTS / /g' $(subst .txt,,$@).sql
+#	sed -i.back 's/ IF NOT EXISTS / /g' $(subst .txt,,$@).sql
+	#sqlite3 $(subst .txt,,$@).db < $(subst .txt,,$@).sql
+	#schemauto import-sql sqlite3 $(subst .txt,,$@).db

--- a/assets/metabref_SQL_table_dump.txt
+++ b/assets/metabref_SQL_table_dump.txt
@@ -1,0 +1,328 @@
+-- Table: public.alembic_version
+
+-- DROP TABLE IF EXISTS public.alembic_version;
+
+CREATE TABLE IF NOT EXISTS public.alembic_version
+(
+    version_num character varying(32) COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.alembic_version
+    OWNER to developer;
+
+-- Table: public.containerType
+
+-- DROP TABLE IF EXISTS public."containerType";
+
+CREATE TABLE IF NOT EXISTS public."containerType"
+(
+    id integer NOT NULL DEFAULT nextval('"containerType_id_seq"'::regclass),
+    description character varying COLLATE pg_catalog."default",
+    type character varying COLLATE pg_catalog."default",
+    size character varying COLLATE pg_catalog."default",
+    was_generated_by character varying COLLATE pg_catalog."default",
+    CONSTRAINT "containerType_pkey" PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."containerType"
+    OWNER to developer;
+
+-- Table: public.detectionActivity
+
+-- DROP TABLE IF EXISTS public."detectionActivity";
+
+CREATE TABLE IF NOT EXISTS public."detectionActivity"
+(
+    id integer NOT NULL DEFAULT nextval('"detectionActivity_id_seq"'::regclass),
+    spectrum_id integer,
+    type character varying COLLATE pg_catalog."default",
+    analyzer character varying COLLATE pg_catalog."default",
+    acquisition character varying COLLATE pg_catalog."default",
+    ionization character varying COLLATE pg_catalog."default",
+    rawdata_url character varying COLLATE pg_catalog."default",
+    CONSTRAINT "detectionActivity_pkey" PRIMARY KEY (id),
+    CONSTRAINT "detectionActivity_spectrum_id_fkey" FOREIGN KEY (spectrum_id)
+        REFERENCES public."massSpectrumObject" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."detectionActivity"
+    OWNER to developer;
+
+-- Table: public.deviceType
+
+-- DROP TABLE IF EXISTS public."deviceType";
+
+CREATE TABLE IF NOT EXISTS public."deviceType"
+(
+    id integer NOT NULL DEFAULT nextval('"deviceType_id_seq"'::regclass),
+    description character varying COLLATE pg_catalog."default",
+    type character varying COLLATE pg_catalog."default",
+    was_generated_by character varying COLLATE pg_catalog."default",
+    CONSTRAINT "deviceType_pkey" PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."deviceType"
+    OWNER to developer;
+
+-- Table: public.massSpectrumObject
+
+-- DROP TABLE IF EXISTS public."massSpectrumObject";
+
+CREATE TABLE IF NOT EXISTS public."massSpectrumObject"
+(
+    id integer NOT NULL DEFAULT nextval('"massSpectrumObject_id_seq"'::regclass),
+    molecular_data_id integer,
+    type character varying COLLATE pg_catalog."default",
+    source character varying COLLATE pg_catalog."default",
+    version character varying COLLATE pg_catalog."default",
+    collision_energy character varying COLLATE pg_catalog."default",
+    precursor_ion double precision,
+    peak_count integer NOT NULL,
+    rt double precision NOT NULL,
+    mz bytea NOT NULL,
+    abundance bytea NOT NULL,
+    polarity character varying COLLATE pg_catalog."default",
+    CONSTRAINT "massSpectrumObject_pkey" PRIMARY KEY (id),
+    CONSTRAINT "massSpectrumObject_molecular_data_id_fkey" FOREIGN KEY (molecular_data_id)
+        REFERENCES public."molecularData" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."massSpectrumObject"
+    OWNER to developer;
+
+-- Table: public.metadata_object
+
+-- DROP TABLE IF EXISTS public.metadata_object;
+
+CREATE TABLE IF NOT EXISTS public.metadata_object
+(
+    id integer NOT NULL DEFAULT nextval('metadata_object_id_seq'::regclass),
+    molecular_data_id integer,
+    source character varying COLLATE pg_catalog."default",
+    source_temp_c double precision,
+    ev double precision,
+    classify character varying COLLATE pg_catalog."default",
+    comment character varying COLLATE pg_catalog."default",
+    CONSTRAINT metadata_object_pkey PRIMARY KEY (id),
+    CONSTRAINT metadata_object_molecular_data_id_fkey FOREIGN KEY (molecular_data_id)
+        REFERENCES public."molecularData" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public.metadata_object
+    OWNER to developer;
+
+-- Table: public.molecularData
+
+-- DROP TABLE IF EXISTS public."molecularData";
+
+CREATE TABLE IF NOT EXISTS public."molecularData"
+(
+    id integer NOT NULL DEFAULT nextval('"molecularData_id_seq"'::regclass),
+    inchikey character varying COLLATE pg_catalog."default" NOT NULL,
+    name character varying COLLATE pg_catalog."default" NOT NULL,
+    formula character varying COLLATE pg_catalog."default",
+    casno character varying COLLATE pg_catalog."default",
+    inchi character varying COLLATE pg_catalog."default" NOT NULL,
+    chebi character varying COLLATE pg_catalog."default",
+    smiles character varying COLLATE pg_catalog."default",
+    kegg character varying COLLATE pg_catalog."default",
+    iupac_name character varying COLLATE pg_catalog."default",
+    traditional_name character varying COLLATE pg_catalog."default",
+    common_name character varying COLLATE pg_catalog."default",
+    match_name character varying COLLATE pg_catalog."default",
+    derivativenum character varying COLLATE pg_catalog."default",
+    CONSTRAINT "molecularData_pkey" PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."molecularData"
+    OWNER to developer;
+
+-- Table: public.quantityValue
+
+-- DROP TABLE IF EXISTS public."quantityValue";
+
+CREATE TABLE IF NOT EXISTS public."quantityValue"
+(
+    id integer NOT NULL DEFAULT nextval('"quantityValue_id_seq"'::regclass),
+    description character varying COLLATE pg_catalog."default",
+    has_numeric_value numeric,
+    has_minimum_numeric_value numeric,
+    has_maximum_numeric_value numeric,
+    has_raw_value character varying COLLATE pg_catalog."default",
+    type character varying COLLATE pg_catalog."default",
+    has_unit character varying COLLATE pg_catalog."default",
+    was_generated_by character varying COLLATE pg_catalog."default",
+    CONSTRAINT "quantityValue_pkey" PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."quantityValue"
+    OWNER to developer;
+
+-- Table: public.referenceMaterial
+
+-- DROP TABLE IF EXISTS public."referenceMaterial";
+
+CREATE TABLE IF NOT EXISTS public."referenceMaterial"
+(
+    id integer NOT NULL DEFAULT nextval('"referenceMaterial_id_seq"'::regclass),
+    sample_operation_id integer,
+    type character varying COLLATE pg_catalog."default",
+    source character varying COLLATE pg_catalog."default",
+    CONSTRAINT "referenceMaterial_pkey" PRIMARY KEY (id),
+    CONSTRAINT "referenceMaterial_sample_operation_id_fkey" FOREIGN KEY (sample_operation_id)
+        REFERENCES public."sampleOperations" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."referenceMaterial"
+    OWNER to developer;
+
+-- Table: public.sampleOperations
+
+-- DROP TABLE IF EXISTS public."sampleOperations";
+
+CREATE TABLE IF NOT EXISTS public."sampleOperations"
+(
+    id integer NOT NULL DEFAULT nextval('"sampleOperations_id_seq"'::regclass),
+    detection_id integer,
+    separation_id integer,
+    type activity NOT NULL,
+    material_input integer,
+    derivatization character varying COLLATE pg_catalog."default",
+    material_output character varying COLLATE pg_catalog."default",
+    reaction_aided_by character varying COLLATE pg_catalog."default",
+    reaction_temperature double precision,
+    reaction_time double precision,
+    extractant character varying COLLATE pg_catalog."default",
+    sample_volume double precision,
+    mixing character varying COLLATE pg_catalog."default",
+    speed character varying COLLATE pg_catalog."default",
+    analyte_id integer NOT NULL,
+    source_mat_id integer,
+    container_type character varying COLLATE pg_catalog."default",
+    volume_unit character varying COLLATE pg_catalog."default",
+    duration double precision,
+    unit character varying COLLATE pg_catalog."default",
+    volume integer,
+    concentration character varying COLLATE pg_catalog."default",
+    starting_amount double precision,
+    material_component_separation character varying COLLATE pg_catalog."default",
+    value double precision,
+    analyte_volume integer,
+    acid character varying COLLATE pg_catalog."default",
+    "pH" double precision,
+    celsius_temperature double precision,
+    separation_method character varying COLLATE pg_catalog."default",
+    filter character varying COLLATE pg_catalog."default",
+    material_pore_size double precision,
+    conditioning character varying COLLATE pg_catalog."default",
+    conditioning_volume integer,
+    CONSTRAINT "sampleOperations_pkey" PRIMARY KEY (id),
+    CONSTRAINT "sampleOperations_detection_id_fkey" FOREIGN KEY (detection_id)
+        REFERENCES public."detectionActivity" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION,
+    CONSTRAINT "sampleOperations_separation_id_fkey" FOREIGN KEY (separation_id)
+        REFERENCES public."separationActivity" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."sampleOperations"
+    OWNER to developer;
+
+-- Table: public.separationActivity
+
+-- DROP TABLE IF EXISTS public."separationActivity";
+
+CREATE TABLE IF NOT EXISTS public."separationActivity"
+(
+    id integer NOT NULL DEFAULT nextval('"separationActivity_id_seq"'::regclass),
+    type separation_types NOT NULL,
+    detection_id integer,
+    "column" character varying COLLATE pg_catalog."default",
+    mobile_phase character varying COLLATE pg_catalog."default",
+    gradient character varying COLLATE pg_catalog."default",
+    flow_rate character varying COLLATE pg_catalog."default",
+    instrument_name character varying COLLATE pg_catalog."default",
+    column_temp integer,
+    sample_chamber_temp integer,
+    separation_id integer,
+    column_lc character varying COLLATE pg_catalog."default",
+    filter character varying COLLATE pg_catalog."default",
+    water_acquity character varying COLLATE pg_catalog."default",
+    column_temp_lc character varying COLLATE pg_catalog."default",
+    gradient_lc character varying COLLATE pg_catalog."default",
+    acceleration character varying COLLATE pg_catalog."default",
+    seal_wash character varying COLLATE pg_catalog."default",
+    max_pressure character varying COLLATE pg_catalog."default",
+    separation_id_gc integer,
+    derivative integer,
+    CONSTRAINT "separationActivity_pkey" PRIMARY KEY (id),
+    CONSTRAINT "separationActivity_detection_id_fkey" FOREIGN KEY (detection_id)
+        REFERENCES public."detectionActivity" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION,
+    CONSTRAINT "separationActivity_separation_id_fkey" FOREIGN KEY (separation_id)
+        REFERENCES public."separationActivity" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION,
+    CONSTRAINT "separationActivity_separation_id_gc_fkey" FOREIGN KEY (separation_id_gc)
+        REFERENCES public."separationActivity" (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."separationActivity"
+    OWNER to developer;
+
+-- Table: public.user
+
+-- DROP TABLE IF EXISTS public."user";
+
+CREATE TABLE IF NOT EXISTS public."user"
+(
+    id integer NOT NULL DEFAULT nextval('user_id_seq'::regclass),
+    email character varying(100) COLLATE pg_catalog."default",
+    password character varying COLLATE pg_catalog."default",
+    username character varying(100) COLLATE pg_catalog."default",
+    api_key character varying COLLATE pg_catalog."default",
+    first_name character varying(100) COLLATE pg_catalog."default",
+    last_name character varying(100) COLLATE pg_catalog."default",
+    CONSTRAINT user_pkey PRIMARY KEY (id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS public."user"
+    OWNER to developer;

--- a/assets/metabref_SQL_table_dump.yaml
+++ b/assets/metabref_SQL_table_dump.yaml
@@ -1,0 +1,290 @@
+name: test-schema
+id: http://example.org/test-schema
+default_prefix: http://example.org/test-schema/
+classes:
+  alembic_version:
+    attributes:
+      version_num:
+        identifier: true
+        range: string
+  containerType:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      description:
+        range: string
+      type:
+        range: string
+      size:
+        range: string
+      was_generated_by:
+        range: string
+  deviceType:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      description:
+        range: string
+      type:
+        range: string
+      was_generated_by:
+        range: string
+  molecularData:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      inchikey:
+        range: string
+      formula:
+        range: string
+      casno:
+        range: string
+      inchi:
+        range: string
+      chebi:
+        range: string
+      smiles:
+        range: string
+      kegg:
+        range: string
+      iupac_name:
+        range: string
+      traditional_name:
+        range: string
+      common_name:
+        range: string
+      match_name:
+        range: string
+      derivativenum:
+        range: string
+  quantityValue:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      description:
+        range: string
+      has_numeric_value:
+        range: string
+      has_minimum_numeric_value:
+        range: string
+      has_maximum_numeric_value:
+        range: string
+      has_raw_value:
+        range: string
+      type:
+        range: string
+      has_unit:
+        range: string
+      was_generated_by:
+        range: string
+  user:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      email:
+        range: string
+      password:
+        range: string
+      username:
+        range: string
+      api_key:
+        range: string
+      first_name:
+        range: string
+      last_name:
+        range: string
+  massSpectrumObject:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      molecular_data_id:
+        range: molecularData
+      type:
+        range: string
+      source:
+        range: string
+      version:
+        range: string
+      collision_energy:
+        range: string
+      precursor_ion:
+        range: string
+      peak_count:
+        range: integer
+      rt:
+        range: string
+      mz:
+        range: string
+      abundance:
+        range: string
+      polarity:
+        range: string
+  metadata_object:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      molecular_data_id:
+        range: molecularData
+      source:
+        range: string
+      source_temp_c:
+        range: string
+      ev:
+        range: string
+      classify:
+        range: string
+      comment:
+        range: string
+  detectionActivity:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      spectrum_id:
+        range: massSpectrumObject
+      type:
+        range: string
+      analyzer:
+        range: string
+      acquisition:
+        range: string
+      ionization:
+        range: string
+      rawdata_url:
+        range: string
+  separationActivity:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      type:
+        range: string
+      detection_id:
+        range: detectionActivity
+      column:
+        range: string
+      mobile_phase:
+        range: string
+      gradient:
+        range: string
+      flow_rate:
+        range: string
+      instrument_name:
+        range: string
+      column_temp:
+        range: integer
+      sample_chamber_temp:
+        range: integer
+      separation_id:
+        range: separationActivity
+      column_lc:
+        range: string
+      filter:
+        range: string
+      water_acquity:
+        range: string
+      column_temp_lc:
+        range: string
+      gradient_lc:
+        range: string
+      acceleration:
+        range: string
+      seal_wash:
+        range: string
+      max_pressure:
+        range: string
+      separation_id_gc:
+        range: separationActivity
+      derivative:
+        range: integer
+  sampleOperations:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      detection_id:
+        range: detectionActivity
+      separation_id:
+        range: separationActivity
+      type:
+        range: string
+      material_input:
+        range: integer
+      derivatization:
+        range: string
+      material_output:
+        range: string
+      reaction_aided_by:
+        range: string
+      reaction_temperature:
+        range: string
+      reaction_time:
+        range: string
+      extractant:
+        range: string
+      sample_volume:
+        range: string
+      mixing:
+        range: string
+      speed:
+        range: string
+      analyte_id:
+        range: integer
+      source_mat_id:
+        range: integer
+      container_type:
+        range: string
+      volume_unit:
+        range: string
+      duration:
+        range: string
+      unit:
+        range: string
+      volume:
+        range: integer
+      concentration:
+        range: string
+      starting_amount:
+        range: string
+      material_component_separation:
+        range: string
+      value:
+        range: string
+      analyte_volume:
+        range: integer
+      acid:
+        range: string
+      pH:
+        range: string
+      celsius_temperature:
+        range: string
+      separation_method:
+        range: string
+      filter:
+        range: string
+      material_pore_size:
+        range: string
+      conditioning:
+        range: string
+      conditioning_volume:
+        range: integer
+  referenceMaterial:
+    attributes:
+      id:
+        identifier: true
+        range: integer
+      sample_operation_id:
+        range: sampleOperations
+      type:
+        range: string
+      source:
+        range: string
+prefixes: {}
+

--- a/assets/metabref_SQL_table_dump_modified.sql
+++ b/assets/metabref_SQL_table_dump_modified.sql
@@ -1,0 +1,368 @@
+-- alter table ... owner to metab_user (not developer)
+--create type  activity as (f1 int,
+--f2 text);
+--create type separation_types as (f1 int,
+--f2 text);
+
+create sequence if not exists "containerType_id_seq";
+
+create sequence if not exists "molecularData_id_seq";
+
+create sequence if not exists "massSpectrumObject_id_seq";
+
+create sequence if not exists "detectionActivity_id_seq";
+
+create sequence if not exists "deviceType_id_seq";
+
+create sequence if not exists "metadata_object_id_seq";
+
+create sequence if not exists "quantityValue_id_seq";
+
+create sequence if not exists "sampleOperations_id_seq";
+
+create sequence if not exists "separationActivity_id_seq";
+
+create sequence if not exists "referenceMaterial_id_seq";
+
+create sequence if not exists "user_id_seq";
+-- Table: public.alembic_version
+-- DROP TABLE IF EXISTS public.alembic_version;
+
+create table if not exists public.alembic_version
+(
+    version_num character varying(32) collate pg_catalog."default" not null,
+    constraint alembic_version_pkc primary key (version_num)
+)
+
+tablespace pg_default;
+
+alter table if exists public.alembic_version
+    owner to metab_user;
+-- Table: public.containerType
+-- DROP TABLE IF EXISTS public."containerType";
+
+create table if not exists public."containerType"
+(
+    id integer not null default nextval('"containerType_id_seq"'::regclass),
+    description character varying collate pg_catalog."default",
+    type character varying collate pg_catalog."default",
+    size character varying collate pg_catalog."default",
+    was_generated_by character varying collate pg_catalog."default",
+    constraint "containerType_pkey" primary key (id)
+)
+
+tablespace pg_default;
+
+alter table if exists public."containerType"
+    owner to metab_user;
+-- Table: public.molecularData
+-- DROP TABLE IF EXISTS public."molecularData";
+
+create table if not exists public."molecularData"
+(
+    id integer not null default nextval('"molecularData_id_seq"'::regclass),
+    inchikey character varying collate pg_catalog."default" not null,
+    name character varying collate pg_catalog."default" not null,
+    formula character varying collate pg_catalog."default",
+    casno character varying collate pg_catalog."default",
+    inchi character varying collate pg_catalog."default" not null,
+    chebi character varying collate pg_catalog."default",
+    smiles character varying collate pg_catalog."default",
+    kegg character varying collate pg_catalog."default",
+    iupac_name character varying collate pg_catalog."default",
+    traditional_name character varying collate pg_catalog."default",
+    common_name character varying collate pg_catalog."default",
+    match_name character varying collate pg_catalog."default",
+    derivativenum character varying collate pg_catalog."default",
+    constraint "molecularData_pkey" primary key (id)
+)
+
+tablespace pg_default;
+
+alter table if exists public."deviceType"
+    owner to metab_user;
+-- Table: public.massSpectrumObject
+-- DROP TABLE IF EXISTS public."massSpectrumObject";
+
+create table if not exists public."massSpectrumObject"
+(
+    id integer not null default nextval('"massSpectrumObject_id_seq"'::regclass),
+    molecular_data_id integer,
+    type character varying collate pg_catalog."default",
+    source character varying collate pg_catalog."default",
+    version character varying collate pg_catalog."default",
+    collision_energy character varying collate pg_catalog."default",
+    precursor_ion double precision,
+    peak_count integer not null,
+    rt double precision not null,
+    mz bytea not null,
+    abundance bytea not null,
+    polarity character varying collate pg_catalog."default",
+    constraint "massSpectrumObject_pkey" primary key (id),
+    constraint "massSpectrumObject_molecular_data_id_fkey" foreign key (molecular_data_id)
+        references public."molecularData" (id) match simple
+        on
+update
+	no action
+        on
+	delete
+		no action
+)
+
+tablespace pg_default;
+
+alter table if exists public."massSpectrumObject"
+    owner to metab_user;
+-- Table: public.detectionActivity
+-- DROP TABLE IF EXISTS public."detectionActivity";
+
+create table if not exists public."detectionActivity"
+(
+    id integer not null default nextval('"detectionActivity_id_seq"'::regclass),
+    spectrum_id integer,
+    type character varying collate pg_catalog."default",
+    analyzer character varying collate pg_catalog."default",
+    acquisition character varying collate pg_catalog."default",
+    ionization character varying collate pg_catalog."default",
+    rawdata_url character varying collate pg_catalog."default",
+    constraint "detectionActivity_pkey" primary key (id),
+    constraint "detectionActivity_spectrum_id_fkey" foreign key (spectrum_id)
+        references public."massSpectrumObject" (id) match simple
+        on
+update
+	no action
+        on
+	delete
+		no action
+)
+
+tablespace pg_default;
+
+alter table if exists public."detectionActivity"
+    owner to metab_user;
+-- Table: public.deviceType
+-- DROP TABLE IF EXISTS public."deviceType";
+
+create table if not exists public."deviceType"
+(
+    id integer not null default nextval('"deviceType_id_seq"'::regclass),
+    description character varying collate pg_catalog."default",
+    type character varying collate pg_catalog."default",
+    was_generated_by character varying collate pg_catalog."default",
+    constraint "deviceType_pkey" primary key (id)
+)
+
+tablespace pg_default;
+
+alter table if exists public."deviceType"
+    owner to metab_user;
+-- Table: public.metadata_object
+-- DROP TABLE IF EXISTS public.metadata_object;
+
+create table if not exists public.metadata_object
+(
+    id integer not null default nextval('metadata_object_id_seq'::regclass),
+    molecular_data_id integer,
+    source character varying collate pg_catalog."default",
+    source_temp_c double precision,
+    ev double precision,
+    classify character varying collate pg_catalog."default",
+    comment character varying collate pg_catalog."default",
+    constraint metadata_object_pkey primary key (id),
+    constraint metadata_object_molecular_data_id_fkey foreign key (molecular_data_id)
+        references public."molecularData" (id) match simple
+        on
+update
+	no action
+        on
+	delete
+		no action
+)
+
+tablespace pg_default;
+
+alter table if exists public.metadata_object
+    owner to metab_user;
+-- Table: public.quantityValue
+-- DROP TABLE IF EXISTS public."quantityValue";
+
+create table if not exists public."quantityValue"
+(
+    id integer not null default nextval('"quantityValue_id_seq"'::regclass),
+    description character varying collate pg_catalog."default",
+    has_numeric_value numeric,
+    has_minimum_numeric_value numeric,
+    has_maximum_numeric_value numeric,
+    has_raw_value character varying collate pg_catalog."default",
+    type character varying collate pg_catalog."default",
+    has_unit character varying collate pg_catalog."default",
+    was_generated_by character varying collate pg_catalog."default",
+    constraint "quantityValue_pkey" primary key (id)
+)
+
+tablespace pg_default;
+
+alter table if exists public."quantityValue"
+    owner to metab_user;
+-- Table: public.separationActivity
+-- DROP TABLE IF EXISTS public."separationActivity";
+
+create table if not exists public."separationActivity"
+(
+    id integer not null default nextval('"separationActivity_id_seq"'::regclass),
+    type separation_types not null,
+    detection_id integer,
+    "column" character varying collate pg_catalog."default",
+    mobile_phase character varying collate pg_catalog."default",
+    gradient character varying collate pg_catalog."default",
+    flow_rate character varying collate pg_catalog."default",
+    instrument_name character varying collate pg_catalog."default",
+    column_temp integer,
+    sample_chamber_temp integer,
+    separation_id integer,
+    column_lc character varying collate pg_catalog."default",
+    filter character varying collate pg_catalog."default",
+    water_acquity character varying collate pg_catalog."default",
+    column_temp_lc character varying collate pg_catalog."default",
+    gradient_lc character varying collate pg_catalog."default",
+    acceleration character varying collate pg_catalog."default",
+    seal_wash character varying collate pg_catalog."default",
+    max_pressure character varying collate pg_catalog."default",
+    separation_id_gc integer,
+    derivative integer,
+    constraint "separationActivity_pkey" primary key (id),
+    constraint "separationActivity_detection_id_fkey" foreign key (detection_id)
+        references public."detectionActivity" (id) match simple
+        on
+update
+	no action
+        on
+	delete
+		no action,
+		constraint "separationActivity_separation_id_fkey" foreign key (separation_id)
+        references public."separationActivity" (id) match simple
+        on
+		update
+			no action
+        on
+			delete
+				no action,
+				constraint "separationActivity_separation_id_gc_fkey" foreign key (separation_id_gc)
+        references public."separationActivity" (id) match simple
+        on
+				update
+					no action
+        on
+					delete
+						no action
+)
+
+tablespace pg_default;
+
+alter table if exists public."separationActivity"
+    owner to metab_user;
+-- Table: public.sampleOperations
+-- DROP TABLE IF EXISTS public."sampleOperations";
+
+create table if not exists public."sampleOperations"
+(
+    id integer not null default nextval('"sampleOperations_id_seq"'::regclass),
+    detection_id integer,
+    separation_id integer,
+    type activity not null,
+    material_input integer,
+    derivatization character varying collate pg_catalog."default",
+    material_output character varying collate pg_catalog."default",
+    reaction_aided_by character varying collate pg_catalog."default",
+    reaction_temperature double precision,
+    reaction_time double precision,
+    extractant character varying collate pg_catalog."default",
+    sample_volume double precision,
+    mixing character varying collate pg_catalog."default",
+    speed character varying collate pg_catalog."default",
+    analyte_id integer not null,
+    source_mat_id integer,
+    container_type character varying collate pg_catalog."default",
+    volume_unit character varying collate pg_catalog."default",
+    duration double precision,
+    unit character varying collate pg_catalog."default",
+    volume integer,
+    concentration character varying collate pg_catalog."default",
+    starting_amount double precision,
+    material_component_separation character varying collate pg_catalog."default",
+    value double precision,
+    analyte_volume integer,
+    acid character varying collate pg_catalog."default",
+    "pH" double precision,
+    celsius_temperature double precision,
+    separation_method character varying collate pg_catalog."default",
+    filter character varying collate pg_catalog."default",
+    material_pore_size double precision,
+    conditioning character varying collate pg_catalog."default",
+    conditioning_volume integer,
+    constraint "sampleOperations_pkey" primary key (id),
+    constraint "sampleOperations_detection_id_fkey" foreign key (detection_id)
+        references public."detectionActivity" (id) match simple
+        on
+update
+	no action
+        on
+	delete
+		no action,
+		constraint "sampleOperations_separation_id_fkey" foreign key (separation_id)
+        references public."separationActivity" (id) match simple
+        on
+		update
+			no action
+        on
+			delete
+				no action
+)
+
+tablespace pg_default;
+
+alter table if exists public."sampleOperations"
+    owner to metab_user;
+-- Table: public.referenceMaterial
+-- DROP TABLE IF EXISTS public."referenceMaterial";
+
+create table if not exists public."referenceMaterial"
+(
+    id integer not null default nextval('"referenceMaterial_id_seq"'::regclass),
+    sample_operation_id integer,
+    type character varying collate pg_catalog."default",
+    source character varying collate pg_catalog."default",
+    constraint "referenceMaterial_pkey" primary key (id),
+    constraint "referenceMaterial_sample_operation_id_fkey" foreign key (sample_operation_id)
+        references public."sampleOperations" (id) match simple
+        on
+update
+	no action
+        on
+	delete
+		no action
+)
+
+tablespace pg_default;
+
+alter table if exists public."referenceMaterial"
+    owner to metab_user;
+-- Table: public.user
+-- DROP TABLE IF EXISTS public."user";
+
+create table if not exists public."user"
+(
+    id integer not null default nextval('user_id_seq'::regclass),
+    email character varying(100) collate pg_catalog."default",
+    password character varying collate pg_catalog."default",
+    username character varying(100) collate pg_catalog."default",
+    api_key character varying collate pg_catalog."default",
+    first_name character varying(100) collate pg_catalog."default",
+    last_name character varying(100) collate pg_catalog."default",
+    constraint user_pkey primary key (id)
+)
+
+tablespace pg_default;
+
+alter table if exists public."user"
+    owner to metab_user;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ nmdc-data = "nmdc_schema.nmdc_data:cli"
 [tool.poetry.dependencies]
 python = "^3.9"
 linkml = "*"
+schema-automator = "^0.2.10"
 
 [tool.poetry.dev-dependencies]
 black = "^22.3.0"


### PR DESCRIPTION
#532 

**For your review... may not actually need to be merged.**

I overlooked the fact that the schema automator can import an SQL schema, but only from a database connection, not from a SQL DDL file.

@anastasiyaprymolenna thanks for providing the SQL DDL statements for metabref (assets/metabref_SQL_table_dump.txt). It looks like that file is table definitions only. I had to make up some sequences and types (assets/metabref_SQL_table_dump_modified.sql).

Then I used the modified SQL DDL file to create a local Postgres database and inferred a LinkML schema from that

```shell
make assets/metabref_SQL_table_dump.yaml
```

The database creation could be easily encapsulated in the Makefile by building an SQLite database instead of a Postgres database, but I didn't see a quick way to convert the Postgres dialect to the simpler SQLite dialect.

In the future, it might be easier for someone with access to the database within PNNL to run the simple inference command

```shell
schemauto import-sql postgresql+psycopg2://<USER>:<PW>@<HOST>:<PORT>/<DB>  > metabref_SQL_table_dump.yaml
```

I think the only requirements for that are `schema-automator` and Postgres drivers