### PR TITLE
add neon mappings tsv

### DIFF
--- a/assets/misc/neon_nmdc_term_mappings.tsv
+++ b/assets/misc/neon_nmdc_term_mappings.tsv
@@ -1,0 +1,363 @@
+neon_table	neon_field_name	match_type	nmdc_class	nmdc_slot	notes
+bgc_CNiso_externalSummary	uid				Exclude
+bgc_CNiso_externalSummary	analyte				Exclude
+bgc_CNiso_externalSummary	analyteUnits				Exclude
+bgc_CNiso_externalSummary	sampleType				Exclude
+bgc_CNiso_externalSummary	qaReferenceID				Exclude
+bgc_CNiso_externalSummary	analyteKnownValue				Exclude
+bgc_CNiso_externalSummary	analyteObservedValue				Exclude
+bgc_CNiso_externalSummary	analyteAbsoluteError				Exclude
+bgc_CNiso_externalSummary	analyteStandardDeviation				Exclude
+bgc_CNiso_externalSummary	analyteMetricsCount				Exclude
+bgc_CNiso_externalSummary	qaReportingStartDate				Exclude
+bgc_CNiso_externalSummary	qaReportingEndDate				Exclude
+bgc_CNiso_externalSummary	laboratoryName				Exclude
+bgc_CNiso_externalSummary	instrument				Exclude
+bgc_CNiso_externalSummary	testMethod				Exclude
+bgc_CNiso_externalSummary	method				Exclude
+bgc_CNiso_externalSummary	dataQF				Exclude
+ntr_externalLab	uid				Exclude
+ntr_externalLab	namedLocation				inherited from sls_soilCoreCollection
+ntr_externalLab	domainID				inherited from sls_soilCoreCollection
+ntr_externalLab	siteID				inherited from sls_soilCoreCollection
+ntr_externalLab	plotID				inherited from sls_soilCoreCollection
+ntr_externalLab	startDate				inherited from sls_soilCoreCollection
+ntr_externalLab	collectDate				inherited from sls_soilCoreCollection
+ntr_externalLab	sampleID				inherited from sls_soilCoreCollection
+ntr_externalLab	sampleCode				inherited from sls_soilCoreCollection
+ntr_externalLab	kclSampleID				inherited from ntr_internalLab
+ntr_externalLab	kclSampleCode				inherited from ntr_internalLab
+ntr_externalLab	sampleCondition				
+ntr_externalLab	ammoniumNAnalysisDate				
+ntr_externalLab	kclAmmoniumNConc	narrow_mapping	Biosample	ammonium_nitrogen	
+ntr_externalLab	ammoniumNRepNum	narrow_mapping	Biosample	replicate_number	
+ntr_externalLab	ammoniumNQF				
+ntr_externalLab	ammoniumNRemarks				Exclude
+ntr_externalLab	nitrateNitriteNAnalysisDate				
+ntr_externalLab	kclNitrateNitriteNConc	exact_mapping	Biosample	tot_nitro_content	
+ntr_externalLab	nitrateNitriteNRepNum	narrow_mapping	Biosample	replicate_number	
+ntr_externalLab	nitrateNitriteNQF				
+ntr_externalLab	nitrateNitriteNRemarks				Exclude
+ntr_externalLab	laboratoryName				
+ntr_externalLab	ammoniumNMethod				
+ntr_externalLab	ammoniumNInstrument				
+ntr_externalLab	ammoniumNAnalyzedBy				Exclude
+ntr_externalLab	ammoniumNReviewedBy				Exclude
+ntr_externalLab	nitrateNitriteNMethod				
+ntr_externalLab	nitrateNitriteNInstrument				
+ntr_externalLab	nitrateNitriteNAnalyzedBy				Exclude
+ntr_externalLab	nitrateNitriteNReviewedBy				Exclude
+ntr_externalLab	dataQF				
+ntr_externalSummary	uid				Exclude
+ntr_externalSummary	analyte				Exclude
+ntr_externalSummary	analyteUnits				Exclude
+ntr_externalSummary	sampleType				Exclude
+ntr_externalSummary	qaReferenceID				Exclude
+ntr_externalSummary	lotID				Exclude
+ntr_externalSummary	analyteKnownValue				Exclude
+ntr_externalSummary	analyteObservedValue				Exclude
+ntr_externalSummary	analytePercentRecovery				Exclude
+ntr_externalSummary	analyteStandardDeviation				Exclude
+ntr_externalSummary	methodDetectionLimit				Exclude
+ntr_externalSummary	analyteMetricsCount				Exclude
+ntr_externalSummary	qaReportingStartDate				Exclude
+ntr_externalSummary	qaReportingEndDate				Exclude
+ntr_externalSummary	laboratoryName				Exclude
+ntr_externalSummary	instrument				Exclude
+ntr_externalSummary	method				Exclude
+ntr_externalSummary	dataQF				Exclude
+ntr_internalLab	uid				Exclude
+ntr_internalLab	namedLocation				inherited from sls_soilCoreCollection
+ntr_internalLab	domainID				inherited from sls_soilCoreCollection
+ntr_internalLab	siteID				inherited from sls_soilCoreCollection
+ntr_internalLab	plotID				inherited from sls_soilCoreCollection
+ntr_internalLab	plotType				inherited from sls_soilCoreCollection
+ntr_internalLab	startDate				inherited from sls_soilCoreCollection
+ntr_internalLab	collectDate				inherited from sls_soilCoreCollection
+ntr_internalLab	samplingProtocolVersion				inherited from sls_soilCoreCollection
+ntr_internalLab	sampleID				inherited from sls_soilCoreCollection
+ntr_internalLab	sampleCode				inherited from sls_soilCoreCollection
+ntr_internalLab	kclSampleID				
+ntr_internalLab	kclSampleCode				
+ntr_internalLab	incubationPairID				
+ntr_internalLab	nTransBoutType				inherited from sls_soilCoreCollection
+ntr_internalLab	incubationLength	related_mapping	Biosample	collection_date_inc	"NMDC requires date, NEON is in days."
+ntr_internalLab	extractionStartDate				
+ntr_internalLab	kclReferenceID				
+ntr_internalLab	soilFreshMass	exact_mapping	Biosample	samp_size	
+ntr_internalLab	kclVolume				
+ntr_internalLab	extractionEndDate				
+ntr_internalLab	sampleCondition				
+ntr_internalLab	remarks				Exclude
+ntr_internalLab	processedBy				Exclude
+ntr_internalLab	recordedBy				Exclude
+ntr_internalLab	dataQF				
+ntr_internalLabBlanks	uid				Exclude
+ntr_internalLabBlanks	domainID				Exclude
+ntr_internalLabBlanks	siteID				Exclude
+ntr_internalLabBlanks	extractionStartDate				Exclude
+ntr_internalLabBlanks	extractionEndDate				Exclude
+ntr_internalLabBlanks	kclReferenceID				Exclude
+ntr_internalLabBlanks	kclBlank1ID				Exclude
+ntr_internalLabBlanks	kclBlank1Code				Exclude
+ntr_internalLabBlanks	kclBlank2ID				Exclude
+ntr_internalLabBlanks	kclBlank2Code				Exclude
+ntr_internalLabBlanks	kclBlank3ID				Exclude
+ntr_internalLabBlanks	kclBlank3Code				Exclude
+ntr_internalLabBlanks	remarks				Exclude
+ntr_internalLabBlanks	dataQF				Exclude
+sls_bgcSubsampling	uid				Exclude
+sls_bgcSubsampling	domainID				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	siteID				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	plotID				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	namedLocation				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	startDate				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	collectDate				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	samplingProtocolVersion				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	horizon				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	ovenStartDate				
+sls_bgcSubsampling	ovenEndDate				
+sls_bgcSubsampling	sampleID				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	sampleCode				inherited from sls_soilCoreCollection
+sls_bgcSubsampling	cnSampleID				
+sls_bgcSubsampling	cnSampleCode				
+sls_bgcSubsampling	bgcArchiveID				
+sls_bgcSubsampling	bgcArchiveCode				
+sls_bgcSubsampling	bgcArchiveMass				
+sls_bgcSubsampling	toxicodendronPossible				
+sls_bgcSubsampling	sampleCondition				
+sls_bgcSubsampling	bgcRemarks				Exclude
+sls_bgcSubsampling	processedBy				Exclude
+sls_bgcSubsampling	bgcDataQF				
+sls_metagenomicsPooling	uid				Exclude
+sls_metagenomicsPooling	domainID				inherited from sls_soilCoreCollection
+sls_metagenomicsPooling	siteID				inherited from sls_soilCoreCollection
+sls_metagenomicsPooling	plotID				inherited from sls_soilCoreCollection
+sls_metagenomicsPooling	namedLocation				inherited from sls_soilCoreCollection
+sls_metagenomicsPooling	startDate	exact_mapping	Pooling	start_date	earliest start date of sampleIDs in genomicsPooledIDList
+sls_metagenomicsPooling	collectDate	exact_mapping	Pooling	end_date	latest collect date of sampleIDs in genomicsPooledIDList
+sls_metagenomicsPooling	eventID				
+sls_metagenomicsPooling	samplingProtocolVersion	close_mapping	Pooling	protocol_link	inherited from sls_soilCoreCollection
+sls_metagenomicsPooling	genomicsPooledIDList	close_mapping	Pooling	has_input	
+sls_metagenomicsPooling	genomicsPooledIDList	related_mapping	Biosample	sample_link	
+sls_metagenomicsPooling	genomicsSampleID	exact_mapping	Pooling	has_output	
+sls_metagenomicsPooling	genomicsSampleCode				
+sls_metagenomicsPooling	sampleCondition				
+sls_metagenomicsPooling	processedBy				Exclude
+sls_metagenomicsPooling	remarks				Exclude
+sls_metagenomicsPooling	genomicsDataQF				
+sls_soilChemistry	uid				Exclude
+sls_soilChemistry	analysisDate				
+sls_soilChemistry	namedLocation				inherited from sls_soilCoreCollection
+sls_soilChemistry	domainID				inherited from sls_soilCoreCollection
+sls_soilChemistry	siteID				inherited from sls_soilCoreCollection
+sls_soilChemistry	plotID				inherited from sls_soilCoreCollection
+sls_soilChemistry	plotType				inherited from sls_soilCoreCollection
+sls_soilChemistry	startDate				inherited from sls_soilCoreCollection
+sls_soilChemistry	collectDate				inherited from sls_soilCoreCollection
+sls_soilChemistry	sampleID				inherited from sls_soilCoreCollection
+sls_soilChemistry	sampleCode				inherited from sls_soilCoreCollection
+sls_soilChemistry	cnSampleID				
+sls_soilChemistry	cnSampleCode				
+sls_soilChemistry	sampleType	exact_mapping	Biosample	env_package	soil
+sls_soilChemistry	acidTreatment				
+sls_soilChemistry	co2Trapped				
+sls_soilChemistry	d15N				
+sls_soilChemistry	organicd13C				
+sls_soilChemistry	nitrogenPercent	close_mapping	Biosample	nitro	
+sls_soilChemistry	organicCPercent	close_mapping	Biosample	org_carb	
+sls_soilChemistry	CNratio	narrow_mapping	Biosample	carb_nitro_ratio	
+sls_soilChemistry	cnIsotopeQF				
+sls_soilChemistry	cnPercentQF				
+sls_soilChemistry	isotopeAccuracyQF				
+sls_soilChemistry	percentAccuracyQF				
+sls_soilChemistry	analyticalRepNumber	close_mapping	Biosample	replicate_number	
+sls_soilChemistry	remarks				Exclude
+sls_soilChemistry	laboratoryName				Exclude
+sls_soilChemistry	testMethod	broad_mapping	Biosample	tot_nitro_cont_meth	
+sls_soilChemistry	testMethod	broad_mapping	Biosample	tot_org_c_meth	
+sls_soilChemistry	instrument				
+sls_soilChemistry	analyzedBy				Exclude
+sls_soilChemistry	reviewedBy				Exclude
+sls_soilChemistry	dataQF				
+sls_soilCoreCollection	uid				Exclude
+sls_soilCoreCollection	domainID				
+sls_soilCoreCollection	siteID	related_mapping	Biosample	geo_loc_name	use siteID to pull location information from NEON API (Mark)
+sls_soilCoreCollection	plotID	related_mapping	Biosample	env_broad_scale	use plotID to pull environmental triad information (Mark/Hugh)
+sls_soilCoreCollection	namedLocation				
+sls_soilCoreCollection	plotType				
+sls_soilCoreCollection	nlcdClass	related_mapping	Biosample	env_broad_scale	determined by Mark/Hugh plot environment information work
+sls_soilCoreCollection	subplotID	related_mapping	Biosample	env_broad_scale	use with plotID to pull environmental triad information (Mark/Hugh)
+sls_soilCoreCollection	subplotID	related_mapping	Biosample	sample_link	Biosamples sharing subplotID and collectionDate are linked
+sls_soilCoreCollection	coreCoordinateX				
+sls_soilCoreCollection	coreCoordinateY				
+sls_soilCoreCollection	geodeticDatum				Exclude
+sls_soilCoreCollection	decimalLatitude	narrow_mapping	GeolocationValue	latitude	Biosample.lat_lon
+sls_soilCoreCollection	decimalLongitude	narrow_mapping	GeolocationValue	longitude	Biosample.lat_lon
+sls_soilCoreCollection	coordinateUncertainty				
+sls_soilCoreCollection	elevation	exact_mapping	Biosample	elev	
+sls_soilCoreCollection	elevationUncertainty				
+sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	samp_collec_method	
+sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	micro_biomass_meth	
+sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	water_cont_soil_meth	
+sls_soilCoreCollection	startDate	exact_mapping	Biosample	collection_date	first value of collection_date range
+sls_soilCoreCollection	collectDate	exact_mapping	Biosample	collection_date	last value of collection_date range
+sls_soilCoreCollection	sampleTiming	close_mapping	Biosample	season	
+sls_soilCoreCollection	biophysicalCriteria				
+sls_soilCoreCollection	eventID				
+sls_soilCoreCollection	standingWaterDepth				
+sls_soilCoreCollection	nTransBoutType				
+sls_soilCoreCollection	boutType				
+sls_soilCoreCollection	samplingImpractical				
+sls_soilCoreCollection	incubationMethod				
+sls_soilCoreCollection	incubationCondition				
+sls_soilCoreCollection	sampleID	exact_mapping	Biosample	samp_name	"Unique per plot, per horizon, per collectDate"
+sls_soilCoreCollection	sampleCode				NEON barcode
+sls_soilCoreCollection	toxicodendronPossible				
+sls_soilCoreCollection	horizon	exact_mapping	Biosample	soil_horizon	
+sls_soilCoreCollection	horizonDetails				
+sls_soilCoreCollection	soilTemp	narrow_mapping	Biosample	temp	
+sls_soilCoreCollection	litterDepth				
+sls_soilCoreCollection	sampleTopDepth	close_mapping	Biosample	depth	first value of depth interval
+sls_soilCoreCollection	sampleBottomDepth	close_mapping	Biosample	depth	last value of depth interval
+sls_soilCoreCollection	sampleExtent				
+sls_soilCoreCollection	soilSamplingDevice	exact_mapping	Biosample	samp_collec_device	
+sls_soilCoreCollection	soilCoreCount				
+sls_soilCoreCollection	geneticSampleID				"related to NEON genetic sample archive process, not metagenomics"
+sls_soilCoreCollection	geneticSampleCode				
+sls_soilCoreCollection	geneticSampleCondition				
+sls_soilCoreCollection	geneticSamplePrepMethod				
+sls_soilCoreCollection	geneticArchiveSample1ID				
+sls_soilCoreCollection	geneticArchiveSample1Code				
+sls_soilCoreCollection	geneticArchiveSample2ID				
+sls_soilCoreCollection	geneticArchiveSample2Code				
+sls_soilCoreCollection	geneticArchiveSample3ID				
+sls_soilCoreCollection	geneticArchiveSample3Code				
+sls_soilCoreCollection	geneticArchiveSample4ID				
+sls_soilCoreCollection	geneticArchiveSample4Code				
+sls_soilCoreCollection	geneticArchiveSample5ID				
+sls_soilCoreCollection	geneticArchiveSample5Code				
+sls_soilCoreCollection	geneticArchiveSamplePrepMethod				
+sls_soilCoreCollection	geneticArchiveContainer				
+sls_soilCoreCollection	biomassID				
+sls_soilCoreCollection	biomassCode				
+sls_soilCoreCollection	biomassSampleCondition				
+sls_soilCoreCollection	remarks				Exclude
+sls_soilCoreCollection	collectedBy				Exclude
+sls_soilCoreCollection	dataQF				
+sls_soilMoisture	uid				Exclude
+sls_soilMoisture	domainID				inherited from sls_soilCoreCollection
+sls_soilMoisture	siteID				inherited from sls_soilCoreCollection
+sls_soilMoisture	plotID				inherited from sls_soilCoreCollection
+sls_soilMoisture	namedLocation				inherited from sls_soilCoreCollection
+sls_soilMoisture	startDate				inherited from sls_soilCoreCollection
+sls_soilMoisture	collectDate				inherited from sls_soilCoreCollection
+sls_soilMoisture	sampleID				inherited from sls_soilCoreCollection
+sls_soilMoisture	sampleCode				inherited from sls_soilCoreCollection
+sls_soilMoisture	moistureSampleID				
+sls_soilMoisture	samplingProtocolVersion				inherited from sls_soilCoreCollection
+sls_soilMoisture	horizon				inherited from sls_soilCoreCollection
+sls_soilMoisture	ovenStartDate				
+sls_soilMoisture	ovenEndDate				
+sls_soilMoisture	boatMass				
+sls_soilMoisture	freshMassBoatMass				
+sls_soilMoisture	dryMassBoatMass				
+sls_soilMoisture	soilMoisture	exact_mapping	Biosample	water_content	
+sls_soilMoisture	dryMassFraction				
+sls_soilMoisture	sampleCondition				
+sls_soilMoisture	smRemarks				Exclude
+sls_soilMoisture	smMeasuredBy				Exclude
+sls_soilMoisture	smDataQF				
+sls_soilpH	uid				Exclude
+sls_soilpH	domainID				inherited from sls_soilCoreCollection
+sls_soilpH	siteID				inherited from sls_soilCoreCollection
+sls_soilpH	plotID				inherited from sls_soilCoreCollection
+sls_soilpH	namedLocation				inherited from sls_soilCoreCollection
+sls_soilpH	startDate				inherited from sls_soilCoreCollection
+sls_soilpH	collectDate				inherited from sls_soilCoreCollection
+sls_soilpH	processedDate				
+sls_soilpH	sampleID				inherited from sls_soilCoreCollection
+sls_soilpH	sampleCode				inherited from sls_soilCoreCollection
+sls_soilpH	pHSampleID				
+sls_soilpH	samplingProtocolVersion	related_mapping	Biosample	ph_meth	inherited from sls_soilCoreCollection
+sls_soilpH	horizon				inherited from sls_soilCoreCollection
+sls_soilpH	soilInWaterpH	narrow_mapping	Biosample	ph	
+sls_soilpH	soilInCaClpH				
+sls_soilpH	pHSoilInWaterMass				
+sls_soilpH	pHWaterVol				
+sls_soilpH	waterpHRatio				
+sls_soilpH	pHSoilInCaClMass				
+sls_soilpH	pHCaClVol				
+sls_soilpH	caclpHRatio				
+sls_soilpH	pHRemarks				Exclude
+sls_soilpH	pHMeasuredBy				Exclude
+sls_soilpH	pHDataQF				
+mms_metagenomeDnaExtraction	uid				Exclude
+mms_metagenomeDnaExtraction	domainID				inherited from sls_soilCoreCollection/Pooling
+mms_metagenomeDnaExtraction	siteID				inherited from sls_soilCoreCollection/Pooling
+mms_metagenomeDnaExtraction	namedLocation				inherited from sls_soilCoreCollection/Pooling
+mms_metagenomeDnaExtraction	laboratoryName	exact_mapping	Extraction	processing_institution	
+mms_metagenomeDnaExtraction	collectDate	close_mapping	Extraction	start_date	inherited from sls_metagenomicsPooling:collectDate
+mms_metagenomeDnaExtraction	processedDate	exact_mapping	Extraction	end_date	
+mms_metagenomeDnaExtraction	genomicsSampleID	exact_mapping	Extraction	has_input	
+mms_metagenomeDnaExtraction	deprecatedVialID				
+mms_metagenomeDnaExtraction	dnaSampleID	exact_mapping	Extraction	has_output	
+mms_metagenomeDnaExtraction	internalLabID				
+mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type	"Exclude ""marker_genes"", import ""metagenomics"""
+mms_metagenomeDnaExtraction	testMethod	close_mapping	Extraction	protocol_link	Document library https://data.neonscience.org/documents
+mms_metagenomeDnaExtraction	sampleMaterial	exact_mapping	Biosample	env_package	Need more information/an example of what this looks like.
+mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass	
+mms_metagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	Extraction	dna_concentration	
+mms_metagenomeDnaExtraction	nucleicAcidQuantMethod				
+mms_metagenomeDnaExtraction	nucleicAcidPurity	related_mapping	Extraction	dna_absorb1	
+mms_metagenomeDnaExtraction	nucleicAcidRange				
+mms_metagenomeDnaExtraction	dnaPooledStatus	narrow_mapping	Extraction	pool_dna_extracts	NEON field does not look like it includes the number of extracts (NMDC includes this number in slot).
+mms_metagenomeDnaExtraction	qaqcStatus	exact_mapping	Extraction	quality_control_report.status	
+mms_metagenomeDnaExtraction	dnaProcessedBy				Exclude
+mms_metagenomeDnaExtraction	remarks				Exclude
+mms_metagenomeDnaExtraction	dataQF				
+mms_metagenomeSequencing	uid				Exclude
+mms_metagenomeSequencing	domainID				inherited from mms_metagenomeDnaExtraction
+mms_metagenomeSequencing	siteID				inherited from mms_metagenomeDnaExtraction
+mms_metagenomeSequencing	namedLocation				inherited from mms_metagenomeDnaExtraction
+mms_metagenomeSequencing	collectDate	close_mapping	LibraryPreparation	start_date	all Neon's collectDates refer to the Pooling table collect dates.
+mms_metagenomeSequencing	laboratoryName	exact_mapping	LibraryPreparation	processing_institution	
+mms_metagenomeSequencing	sequencingFacilityID	close_mapping	OmicsProcessing	processing_institution	"Who sequenced the sample, vs laboratoryName is who processed the sample."
+mms_metagenomeSequencing	processedDate	exact_mapping	LibraryPreparation	end_date	
+mms_metagenomeSequencing	dnaSampleID	exact_mapping	LibraryPreparation	has_input	inherited from mms_metagenomeDnaExtraction
+mms_metagenomeSequencing	internalLabID				
+mms_metagenomeSequencing	barcodeSequence				
+mms_metagenomeSequencing	instrument_model	narrow_mapping	OmicsProcessing	instrument_name	
+mms_metagenomeSequencing	sequencingMethod				"Neon data example is ""Illumina"""
+mms_metagenomeSequencing	investigation_type	close_mapping	OmicsProcessing	omics_type	
+mms_metagenomeSequencing	sequencingConcentration				
+mms_metagenomeSequencing	labPrepMethod	close_mapping	LibraryPreparation	protocol_link	LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
+mms_metagenomeSequencing	sequencingProtocol	close_mapping	LibraryPreparation	protocol_link	LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
+mms_metagenomeSequencing	illuminaAdapterKit	related_mapping	OmicsProcessing	pcr_primers	
+mms_metagenomeSequencing	illuminaIndex1	broad_mapping	OmicsProcessing	pcr_primers	
+mms_metagenomeSequencing	illuminaIndex2	broad_mapping	OmicsProcessing	pcr_primers	
+mms_metagenomeSequencing	sequencerRunID				
+mms_metagenomeSequencing	qaqcStatus	exact_mapping	LibraryPreparation	quality_control_report.status	
+mms_metagenomeSequencing	sampleTotalReadNumber				
+mms_metagenomeSequencing	sampleFilteredReadNumber				
+mms_metagenomeSequencing	ncbiProjectID	close_mapping	OmicsProcessing	ncbi_project_name	
+mms_metagenomeSequencing	analyzedBy				Exclude
+mms_metagenomeSequencing	remarks				Exclude
+mms_metagenomeSequencing	dataQF				
+mms_rawDataFiles	uid				Exclude
+mms_rawDataFiles	domainID				inherited from sls_soilCoreCollection
+mms_rawDataFiles	siteID				inherited from sls_soilCoreCollection
+mms_rawDataFiles	namedLocation				inherited from sls_soilCoreCollection
+mms_rawDataFiles	laboratoryName				inherited from mms_metagenomeSequencing
+mms_rawDataFiles	sequencingFacilityID				inherited from mms_metagenomeSequencing
+mms_rawDataFiles	startDate				
+mms_rawDataFiles	endDate				
+mms_rawDataFiles	sequencerRunID				inherited from mms_metagenomeSequencing
+mms_rawDataFiles	dnaSampleID				inherited from mms_metagenomeSequencing
+mms_rawDataFiles	dnaSampleCode				
+mms_rawDataFiles	internalLabID				
+mms_rawDataFiles	rawDataFileName	exact_mapping	DataObject	name	
+mms_rawDataFiles	rawDataFileDescription	exact_mapping	DataObject	description	
+mms_rawDataFiles	rawDataFilePath	broad_mapping	DataObject	data_object_type	
+mms_rawDataFiles	remarks				Exclude
+mms_rawDataFiles	dataQF				


### PR DESCRIPTION
@turbomam @sujaypatil96 @mslarae13 for issue #928 @bmeluch and I added the Neon mappings and clarified the match types. We suggested a small handful of slots get added to other classes (namely the Extraction class). We also included `has_input `and `has_output` mappings using Neon's identifiers in their metagenomic sequencing and pooling tables. Although we were not sure if these will be nmdc identifiers. Let us know if you have questions!

