### PR TITLE
removed old NMDC metadata downloads link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,3 @@ primer provides some the context for this project.
 **New system requirement: [Mike Farah's GO-based yq](https://github.com/mikefarah/yq)**
 
 See [MAINTAINERS.md](MAINTAINERS.md) for instructions on maintaining and updating the schema.
-
-## NMDC metadata downloads
-
-See https://github.com/microbiomedata/nmdc-runtime/#data-exports


### PR DESCRIPTION
- #739 

From README.md

## NMDC metadata downloads

See https://github.com/microbiomedata/nmdc-runtime/#data-exports