### PR TITLE
Use Makefile targets instead of individual poetry commands

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -27,7 +27,5 @@ jobs:
         run: |
           mkdir -p docs
           touch docs/.nojekyll
-          cp src/docs/*md docs
-          cp -r src/docs/images docs
-          poetry run gen-doc -d docs src/schema/nmdc.yaml
-          poetry run mkdocs gh-deploy
+          make gendoc
+          make mkd-gh-deploy


### PR DESCRIPTION
Use Makefile targets like `make gendoc` and `make mkd-gh-deploy` instead of individual poetry commands in GitHub Actions workflows.