### PR TITLE
add `samp_taxon_id` slot to MIxS schema

### DIFF
--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -14,7 +14,7 @@ notes:
 prefixes:
   nmdc: https://w3id.org/nmdc/
   mixs: https://w3id.org/mixs/
-
+  NCBITaxon: https://ontobee.org/ontology/NCBITaxon
 
 default_prefix: nmdc
 
@@ -7335,6 +7335,10 @@ slots:
     slot_uri: mixs:0000813
     multivalued: false
     range: TextValue
+  investigation field:
+    abstract: true
+    description: field describing aspect of the investigation/study to which the sample
+      belongs
   iw_bt_date_well:
     name: iw_bt_date_well
     aliases:
@@ -10882,6 +10886,24 @@ slots:
     slot_uri: mixs:0000999
     multivalued: false
     range: TextValue
+  samp_taxon_id:
+    is_a: investigation field
+    title: Taxonomy ID of DNA sample
+    description: "NCBI taxon id of the sample.  Maybe be a single taxon or mixed taxa\
+      \ sample. Use 'synthetic metagenome\u2019 for mock community/positive controls,\
+      \ or 'blank sample' for negative controls."
+    range: string
+    multivalued: false
+    examples:
+    - value: soil metagenome [NCBITaxon:410658]
+    comments: []
+    todos:
+    - "structured pattern: {text} [NCBITaxon:{integer}]"
+    aliases:
+    - Taxonomy ID of DNA sample
+    annotations:
+      expected_value: Taxonomy ID
+    slot_uri: mixs:0001320
   samp_time_out:
     name: samp_time_out
     aliases:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -10889,9 +10889,9 @@ slots:
   samp_taxon_id:
     is_a: investigation field
     title: Taxonomy ID of DNA sample
-    description: "NCBI taxon id of the sample.  Maybe be a single taxon or mixed taxa\
-      \ sample. Use 'synthetic metagenome\u2019 for mock community/positive controls,\
-      \ or 'blank sample' for negative controls."
+    description: NCBI taxon id of the sample. May be a single taxon or mixed taxa 
+      sample. Use 'synthetic metagenome' for mock community/positive controls, 
+      or 'blank sample' for negative controls.
     range: string
     multivalued: false
     examples:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -350,6 +350,7 @@ classes:
       - samp_mat_process
       - samp_store_dur
       - samp_store_loc
+      - samp_taxon_id
       - samp_store_temp
       - samp_vol_we_dna_ext
       - season_temp

--- a/test/data/biosample_test.json
+++ b/test/data/biosample_test.json
@@ -48,6 +48,7 @@
       "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
       "mod_date": "26-AUG-16 01.50.27.000000000 PM",
       "ncbi_taxonomy_name": "coal metagenome",
+      "samp_taxon_id": "coal metagenome [NCBITaxon:1260732]",
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
@@ -102,6 +103,7 @@
       "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
       "mod_date": "26-AUG-16 01.50.27.000000000 PM",
       "ncbi_taxonomy_name": "coal metagenome",
+      "samp_taxon_id": "coal metagenome [NCBITaxon:1260732]",
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
@@ -152,6 +154,7 @@
       "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
       "mod_date": "26-AUG-16 01.50.27.000000000 PM",
       "ncbi_taxonomy_name": "coal metagenome",
+      "samp_taxon_id": "coal metagenome [NCBITaxon:1260732]",
       "sample_collection_site": "Lithgow State Coal Mine"
     },
     {
@@ -202,6 +205,7 @@
       "location": "from the Lithgow State Coal Mine, New South Wales, Australia",
       "mod_date": "26-AUG-16 01.50.27.000000000 PM",
       "ncbi_taxonomy_name": "coal metagenome",
+      "samp_taxon_id": "coal metagenome [NCBITaxon:1260732]",
       "sample_collection_site": "Lithgow State Coal Mine"
     }
   ]


### PR DESCRIPTION
Add `samp_taxon_id` to MIxS schema `mixs.yaml`, imported by `nmdc.yaml`. In `nmdc.yaml` assert the newly added `samp_taxon_id` slot on `Biosample` class.

Fixes #574 