### PR TITLE
classes on index page should be hierarchically indented

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DEST = project
 #PYMODEL = $(SRC)/$(SCHEMA_NAME)
 PYMODEL = $(SCHEMA_NAME)
 EXAMPLEDIR = examples
+TEMPLATEDIR = doc-templates
 
 .PHONY: all clean combined-extras examples-clean site test
 
@@ -156,7 +157,7 @@ gendoc: $(DOCDIR)
 	# added copying of images and renaming of TEMP.md
 	cp $(SRC)/docs/*md $(DOCDIR) ; \
 	cp -r $(SRC)/docs/images $(DOCDIR) ; \
-	$(RUN) gen-doc -d $(DOCDIR) $(SOURCE_SCHEMA_PATH)
+	$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH)
 	#mv $(DOCDIR)/TEMP.md $(DOCDIR)/temp.md
 
 testdoc: gendoc serve


### PR DESCRIPTION
The `Classes` section on the index page in the NMDC Schema documentation is not hierarchically indented as it was previously, and the reason for that is that the gendoc Makefile rule was not consuming the custom index jinja template. This PR seeks to add that functionality back.