### PR TITLE
Corrections to NEON NMDC mappings TSV file

### DIFF
--- a/assets/misc/neon_nmdc_term_mappings.tsv
+++ b/assets/misc/neon_nmdc_term_mappings.tsv
@@ -139,7 +139,7 @@ DP1.10086.001	sls_metagenomicsPooling	collectDate	exact_mapping	Pooling	end_date
 DP1.10086.001	sls_metagenomicsPooling	eventID					
 DP1.10086.001	sls_metagenomicsPooling	samplingProtocolVersion	close_mapping	Pooling	protocol_link.url		inherited from sls_soilCoreCollection
 DP1.10086.001	sls_metagenomicsPooling	genomicsPooledIDList	close_mapping	Pooling	has_input		
-DP1.10086.001	sls_metagenomicsPooling	genomicsPooledIDList	related_mapping	Biosample	sample_link		genomicsPooledIDList values need to be split by "|" and prefixed with NEON: since they are IDs
+DP1.10086.001	sls_metagenomicsPooling	genomicsPooledIDList	related_mapping	Biosample	sample_link		genomicsPooledIDList values need to be split by | and prefixed with NEON: since they are IDs
 DP1.10086.001	sls_metagenomicsPooling	genomicsSampleID	exact_mapping	Pooling	has_output.id		
 DP1.10086.001	sls_metagenomicsPooling	genomicsSampleCode					
 DP1.10086.001	sls_metagenomicsPooling	sampleCondition					
@@ -214,7 +214,7 @@ DP1.10086.001	sls_soilCoreCollection	incubationCondition
 DP1.10086.001	sls_soilCoreCollection	sampleID	exact_mapping	Biosample	samp_name		Unique per plot, per horizon, per collectDate
 DP1.10086.001	sls_soilCoreCollection	sampleCode					NEON barcode
 DP1.10086.001	sls_soilCoreCollection	toxicodendronPossible					
-DP1.10086.001	sls_soilCoreCollection	horizon	exact_mapping	Biosample	soil_horizon		Append " horizon" at the end of the horizon value
+DP1.10086.001	sls_soilCoreCollection	horizon	exact_mapping	Biosample	soil_horizon		"Append "" horizon"" at the end of the horizon value"
 DP1.10086.001	sls_soilCoreCollection	horizonDetails					
 DP1.10086.001	sls_soilCoreCollection	soilTemp	narrow_mapping	Biosample	temp.has_numeric_value		
 DP1.10086.001	sls_soilCoreCollection	litterDepth					
@@ -303,7 +303,7 @@ DP1.10107.001	mms_metagenomeDnaExtraction	genomicsSampleID	exact_mapping	Extract
 DP1.10107.001	mms_metagenomeDnaExtraction	deprecatedVialID					
 DP1.10107.001	mms_metagenomeDnaExtraction	dnaSampleID	exact_mapping	Extraction	has_output		
 DP1.10107.001	mms_metagenomeDnaExtraction	internalLabID					
-DP1.10107.001	mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type		Exclude "marker_genes", import "metagenomics"
+DP1.10107.001	mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type		"Exclude ""marker_genes"", import ""metagenomics"""
 DP1.10107.001	mms_metagenomeDnaExtraction	testMethod	close_mapping	Extraction	protocol_link		Document library https://data.neonscience.org/documents
 DP1.10107.001	mms_metagenomeDnaExtraction	sampleMaterial	exact_mapping	Biosample	env_package		Need more information/an example of what this looks like.
 DP1.10107.001	mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		
@@ -328,14 +328,14 @@ DP1.10107.001	mms_metagenomeSequencing	dnaSampleID	exact_mapping	LibraryPreparat
 DP1.10107.001	mms_metagenomeSequencing	internalLabID					
 DP1.10107.001	mms_metagenomeSequencing	barcodeSequence					
 DP1.10107.001	mms_metagenomeSequencing	instrument_model	narrow_mapping	OmicsProcessing	instrument_name		
-DP1.10107.001	mms_metagenomeSequencing	sequencingMethod					Neon data example is "Illumina"
+DP1.10107.001	mms_metagenomeSequencing	sequencingMethod					"Neon data example is ""Illumina"""
 DP1.10107.001	mms_metagenomeSequencing	investigation_type	close_mapping	OmicsProcessing	omics_type.term.name		
 DP1.10107.001	mms_metagenomeSequencing	sequencingConcentration					
 DP1.10107.001	mms_metagenomeSequencing	labPrepMethod	close_mapping	LibraryPreparation	protocol_link.name		LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
 DP1.10107.001	mms_metagenomeSequencing	sequencingProtocol	close_mapping	LibraryPreparation	protocol_link		LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
-DP1.10107.001	mms_metagenomeSequencing	illuminaAdapterKit	related_mapping	OmicsProcessing	pcr_primers		
-DP1.10107.001	mms_metagenomeSequencing	illuminaIndex1	broad_mapping	OmicsProcessing	pcr_primers		
-DP1.10107.001	mms_metagenomeSequencing	illuminaIndex2	broad_mapping	OmicsProcessing	pcr_primers		
+DP1.10107.001	mms_metagenomeSequencing	illuminaAdapterKit	related_mapping	OmicsProcessing	pcr_primers		The name of the adapter kit used. User would have to search the adapter kit documentation for primer sequences, they are not directly provided.
+DP1.10107.001	mms_metagenomeSequencing	illuminaIndex1					
+DP1.10107.001	mms_metagenomeSequencing	illuminaIndex2					
 DP1.10107.001	mms_metagenomeSequencing	sequencerRunID					
 DP1.10107.001	mms_metagenomeSequencing	sampleTotalReadNumber					
 DP1.10107.001	mms_metagenomeSequencing	sampleFilteredReadNumber					
@@ -364,3 +364,134 @@ DP1.10107.001	mms_rawDataFiles	dataQF
 				Biosample	env_broad_scale.term.name	terrestrial biome	
 				Biosample	env_medium.term.id	ENVO:00001998	
 				Biosample	env_medium.term.name	soil	
+DP1.20281.00	amc_fieldGenetic	uid					Exclude
+DP1.20281.00	amc_fieldGenetic	domainID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	amc_fieldGenetic	siteID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	amc_fieldGenetic	namedLocation					inherited from amc_fieldSuperParent table.
+DP1.20281.00	amc_fieldGenetic	collectDate					inherited from amc_fieldSuperParent table.
+DP1.20281.00	amc_fieldGenetic	parentSampleID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	amc_fieldGenetic	parentSampleCode					exclude
+DP1.20281.00	amc_fieldGenetic	archiveSampleCond					exclude
+DP1.20281.00	amc_fieldGenetic	archiveID					exclude
+DP1.20281.00	amc_fieldGenetic	archiveSampleCode					exclude
+DP1.20281.00	amc_fieldGenetic	archiveFilteredSampleVolume					exclude
+DP1.20281.00	amc_fieldGenetic	geneticSampleCond					
+DP1.20281.00	amc_fieldGenetic	geneticSampleID					The same as genomicsSampleId from the metagenomics table, which is being mapped to has_input for the Extraction class.
+DP1.20281.00	amc_fieldGenetic	geneticSampleCode					
+DP1.20281.00	amc_fieldGenetic	geneticFilteredSampleVolume	exact_mapping	Biosample	samp_size		Alicia mentioned this will map and filtration will be ignored.
+DP1.20281.00	amc_fieldGenetic	metagenomicsCollected					Exclude
+DP1.20281.00	amc_fieldGenetic	metagenomicSampleCond					Exclude
+DP1.20281.00	amc_fieldGenetic	metagenomicSampleID					Exclude
+DP1.20281.00	amc_fieldGenetic	metagenomicSampleCode					Exclude
+DP1.20281.00	amc_fieldGenetic	metagenomicFilteredSampleVolume					Exclude
+DP1.20281.00	amc_fieldGenetic	sampleMaterial	exact_mapping	Biosample	env_package.has_raw_value	water	
+DP1.20281.00	amc_fieldGenetic	remarks					Exclude
+DP1.20281.00	amc_fieldGenetic	dataQF					
+DP1.20281.00	amc_fieldSuperParent	uid					exclude
+DP1.20281.00	amc_fieldSuperParent	domainID					
+DP1.20281.00	amc_fieldSuperParent	siteID	related_mapping	Biosample	geo_loc_name		use siteID to pull location information from NEON API (Mark)
+DP1.20281.00	amc_fieldSuperParent	namedLocation					exclude
+DP1.20281.00	amc_fieldSuperParent	decimalLatitude	exact_mapping	Biosample	lat_lon.latitude		
+DP1.20281.00	amc_fieldSuperParent	decimalLongitude	exact_mapping	Biosample	lat_lon.longitude		
+DP1.20281.00	amc_fieldSuperParent	coordinateUncertainty					
+DP1.20281.00	amc_fieldSuperParent	additionalCoordUncertainty					
+DP1.20281.00	amc_fieldSuperParent	elevation	exact_mapping	Biosample	elev		
+DP1.20281.00	amc_fieldSuperParent	elevationUncertainty					
+DP1.20281.00	amc_fieldSuperParent	geodeticDatum					Exclude
+DP1.20281.00	amc_fieldSuperParent	altLocation					
+DP1.20281.00	amc_fieldSuperParent	altLatitude	exact_mapping	Biosample	lat_lon.latitude		if a value is present, supersedes amc_fieldSuperParent.decimalLatitude
+DP1.20281.00	amc_fieldSuperParent	altLongitude	exact_mapping	Biosample	lat_lon.longitude		if a value is present, supersedes amc_fieldSuperParent.decimalLongitude
+DP1.20281.00	amc_fieldSuperParent	altCoordinateUncertainty					
+DP1.20281.00	amc_fieldSuperParent	altGeodeticDatum					Exclude
+DP1.20281.00	amc_fieldSuperParent	collectDate	exact_mapping	Biosample	collection_date		
+DP1.20281.00	amc_fieldSuperParent	aquaticSiteType	close_mapping	Biosample	env_local_scale		Related to Envo triad determination. See here: https://github.com/microbiomedata/nmdc-schema/blob/main/assets/neon_mixs_env_triad_mappings/neon-nlcd-local-broad-mappings.tsv
+DP1.20281.00	amc_fieldSuperParent	samplingImpractical					
+DP1.20281.00	amc_fieldSuperParent	microbeSamplesCollected					
+DP1.20281.00	amc_fieldSuperParent	parentSampleID					
+DP1.20281.00	amc_fieldSuperParent	parentSampleCode					
+DP1.20281.00	amc_fieldSuperParent	eventID					
+DP1.20281.00	amc_fieldSuperParent	samplerType	exact_mapping	Biosample	samp_collec_device		
+DP1.20281.00	amc_fieldSuperParent	dissolvedOxygen	exact_mapping	Biosample	diss_oxygen		
+DP1.20281.00	amc_fieldSuperParent	dissolvedOxygenSaturation					
+DP1.20281.00	amc_fieldSuperParent	specificConductance	exact_mapping	Biosample	conduc		
+DP1.20281.00	amc_fieldSuperParent	waterTemp	exact_mapping	Biosample	temp		
+DP1.20281.00	amc_fieldSuperParent	amcSamplingProtocolVersion	exact_mapping	CollectingBiosamplesFromSite	protocol_link.Protocol.name		
+DP1.20281.00	amc_fieldSuperParent	lowerSegmentDepth	narrow_mapping	Biosample	depth		lowerSegmentDepth will need to be combined with upperSegmentDepth to give an interval and map to nmdc depth.
+DP1.20281.00	amc_fieldSuperParent	upperSegmentDepth	narrow_mapping	Biosample	depth		See comment for lowerSegmentDepth
+DP1.20281.00	amc_fieldSuperParent	maxDepth					
+DP1.20281.00	amc_fieldSuperParent	lakeSampleDepth1					
+DP1.20281.00	amc_fieldSuperParent	lakeSampleDepth2					
+DP1.20281.00	amc_fieldSuperParent	aCollectedBy					Exclude
+DP1.20281.00	amc_fieldSuperParent	bCollectedBy					Exclude
+DP1.20281.00	amc_fieldSuperParent	remarks					Exclude
+DP1.20281.00	amc_fieldSuperParent	fieldDataQF					
+DP1.20281.00	mms_swMetagenomeDnaExtraction	uid					Exclude
+DP1.20281.00	mms_swMetagenomeDnaExtraction	domainID					inherited from amc_fieldSuperParent
+DP1.20281.00	mms_swMetagenomeDnaExtraction	siteID					inherited from amc_fieldSuperParent
+DP1.20281.00	mms_swMetagenomeDnaExtraction	namedLocation					inherited from amc_fieldSuperParent
+DP1.20281.00	mms_swMetagenomeDnaExtraction	laboratoryName	exact_mapping	Extraction	processing_institution		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	collectDate					inherited from amc_fieldSuperParent
+DP1.20281.00	mms_swMetagenomeDnaExtraction	processedDate	exact_mapping	Extraction	end_date		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	genomicsSampleID	exact_mapping	Extraction	has_input		matches amc_fieldGenetic.geneticSampleID
+DP1.20281.00	mms_swMetagenomeDnaExtraction	deprecatedVialID					
+DP1.20281.00	mms_swMetagenomeDnaExtraction	dnaSampleID	exact_mapping	Extraction	has_output		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	internalLabID					
+DP1.20281.00	mms_swMetagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type		"Exclude ""marker_genes"", import ""metagenomics"""
+DP1.20281.00	mms_swMetagenomeDnaExtraction	testMethod	exact_mapping	Extraction	protocol_link.Protocol.name		Document library https://data.neonscience.org/documents
+DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMaterial					Captured from fieldGenetic table and will map to env_package in the Biosample class.
+DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	samplePercent					
+DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidConcentration	exact_mapping	ProcessedSample	nucleic_acid_concentration		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidQuantMethod					
+DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidPurity	exact_mapping	ProcessedSample	biomaterial_purity		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidRange					
+DP1.20281.00	mms_swMetagenomeDnaExtraction	dnaPooledStatus	broad_mapping	ProcessedSample	pool_dna_extracts		NEON field does not look like it includes the number of extracts (NMDC includes this number in slot).
+DP1.20281.00	mms_swMetagenomeDnaExtraction	qaqcStatus	exact_mapping	Extraction	quality_control_report.status		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	dnaProcessedBy					Exclude
+DP1.20281.00	mms_swMetagenomeDnaExtraction	remarks					Exclude
+DP1.20281.00	mms_swMetagenomeDnaExtraction	dataQF					
+DP1.20281.00	mms_swMetagenomeSequencing	uid					Exclude
+DP1.20281.00	mms_swMetagenomeSequencing	domainID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swMetagenomeSequencing	siteID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swMetagenomeSequencing	namedLocation					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swMetagenomeSequencing	collectDate					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swMetagenomeSequencing	laboratoryName	exact_mapping	LibraryPreparation	processing_institution		
+DP1.20281.00	mms_swMetagenomeSequencing	sequencingFacilityID	exact_mapping	OmicsProcessing	processing_institution		Although it is an ID, the data values are names, so mapping is exact.
+DP1.20281.00	mms_swMetagenomeSequencing	processedDate	exact_mapping	LibraryPreparation	end_date		
+DP1.20281.00	mms_swMetagenomeSequencing	dnaSampleID	exact_mapping	LibraryPreparation	has_input		inherited from mms_swMetagenomeDnaExtraction
+DP1.20281.00	mms_swMetagenomeSequencing	internalLabID					
+DP1.20281.00	mms_swMetagenomeSequencing	barcodeSequence					
+DP1.20281.00	mms_swMetagenomeSequencing	instrument_model	narrow_mapping	OmicsProcessing	instrument_name		
+DP1.20281.00	mms_swMetagenomeSequencing	sequencingMethod					"Neon data example is ""Illumina"""
+DP1.20281.00	mms_swMetagenomeSequencing	investigation_type	close_mapping	OmicsProcessing	omics_type		
+DP1.20281.00	mms_swMetagenomeSequencing	sequencingConcentration					
+DP1.20281.00	mms_swMetagenomeSequencing	labPrepMethod	close_mapping	LibraryPreparation	protocol_link		LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
+DP1.20281.00	mms_swMetagenomeSequencing	sequencingProtocol	close_mapping	LibraryPreparation	protocol_link		LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
+DP1.20281.00	mms_swMetagenomeSequencing	illuminaAdapterKit	related_mapping	OmicsProcessing	pcr_primers		The name of the adapter kit used. User would have to search the adapter kit documentation for primer sequences, they are not directly provided.
+DP1.20281.00	mms_swMetagenomeSequencing	illuminaIndex1					
+DP1.20281.00	mms_swMetagenomeSequencing	illuminaIndex2					
+DP1.20281.00	mms_swMetagenomeSequencing	sequencerRunID					
+DP1.20281.00	mms_swMetagenomeSequencing	qaqcStatus	exact_mapping	LibraryPreparation	quality_control_report.status		
+DP1.20281.00	mms_swMetagenomeSequencing	sampleTotalReadNumber					
+DP1.20281.00	mms_swMetagenomeSequencing	sampleFilteredReadNumber					
+DP1.20281.00	mms_swMetagenomeSequencing	ncbiProjectID	close_mapping	OmicsProcessing	ncbi_project_name		
+DP1.20281.00	mms_swMetagenomeSequencing	analyzedBy					Exclude
+DP1.20281.00	mms_swMetagenomeSequencing	remarks					Exclude
+DP1.20281.00	mms_swMetagenomeSequencing	dataQF					
+DP1.20281.00	mms_swRawDataFiles	uid					Exclude
+DP1.20281.00	mms_swRawDataFiles	domainID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swRawDataFiles	siteID					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swRawDataFiles	namedLocation					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swRawDataFiles	laboratoryName					inherited from mms_swMetagenomeSequencing
+DP1.20281.00	mms_swRawDataFiles	sequencingFacilityID					inherited from mms_swMetagenomeSequencing
+DP1.20281.00	mms_swRawDataFiles	startDate					
+DP1.20281.00	mms_swRawDataFiles	collectDate					inherited from amc_fieldSuperParent table.
+DP1.20281.00	mms_swRawDataFiles	sequencerRunID					inherited from mms_swMetagenomeSequencing
+DP1.20281.00	mms_swRawDataFiles	dnaSampleID					inherited from mms_swMetagenomeSequencing
+DP1.20281.00	mms_swRawDataFiles	dnaSampleCode					
+DP1.20281.00	mms_swRawDataFiles	internalLabID					
+DP1.20281.00	mms_swRawDataFiles	rawDataFileName	exact_mapping	OmicsProcessing	name		
+DP1.20281.00	mms_swRawDataFiles	rawDataFileDescription	exact_mapping	OmicsProcessing	description		
+DP1.20281.00	mms_swRawDataFiles	rawDataFilePath	broad_mapping	OmicsProcessing	data_object_type		Extract file extension out of file path.
+DP1.20281.00	mms_swRawDataFiles	remarks					Exclude
+DP1.20281.00	mms_swRawDataFiles	dataQF					

--- a/assets/misc/neon_nmdc_term_mappings.tsv
+++ b/assets/misc/neon_nmdc_term_mappings.tsv
@@ -1,363 +1,366 @@
-neon_table	neon_field_name	match_type	nmdc_class	nmdc_slot	notes
-bgc_CNiso_externalSummary	uid				Exclude
-bgc_CNiso_externalSummary	analyte				Exclude
-bgc_CNiso_externalSummary	analyteUnits				Exclude
-bgc_CNiso_externalSummary	sampleType				Exclude
-bgc_CNiso_externalSummary	qaReferenceID				Exclude
-bgc_CNiso_externalSummary	analyteKnownValue				Exclude
-bgc_CNiso_externalSummary	analyteObservedValue				Exclude
-bgc_CNiso_externalSummary	analyteAbsoluteError				Exclude
-bgc_CNiso_externalSummary	analyteStandardDeviation				Exclude
-bgc_CNiso_externalSummary	analyteMetricsCount				Exclude
-bgc_CNiso_externalSummary	qaReportingStartDate				Exclude
-bgc_CNiso_externalSummary	qaReportingEndDate				Exclude
-bgc_CNiso_externalSummary	laboratoryName				Exclude
-bgc_CNiso_externalSummary	instrument				Exclude
-bgc_CNiso_externalSummary	testMethod				Exclude
-bgc_CNiso_externalSummary	method				Exclude
-bgc_CNiso_externalSummary	dataQF				Exclude
-ntr_externalLab	uid				Exclude
-ntr_externalLab	namedLocation				inherited from sls_soilCoreCollection
-ntr_externalLab	domainID				inherited from sls_soilCoreCollection
-ntr_externalLab	siteID				inherited from sls_soilCoreCollection
-ntr_externalLab	plotID				inherited from sls_soilCoreCollection
-ntr_externalLab	startDate				inherited from sls_soilCoreCollection
-ntr_externalLab	collectDate				inherited from sls_soilCoreCollection
-ntr_externalLab	sampleID				inherited from sls_soilCoreCollection
-ntr_externalLab	sampleCode				inherited from sls_soilCoreCollection
-ntr_externalLab	kclSampleID				inherited from ntr_internalLab
-ntr_externalLab	kclSampleCode				inherited from ntr_internalLab
-ntr_externalLab	sampleCondition				
-ntr_externalLab	ammoniumNAnalysisDate				
-ntr_externalLab	kclAmmoniumNConc	narrow_mapping	Biosample	ammonium_nitrogen	
-ntr_externalLab	ammoniumNRepNum	narrow_mapping	Biosample	replicate_number	
-ntr_externalLab	ammoniumNQF				
-ntr_externalLab	ammoniumNRemarks				Exclude
-ntr_externalLab	nitrateNitriteNAnalysisDate				
-ntr_externalLab	kclNitrateNitriteNConc	exact_mapping	Biosample	tot_nitro_content	
-ntr_externalLab	nitrateNitriteNRepNum	narrow_mapping	Biosample	replicate_number	
-ntr_externalLab	nitrateNitriteNQF				
-ntr_externalLab	nitrateNitriteNRemarks				Exclude
-ntr_externalLab	laboratoryName				
-ntr_externalLab	ammoniumNMethod				
-ntr_externalLab	ammoniumNInstrument				
-ntr_externalLab	ammoniumNAnalyzedBy				Exclude
-ntr_externalLab	ammoniumNReviewedBy				Exclude
-ntr_externalLab	nitrateNitriteNMethod				
-ntr_externalLab	nitrateNitriteNInstrument				
-ntr_externalLab	nitrateNitriteNAnalyzedBy				Exclude
-ntr_externalLab	nitrateNitriteNReviewedBy				Exclude
-ntr_externalLab	dataQF				
-ntr_externalSummary	uid				Exclude
-ntr_externalSummary	analyte				Exclude
-ntr_externalSummary	analyteUnits				Exclude
-ntr_externalSummary	sampleType				Exclude
-ntr_externalSummary	qaReferenceID				Exclude
-ntr_externalSummary	lotID				Exclude
-ntr_externalSummary	analyteKnownValue				Exclude
-ntr_externalSummary	analyteObservedValue				Exclude
-ntr_externalSummary	analytePercentRecovery				Exclude
-ntr_externalSummary	analyteStandardDeviation				Exclude
-ntr_externalSummary	methodDetectionLimit				Exclude
-ntr_externalSummary	analyteMetricsCount				Exclude
-ntr_externalSummary	qaReportingStartDate				Exclude
-ntr_externalSummary	qaReportingEndDate				Exclude
-ntr_externalSummary	laboratoryName				Exclude
-ntr_externalSummary	instrument				Exclude
-ntr_externalSummary	method				Exclude
-ntr_externalSummary	dataQF				Exclude
-ntr_internalLab	uid				Exclude
-ntr_internalLab	namedLocation				inherited from sls_soilCoreCollection
-ntr_internalLab	domainID				inherited from sls_soilCoreCollection
-ntr_internalLab	siteID				inherited from sls_soilCoreCollection
-ntr_internalLab	plotID				inherited from sls_soilCoreCollection
-ntr_internalLab	plotType				inherited from sls_soilCoreCollection
-ntr_internalLab	startDate				inherited from sls_soilCoreCollection
-ntr_internalLab	collectDate				inherited from sls_soilCoreCollection
-ntr_internalLab	samplingProtocolVersion				inherited from sls_soilCoreCollection
-ntr_internalLab	sampleID				inherited from sls_soilCoreCollection
-ntr_internalLab	sampleCode				inherited from sls_soilCoreCollection
-ntr_internalLab	kclSampleID				
-ntr_internalLab	kclSampleCode				
-ntr_internalLab	incubationPairID				
-ntr_internalLab	nTransBoutType				inherited from sls_soilCoreCollection
-ntr_internalLab	incubationLength	related_mapping	Biosample	collection_date_inc	"NMDC requires date, NEON is in days."
-ntr_internalLab	extractionStartDate				
-ntr_internalLab	kclReferenceID				
-ntr_internalLab	soilFreshMass	exact_mapping	Biosample	samp_size	
-ntr_internalLab	kclVolume				
-ntr_internalLab	extractionEndDate				
-ntr_internalLab	sampleCondition				
-ntr_internalLab	remarks				Exclude
-ntr_internalLab	processedBy				Exclude
-ntr_internalLab	recordedBy				Exclude
-ntr_internalLab	dataQF				
-ntr_internalLabBlanks	uid				Exclude
-ntr_internalLabBlanks	domainID				Exclude
-ntr_internalLabBlanks	siteID				Exclude
-ntr_internalLabBlanks	extractionStartDate				Exclude
-ntr_internalLabBlanks	extractionEndDate				Exclude
-ntr_internalLabBlanks	kclReferenceID				Exclude
-ntr_internalLabBlanks	kclBlank1ID				Exclude
-ntr_internalLabBlanks	kclBlank1Code				Exclude
-ntr_internalLabBlanks	kclBlank2ID				Exclude
-ntr_internalLabBlanks	kclBlank2Code				Exclude
-ntr_internalLabBlanks	kclBlank3ID				Exclude
-ntr_internalLabBlanks	kclBlank3Code				Exclude
-ntr_internalLabBlanks	remarks				Exclude
-ntr_internalLabBlanks	dataQF				Exclude
-sls_bgcSubsampling	uid				Exclude
-sls_bgcSubsampling	domainID				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	siteID				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	plotID				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	namedLocation				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	startDate				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	collectDate				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	samplingProtocolVersion				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	horizon				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	ovenStartDate				
-sls_bgcSubsampling	ovenEndDate				
-sls_bgcSubsampling	sampleID				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	sampleCode				inherited from sls_soilCoreCollection
-sls_bgcSubsampling	cnSampleID				
-sls_bgcSubsampling	cnSampleCode				
-sls_bgcSubsampling	bgcArchiveID				
-sls_bgcSubsampling	bgcArchiveCode				
-sls_bgcSubsampling	bgcArchiveMass				
-sls_bgcSubsampling	toxicodendronPossible				
-sls_bgcSubsampling	sampleCondition				
-sls_bgcSubsampling	bgcRemarks				Exclude
-sls_bgcSubsampling	processedBy				Exclude
-sls_bgcSubsampling	bgcDataQF				
-sls_metagenomicsPooling	uid				Exclude
-sls_metagenomicsPooling	domainID				inherited from sls_soilCoreCollection
-sls_metagenomicsPooling	siteID				inherited from sls_soilCoreCollection
-sls_metagenomicsPooling	plotID				inherited from sls_soilCoreCollection
-sls_metagenomicsPooling	namedLocation				inherited from sls_soilCoreCollection
-sls_metagenomicsPooling	startDate	exact_mapping	Pooling	start_date	earliest start date of sampleIDs in genomicsPooledIDList
-sls_metagenomicsPooling	collectDate	exact_mapping	Pooling	end_date	latest collect date of sampleIDs in genomicsPooledIDList
-sls_metagenomicsPooling	eventID				
-sls_metagenomicsPooling	samplingProtocolVersion	close_mapping	Pooling	protocol_link	inherited from sls_soilCoreCollection
-sls_metagenomicsPooling	genomicsPooledIDList	close_mapping	Pooling	has_input	
-sls_metagenomicsPooling	genomicsPooledIDList	related_mapping	Biosample	sample_link	
-sls_metagenomicsPooling	genomicsSampleID	exact_mapping	Pooling	has_output	
-sls_metagenomicsPooling	genomicsSampleCode				
-sls_metagenomicsPooling	sampleCondition				
-sls_metagenomicsPooling	processedBy				Exclude
-sls_metagenomicsPooling	remarks				Exclude
-sls_metagenomicsPooling	genomicsDataQF				
-sls_soilChemistry	uid				Exclude
-sls_soilChemistry	analysisDate				
-sls_soilChemistry	namedLocation				inherited from sls_soilCoreCollection
-sls_soilChemistry	domainID				inherited from sls_soilCoreCollection
-sls_soilChemistry	siteID				inherited from sls_soilCoreCollection
-sls_soilChemistry	plotID				inherited from sls_soilCoreCollection
-sls_soilChemistry	plotType				inherited from sls_soilCoreCollection
-sls_soilChemistry	startDate				inherited from sls_soilCoreCollection
-sls_soilChemistry	collectDate				inherited from sls_soilCoreCollection
-sls_soilChemistry	sampleID				inherited from sls_soilCoreCollection
-sls_soilChemistry	sampleCode				inherited from sls_soilCoreCollection
-sls_soilChemistry	cnSampleID				
-sls_soilChemistry	cnSampleCode				
-sls_soilChemistry	sampleType	exact_mapping	Biosample	env_package	soil
-sls_soilChemistry	acidTreatment				
-sls_soilChemistry	co2Trapped				
-sls_soilChemistry	d15N				
-sls_soilChemistry	organicd13C				
-sls_soilChemistry	nitrogenPercent	close_mapping	Biosample	nitro	
-sls_soilChemistry	organicCPercent	close_mapping	Biosample	org_carb	
-sls_soilChemistry	CNratio	narrow_mapping	Biosample	carb_nitro_ratio	
-sls_soilChemistry	cnIsotopeQF				
-sls_soilChemistry	cnPercentQF				
-sls_soilChemistry	isotopeAccuracyQF				
-sls_soilChemistry	percentAccuracyQF				
-sls_soilChemistry	analyticalRepNumber	close_mapping	Biosample	replicate_number	
-sls_soilChemistry	remarks				Exclude
-sls_soilChemistry	laboratoryName				Exclude
-sls_soilChemistry	testMethod	broad_mapping	Biosample	tot_nitro_cont_meth	
-sls_soilChemistry	testMethod	broad_mapping	Biosample	tot_org_c_meth	
-sls_soilChemistry	instrument				
-sls_soilChemistry	analyzedBy				Exclude
-sls_soilChemistry	reviewedBy				Exclude
-sls_soilChemistry	dataQF				
-sls_soilCoreCollection	uid				Exclude
-sls_soilCoreCollection	domainID				
-sls_soilCoreCollection	siteID	related_mapping	Biosample	geo_loc_name	use siteID to pull location information from NEON API (Mark)
-sls_soilCoreCollection	plotID	related_mapping	Biosample	env_broad_scale	use plotID to pull environmental triad information (Mark/Hugh)
-sls_soilCoreCollection	namedLocation				
-sls_soilCoreCollection	plotType				
-sls_soilCoreCollection	nlcdClass	related_mapping	Biosample	env_broad_scale	determined by Mark/Hugh plot environment information work
-sls_soilCoreCollection	subplotID	related_mapping	Biosample	env_broad_scale	use with plotID to pull environmental triad information (Mark/Hugh)
-sls_soilCoreCollection	subplotID	related_mapping	Biosample	sample_link	Biosamples sharing subplotID and collectionDate are linked
-sls_soilCoreCollection	coreCoordinateX				
-sls_soilCoreCollection	coreCoordinateY				
-sls_soilCoreCollection	geodeticDatum				Exclude
-sls_soilCoreCollection	decimalLatitude	narrow_mapping	GeolocationValue	latitude	Biosample.lat_lon
-sls_soilCoreCollection	decimalLongitude	narrow_mapping	GeolocationValue	longitude	Biosample.lat_lon
-sls_soilCoreCollection	coordinateUncertainty				
-sls_soilCoreCollection	elevation	exact_mapping	Biosample	elev	
-sls_soilCoreCollection	elevationUncertainty				
-sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	samp_collec_method	
-sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	micro_biomass_meth	
-sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	water_cont_soil_meth	
-sls_soilCoreCollection	startDate	exact_mapping	Biosample	collection_date	first value of collection_date range
-sls_soilCoreCollection	collectDate	exact_mapping	Biosample	collection_date	last value of collection_date range
-sls_soilCoreCollection	sampleTiming	close_mapping	Biosample	season	
-sls_soilCoreCollection	biophysicalCriteria				
-sls_soilCoreCollection	eventID				
-sls_soilCoreCollection	standingWaterDepth				
-sls_soilCoreCollection	nTransBoutType				
-sls_soilCoreCollection	boutType				
-sls_soilCoreCollection	samplingImpractical				
-sls_soilCoreCollection	incubationMethod				
-sls_soilCoreCollection	incubationCondition				
-sls_soilCoreCollection	sampleID	exact_mapping	Biosample	samp_name	"Unique per plot, per horizon, per collectDate"
-sls_soilCoreCollection	sampleCode				NEON barcode
-sls_soilCoreCollection	toxicodendronPossible				
-sls_soilCoreCollection	horizon	exact_mapping	Biosample	soil_horizon	
-sls_soilCoreCollection	horizonDetails				
-sls_soilCoreCollection	soilTemp	narrow_mapping	Biosample	temp	
-sls_soilCoreCollection	litterDepth				
-sls_soilCoreCollection	sampleTopDepth	close_mapping	Biosample	depth	first value of depth interval
-sls_soilCoreCollection	sampleBottomDepth	close_mapping	Biosample	depth	last value of depth interval
-sls_soilCoreCollection	sampleExtent				
-sls_soilCoreCollection	soilSamplingDevice	exact_mapping	Biosample	samp_collec_device	
-sls_soilCoreCollection	soilCoreCount				
-sls_soilCoreCollection	geneticSampleID				"related to NEON genetic sample archive process, not metagenomics"
-sls_soilCoreCollection	geneticSampleCode				
-sls_soilCoreCollection	geneticSampleCondition				
-sls_soilCoreCollection	geneticSamplePrepMethod				
-sls_soilCoreCollection	geneticArchiveSample1ID				
-sls_soilCoreCollection	geneticArchiveSample1Code				
-sls_soilCoreCollection	geneticArchiveSample2ID				
-sls_soilCoreCollection	geneticArchiveSample2Code				
-sls_soilCoreCollection	geneticArchiveSample3ID				
-sls_soilCoreCollection	geneticArchiveSample3Code				
-sls_soilCoreCollection	geneticArchiveSample4ID				
-sls_soilCoreCollection	geneticArchiveSample4Code				
-sls_soilCoreCollection	geneticArchiveSample5ID				
-sls_soilCoreCollection	geneticArchiveSample5Code				
-sls_soilCoreCollection	geneticArchiveSamplePrepMethod				
-sls_soilCoreCollection	geneticArchiveContainer				
-sls_soilCoreCollection	biomassID				
-sls_soilCoreCollection	biomassCode				
-sls_soilCoreCollection	biomassSampleCondition				
-sls_soilCoreCollection	remarks				Exclude
-sls_soilCoreCollection	collectedBy				Exclude
-sls_soilCoreCollection	dataQF				
-sls_soilMoisture	uid				Exclude
-sls_soilMoisture	domainID				inherited from sls_soilCoreCollection
-sls_soilMoisture	siteID				inherited from sls_soilCoreCollection
-sls_soilMoisture	plotID				inherited from sls_soilCoreCollection
-sls_soilMoisture	namedLocation				inherited from sls_soilCoreCollection
-sls_soilMoisture	startDate				inherited from sls_soilCoreCollection
-sls_soilMoisture	collectDate				inherited from sls_soilCoreCollection
-sls_soilMoisture	sampleID				inherited from sls_soilCoreCollection
-sls_soilMoisture	sampleCode				inherited from sls_soilCoreCollection
-sls_soilMoisture	moistureSampleID				
-sls_soilMoisture	samplingProtocolVersion				inherited from sls_soilCoreCollection
-sls_soilMoisture	horizon				inherited from sls_soilCoreCollection
-sls_soilMoisture	ovenStartDate				
-sls_soilMoisture	ovenEndDate				
-sls_soilMoisture	boatMass				
-sls_soilMoisture	freshMassBoatMass				
-sls_soilMoisture	dryMassBoatMass				
-sls_soilMoisture	soilMoisture	exact_mapping	Biosample	water_content	
-sls_soilMoisture	dryMassFraction				
-sls_soilMoisture	sampleCondition				
-sls_soilMoisture	smRemarks				Exclude
-sls_soilMoisture	smMeasuredBy				Exclude
-sls_soilMoisture	smDataQF				
-sls_soilpH	uid				Exclude
-sls_soilpH	domainID				inherited from sls_soilCoreCollection
-sls_soilpH	siteID				inherited from sls_soilCoreCollection
-sls_soilpH	plotID				inherited from sls_soilCoreCollection
-sls_soilpH	namedLocation				inherited from sls_soilCoreCollection
-sls_soilpH	startDate				inherited from sls_soilCoreCollection
-sls_soilpH	collectDate				inherited from sls_soilCoreCollection
-sls_soilpH	processedDate				
-sls_soilpH	sampleID				inherited from sls_soilCoreCollection
-sls_soilpH	sampleCode				inherited from sls_soilCoreCollection
-sls_soilpH	pHSampleID				
-sls_soilpH	samplingProtocolVersion	related_mapping	Biosample	ph_meth	inherited from sls_soilCoreCollection
-sls_soilpH	horizon				inherited from sls_soilCoreCollection
-sls_soilpH	soilInWaterpH	narrow_mapping	Biosample	ph	
-sls_soilpH	soilInCaClpH				
-sls_soilpH	pHSoilInWaterMass				
-sls_soilpH	pHWaterVol				
-sls_soilpH	waterpHRatio				
-sls_soilpH	pHSoilInCaClMass				
-sls_soilpH	pHCaClVol				
-sls_soilpH	caclpHRatio				
-sls_soilpH	pHRemarks				Exclude
-sls_soilpH	pHMeasuredBy				Exclude
-sls_soilpH	pHDataQF				
-mms_metagenomeDnaExtraction	uid				Exclude
-mms_metagenomeDnaExtraction	domainID				inherited from sls_soilCoreCollection/Pooling
-mms_metagenomeDnaExtraction	siteID				inherited from sls_soilCoreCollection/Pooling
-mms_metagenomeDnaExtraction	namedLocation				inherited from sls_soilCoreCollection/Pooling
-mms_metagenomeDnaExtraction	laboratoryName	exact_mapping	Extraction	processing_institution	
-mms_metagenomeDnaExtraction	collectDate	close_mapping	Extraction	start_date	inherited from sls_metagenomicsPooling:collectDate
-mms_metagenomeDnaExtraction	processedDate	exact_mapping	Extraction	end_date	
-mms_metagenomeDnaExtraction	genomicsSampleID	exact_mapping	Extraction	has_input	
-mms_metagenomeDnaExtraction	deprecatedVialID				
-mms_metagenomeDnaExtraction	dnaSampleID	exact_mapping	Extraction	has_output	
-mms_metagenomeDnaExtraction	internalLabID				
-mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type	"Exclude ""marker_genes"", import ""metagenomics"""
-mms_metagenomeDnaExtraction	testMethod	close_mapping	Extraction	protocol_link	Document library https://data.neonscience.org/documents
-mms_metagenomeDnaExtraction	sampleMaterial	exact_mapping	Biosample	env_package	Need more information/an example of what this looks like.
-mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass	
-mms_metagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	Extraction	dna_concentration	
-mms_metagenomeDnaExtraction	nucleicAcidQuantMethod				
-mms_metagenomeDnaExtraction	nucleicAcidPurity	related_mapping	Extraction	dna_absorb1	
-mms_metagenomeDnaExtraction	nucleicAcidRange				
-mms_metagenomeDnaExtraction	dnaPooledStatus	narrow_mapping	Extraction	pool_dna_extracts	NEON field does not look like it includes the number of extracts (NMDC includes this number in slot).
-mms_metagenomeDnaExtraction	qaqcStatus	exact_mapping	Extraction	quality_control_report.status	
-mms_metagenomeDnaExtraction	dnaProcessedBy				Exclude
-mms_metagenomeDnaExtraction	remarks				Exclude
-mms_metagenomeDnaExtraction	dataQF				
-mms_metagenomeSequencing	uid				Exclude
-mms_metagenomeSequencing	domainID				inherited from mms_metagenomeDnaExtraction
-mms_metagenomeSequencing	siteID				inherited from mms_metagenomeDnaExtraction
-mms_metagenomeSequencing	namedLocation				inherited from mms_metagenomeDnaExtraction
-mms_metagenomeSequencing	collectDate	close_mapping	LibraryPreparation	start_date	all Neon's collectDates refer to the Pooling table collect dates.
-mms_metagenomeSequencing	laboratoryName	exact_mapping	LibraryPreparation	processing_institution	
-mms_metagenomeSequencing	sequencingFacilityID	close_mapping	OmicsProcessing	processing_institution	"Who sequenced the sample, vs laboratoryName is who processed the sample."
-mms_metagenomeSequencing	processedDate	exact_mapping	LibraryPreparation	end_date	
-mms_metagenomeSequencing	dnaSampleID	exact_mapping	LibraryPreparation	has_input	inherited from mms_metagenomeDnaExtraction
-mms_metagenomeSequencing	internalLabID				
-mms_metagenomeSequencing	barcodeSequence				
-mms_metagenomeSequencing	instrument_model	narrow_mapping	OmicsProcessing	instrument_name	
-mms_metagenomeSequencing	sequencingMethod				"Neon data example is ""Illumina"""
-mms_metagenomeSequencing	investigation_type	close_mapping	OmicsProcessing	omics_type	
-mms_metagenomeSequencing	sequencingConcentration				
-mms_metagenomeSequencing	labPrepMethod	close_mapping	LibraryPreparation	protocol_link	LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
-mms_metagenomeSequencing	sequencingProtocol	close_mapping	LibraryPreparation	protocol_link	LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
-mms_metagenomeSequencing	illuminaAdapterKit	related_mapping	OmicsProcessing	pcr_primers	
-mms_metagenomeSequencing	illuminaIndex1	broad_mapping	OmicsProcessing	pcr_primers	
-mms_metagenomeSequencing	illuminaIndex2	broad_mapping	OmicsProcessing	pcr_primers	
-mms_metagenomeSequencing	sequencerRunID				
-mms_metagenomeSequencing	qaqcStatus	exact_mapping	LibraryPreparation	quality_control_report.status	
-mms_metagenomeSequencing	sampleTotalReadNumber				
-mms_metagenomeSequencing	sampleFilteredReadNumber				
-mms_metagenomeSequencing	ncbiProjectID	close_mapping	OmicsProcessing	ncbi_project_name	
-mms_metagenomeSequencing	analyzedBy				Exclude
-mms_metagenomeSequencing	remarks				Exclude
-mms_metagenomeSequencing	dataQF				
-mms_rawDataFiles	uid				Exclude
-mms_rawDataFiles	domainID				inherited from sls_soilCoreCollection
-mms_rawDataFiles	siteID				inherited from sls_soilCoreCollection
-mms_rawDataFiles	namedLocation				inherited from sls_soilCoreCollection
-mms_rawDataFiles	laboratoryName				inherited from mms_metagenomeSequencing
-mms_rawDataFiles	sequencingFacilityID				inherited from mms_metagenomeSequencing
-mms_rawDataFiles	startDate				
-mms_rawDataFiles	endDate				
-mms_rawDataFiles	sequencerRunID				inherited from mms_metagenomeSequencing
-mms_rawDataFiles	dnaSampleID				inherited from mms_metagenomeSequencing
-mms_rawDataFiles	dnaSampleCode				
-mms_rawDataFiles	internalLabID				
-mms_rawDataFiles	rawDataFileName	exact_mapping	DataObject	name	
-mms_rawDataFiles	rawDataFileDescription	exact_mapping	DataObject	description	
-mms_rawDataFiles	rawDataFilePath	broad_mapping	DataObject	data_object_type	
-mms_rawDataFiles	remarks				Exclude
-mms_rawDataFiles	dataQF				
+data_product	neon_table	neon_field_name	match_type	nmdc_class	nmdc_slot	static_value	notes
+DP1.10086.001	bgc_CNiso_externalSummary	uid					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyte					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyteUnits					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	sampleType					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	qaReferenceID					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyteKnownValue					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyteObservedValue					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyteAbsoluteError					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyteStandardDeviation					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	analyteMetricsCount					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	qaReportingStartDate					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	qaReportingEndDate					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	laboratoryName					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	instrument					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	testMethod					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	method					Exclude
+DP1.10086.001	bgc_CNiso_externalSummary	dataQF					Exclude
+DP1.10086.001	ntr_externalLab	uid					Exclude
+DP1.10086.001	ntr_externalLab	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	startDate					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	collectDate					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	sampleID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	sampleCode					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_externalLab	kclSampleID					inherited from ntr_internalLab
+DP1.10086.001	ntr_externalLab	kclSampleCode					inherited from ntr_internalLab
+DP1.10086.001	ntr_externalLab	sampleCondition					
+DP1.10086.001	ntr_externalLab	ammoniumNAnalysisDate					
+DP1.10086.001	ntr_externalLab	kclAmmoniumNConc	narrow_mapping	Biosample	ammonium_nitrogen.has_numeric_value		
+DP1.10086.001	ntr_externalLab	ammoniumNRepNum	narrow_mapping	Biosample	replicate_number		
+DP1.10086.001	ntr_externalLab	ammoniumNQF					
+DP1.10086.001	ntr_externalLab	ammoniumNRemarks					Exclude
+DP1.10086.001	ntr_externalLab	nitrateNitriteNAnalysisDate					
+DP1.10086.001	ntr_externalLab	kclNitrateNitriteNConc	exact_mapping	Biosample	tot_nitro_content.has_numeric_value		
+DP1.10086.001	ntr_externalLab	nitrateNitriteNRepNum	narrow_mapping	Biosample	replicate_number		
+DP1.10086.001	ntr_externalLab	nitrateNitriteNQF					
+DP1.10086.001	ntr_externalLab	nitrateNitriteNRemarks					Exclude
+DP1.10086.001	ntr_externalLab	laboratoryName					
+DP1.10086.001	ntr_externalLab	ammoniumNMethod					
+DP1.10086.001	ntr_externalLab	ammoniumNInstrument					
+DP1.10086.001	ntr_externalLab	ammoniumNAnalyzedBy					Exclude
+DP1.10086.001	ntr_externalLab	ammoniumNReviewedBy					Exclude
+DP1.10086.001	ntr_externalLab	nitrateNitriteNMethod					
+DP1.10086.001	ntr_externalLab	nitrateNitriteNInstrument					
+DP1.10086.001	ntr_externalLab	nitrateNitriteNAnalyzedBy					Exclude
+DP1.10086.001	ntr_externalLab	nitrateNitriteNReviewedBy					Exclude
+DP1.10086.001	ntr_externalLab	dataQF					
+DP1.10086.001	ntr_externalSummary	uid					Exclude
+DP1.10086.001	ntr_externalSummary	analyte					Exclude
+DP1.10086.001	ntr_externalSummary	analyteUnits					Exclude
+DP1.10086.001	ntr_externalSummary	sampleType					Exclude
+DP1.10086.001	ntr_externalSummary	qaReferenceID					Exclude
+DP1.10086.001	ntr_externalSummary	lotID					Exclude
+DP1.10086.001	ntr_externalSummary	analyteKnownValue					Exclude
+DP1.10086.001	ntr_externalSummary	analyteObservedValue					Exclude
+DP1.10086.001	ntr_externalSummary	analytePercentRecovery					Exclude
+DP1.10086.001	ntr_externalSummary	analyteStandardDeviation					Exclude
+DP1.10086.001	ntr_externalSummary	methodDetectionLimit					Exclude
+DP1.10086.001	ntr_externalSummary	analyteMetricsCount					Exclude
+DP1.10086.001	ntr_externalSummary	qaReportingStartDate					Exclude
+DP1.10086.001	ntr_externalSummary	qaReportingEndDate					Exclude
+DP1.10086.001	ntr_externalSummary	laboratoryName					Exclude
+DP1.10086.001	ntr_externalSummary	instrument					Exclude
+DP1.10086.001	ntr_externalSummary	method					Exclude
+DP1.10086.001	ntr_externalSummary	dataQF					Exclude
+DP1.10086.001	ntr_internalLab	uid					Exclude
+DP1.10086.001	ntr_internalLab	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	plotType					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	startDate					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	collectDate					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	samplingProtocolVersion					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	sampleID					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	sampleCode					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	kclSampleID					
+DP1.10086.001	ntr_internalLab	kclSampleCode					
+DP1.10086.001	ntr_internalLab	incubationPairID					
+DP1.10086.001	ntr_internalLab	nTransBoutType					inherited from sls_soilCoreCollection
+DP1.10086.001	ntr_internalLab	incubationLength	related_mapping	Biosample	collection_date_inc		NMDC requires date, NEON is in days.
+DP1.10086.001	ntr_internalLab	extractionStartDate					
+DP1.10086.001	ntr_internalLab	kclReferenceID					
+DP1.10086.001	ntr_internalLab	soilFreshMass	exact_mapping	Biosample	samp_size.has_numeric_value		
+DP1.10086.001	ntr_internalLab	kclVolume					
+DP1.10086.001	ntr_internalLab	extractionEndDate					
+DP1.10086.001	ntr_internalLab	sampleCondition					
+DP1.10086.001	ntr_internalLab	remarks					Exclude
+DP1.10086.001	ntr_internalLab	processedBy					Exclude
+DP1.10086.001	ntr_internalLab	recordedBy					Exclude
+DP1.10086.001	ntr_internalLab	dataQF					
+DP1.10086.001	ntr_internalLabBlanks	uid					Exclude
+DP1.10086.001	ntr_internalLabBlanks	domainID					Exclude
+DP1.10086.001	ntr_internalLabBlanks	siteID					Exclude
+DP1.10086.001	ntr_internalLabBlanks	extractionStartDate					Exclude
+DP1.10086.001	ntr_internalLabBlanks	extractionEndDate					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclReferenceID					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclBlank1ID					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclBlank1Code					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclBlank2ID					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclBlank2Code					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclBlank3ID					Exclude
+DP1.10086.001	ntr_internalLabBlanks	kclBlank3Code					Exclude
+DP1.10086.001	ntr_internalLabBlanks	remarks					Exclude
+DP1.10086.001	ntr_internalLabBlanks	dataQF					Exclude
+DP1.10086.001	sls_bgcSubsampling	uid					Exclude
+DP1.10086.001	sls_bgcSubsampling	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	startDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	collectDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	samplingProtocolVersion					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	horizon					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	ovenStartDate					
+DP1.10086.001	sls_bgcSubsampling	ovenEndDate					
+DP1.10086.001	sls_bgcSubsampling	sampleID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	sampleCode					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_bgcSubsampling	cnSampleID					
+DP1.10086.001	sls_bgcSubsampling	cnSampleCode					
+DP1.10086.001	sls_bgcSubsampling	bgcArchiveID					
+DP1.10086.001	sls_bgcSubsampling	bgcArchiveCode					
+DP1.10086.001	sls_bgcSubsampling	bgcArchiveMass					
+DP1.10086.001	sls_bgcSubsampling	toxicodendronPossible					
+DP1.10086.001	sls_bgcSubsampling	sampleCondition					
+DP1.10086.001	sls_bgcSubsampling	bgcRemarks					Exclude
+DP1.10086.001	sls_bgcSubsampling	processedBy					Exclude
+DP1.10086.001	sls_bgcSubsampling	bgcDataQF					
+DP1.10086.001	sls_metagenomicsPooling	uid					Exclude
+DP1.10086.001	sls_metagenomicsPooling	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_metagenomicsPooling	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_metagenomicsPooling	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_metagenomicsPooling	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_metagenomicsPooling	startDate	exact_mapping	Pooling	start_date		earliest start date of sampleIDs in genomicsPooledIDList
+DP1.10086.001	sls_metagenomicsPooling	collectDate	exact_mapping	Pooling	end_date		latest collect date of sampleIDs in genomicsPooledIDList
+DP1.10086.001	sls_metagenomicsPooling	eventID					
+DP1.10086.001	sls_metagenomicsPooling	samplingProtocolVersion	close_mapping	Pooling	protocol_link.url		inherited from sls_soilCoreCollection
+DP1.10086.001	sls_metagenomicsPooling	genomicsPooledIDList	close_mapping	Pooling	has_input		
+DP1.10086.001	sls_metagenomicsPooling	genomicsPooledIDList	related_mapping	Biosample	sample_link		genomicsPooledIDList values need to be split by "|" and prefixed with NEON: since they are IDs
+DP1.10086.001	sls_metagenomicsPooling	genomicsSampleID	exact_mapping	Pooling	has_output.id		
+DP1.10086.001	sls_metagenomicsPooling	genomicsSampleCode					
+DP1.10086.001	sls_metagenomicsPooling	sampleCondition					
+DP1.10086.001	sls_metagenomicsPooling	processedBy					Exclude
+DP1.10086.001	sls_metagenomicsPooling	remarks					Exclude
+DP1.10086.001	sls_metagenomicsPooling	genomicsDataQF					
+DP1.10086.001	sls_soilChemistry	uid					Exclude
+DP1.10086.001	sls_soilChemistry	analysisDate					
+DP1.10086.001	sls_soilChemistry	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	plotType					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	startDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	collectDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	sampleID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	sampleCode					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilChemistry	cnSampleID					
+DP1.10086.001	sls_soilChemistry	cnSampleCode					
+DP1.10086.001	sls_soilChemistry	sampleType	exact_mapping	Biosample	env_package.has_raw_value		soil
+DP1.10086.001	sls_soilChemistry	acidTreatment					
+DP1.10086.001	sls_soilChemistry	co2Trapped					
+DP1.10086.001	sls_soilChemistry	d15N					
+DP1.10086.001	sls_soilChemistry	organicd13C					
+DP1.10086.001	sls_soilChemistry	nitrogenPercent	close_mapping	Biosample	nitro.has_numeric_value		
+DP1.10086.001	sls_soilChemistry	organicCPercent	close_mapping	Biosample	org_carb.has_numeric_value		
+DP1.10086.001	sls_soilChemistry	CNratio	narrow_mapping	Biosample	carb_nitro_ratio.has_numeric_value		
+DP1.10086.001	sls_soilChemistry	cnIsotopeQF					
+DP1.10086.001	sls_soilChemistry	cnPercentQF					
+DP1.10086.001	sls_soilChemistry	isotopeAccuracyQF					
+DP1.10086.001	sls_soilChemistry	percentAccuracyQF					
+DP1.10086.001	sls_soilChemistry	analyticalRepNumber	close_mapping	Biosample	replicate_number		
+DP1.10086.001	sls_soilChemistry	remarks					Exclude
+DP1.10086.001	sls_soilChemistry	laboratoryName					Exclude
+DP1.10086.001	sls_soilChemistry	testMethod	broad_mapping	Biosample	tot_nitro_cont_meth		
+DP1.10086.001	sls_soilChemistry	testMethod	broad_mapping	Biosample	tot_org_c_meth		
+DP1.10086.001	sls_soilChemistry	instrument					
+DP1.10086.001	sls_soilChemistry	analyzedBy					Exclude
+DP1.10086.001	sls_soilChemistry	reviewedBy					Exclude
+DP1.10086.001	sls_soilChemistry	dataQF					
+DP1.10086.001	sls_soilCoreCollection	uid					Exclude
+DP1.10086.001	sls_soilCoreCollection	domainID					
+DP1.10086.001	sls_soilCoreCollection	siteID	related_mapping	Biosample	geo_loc_name		use siteID to pull location information from NEON API (Mark)
+DP1.10086.001	sls_soilCoreCollection	plotID	related_mapping	Biosample	env_broad_scale		use plotID to pull environmental triad information (Mark/Hugh)
+DP1.10086.001	sls_soilCoreCollection	namedLocation					
+DP1.10086.001	sls_soilCoreCollection	plotType					
+DP1.10086.001	sls_soilCoreCollection	nlcdClass	related_mapping	Biosample	env_broad_scale		determined by Mark/Hugh plot environment information work
+DP1.10086.001	sls_soilCoreCollection	subplotID	related_mapping	Biosample	env_broad_scale		use with plotID to pull environmental triad information (Mark/Hugh)
+DP1.10086.001	sls_soilCoreCollection	subplotID	related_mapping	Biosample	sample_link		Biosamples sharing subplotID and collectionDate are linked
+DP1.10086.001	sls_soilCoreCollection	coreCoordinateX					
+DP1.10086.001	sls_soilCoreCollection	coreCoordinateY					
+DP1.10086.001	sls_soilCoreCollection	geodeticDatum					Exclude
+DP1.10086.001	sls_soilCoreCollection	decimalLatitude	narrow_mapping	Biosample	lat_lon.latitude		Biosample.lat_lon
+DP1.10086.001	sls_soilCoreCollection	decimalLongitude	narrow_mapping	Biosample	lat_lon.longitude		Biosample.lat_lon
+DP1.10086.001	sls_soilCoreCollection	coordinateUncertainty					
+DP1.10086.001	sls_soilCoreCollection	elevation	exact_mapping	Biosample	elev		
+DP1.10086.001	sls_soilCoreCollection	elevationUncertainty					
+DP1.10086.001	sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	samp_collec_method		
+DP1.10086.001	sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	micro_biomass_meth		
+DP1.10086.001	sls_soilCoreCollection	samplingProtocolVersion	related_mapping	Biosample	water_cont_soil_meth		
+DP1.10086.001	sls_soilCoreCollection	startDate	exact_mapping	Biosample	collection_date		first value of collection_date range
+DP1.10086.001	sls_soilCoreCollection	collectDate	exact_mapping	Biosample	collection_date		last value of collection_date range
+DP1.10086.001	sls_soilCoreCollection	sampleTiming	close_mapping	Biosample	season		
+DP1.10086.001	sls_soilCoreCollection	biophysicalCriteria					
+DP1.10086.001	sls_soilCoreCollection	eventID					
+DP1.10086.001	sls_soilCoreCollection	standingWaterDepth					
+DP1.10086.001	sls_soilCoreCollection	nTransBoutType					
+DP1.10086.001	sls_soilCoreCollection	boutType					
+DP1.10086.001	sls_soilCoreCollection	samplingImpractical					
+DP1.10086.001	sls_soilCoreCollection	incubationMethod					
+DP1.10086.001	sls_soilCoreCollection	incubationCondition					
+DP1.10086.001	sls_soilCoreCollection	sampleID	exact_mapping	Biosample	samp_name		Unique per plot, per horizon, per collectDate
+DP1.10086.001	sls_soilCoreCollection	sampleCode					NEON barcode
+DP1.10086.001	sls_soilCoreCollection	toxicodendronPossible					
+DP1.10086.001	sls_soilCoreCollection	horizon	exact_mapping	Biosample	soil_horizon		Append " horizon" at the end of the horizon value
+DP1.10086.001	sls_soilCoreCollection	horizonDetails					
+DP1.10086.001	sls_soilCoreCollection	soilTemp	narrow_mapping	Biosample	temp.has_numeric_value		
+DP1.10086.001	sls_soilCoreCollection	litterDepth					
+DP1.10086.001	sls_soilCoreCollection	sampleTopDepth	close_mapping	Biosample	depth.has_maximum_numeric_value		first value of depth interval
+DP1.10086.001	sls_soilCoreCollection	sampleBottomDepth	close_mapping	Biosample	depth.has_minimum_numeric_value		last value of depth interval
+DP1.10086.001	sls_soilCoreCollection	sampleExtent					
+DP1.10086.001	sls_soilCoreCollection	soilSamplingDevice	exact_mapping	Biosample	samp_collec_device		
+DP1.10086.001	sls_soilCoreCollection	soilCoreCount					
+DP1.10086.001	sls_soilCoreCollection	geneticSampleID					related to NEON genetic sample archive process, not metagenomics
+DP1.10086.001	sls_soilCoreCollection	geneticSampleCode					
+DP1.10086.001	sls_soilCoreCollection	geneticSampleCondition					
+DP1.10086.001	sls_soilCoreCollection	geneticSamplePrepMethod					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample1ID					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample1Code					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample2ID					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample2Code					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample3ID					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample3Code					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample4ID					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample4Code					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample5ID					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSample5Code					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveSamplePrepMethod					
+DP1.10086.001	sls_soilCoreCollection	geneticArchiveContainer					
+DP1.10086.001	sls_soilCoreCollection	biomassID					
+DP1.10086.001	sls_soilCoreCollection	biomassCode					
+DP1.10086.001	sls_soilCoreCollection	biomassSampleCondition					
+DP1.10086.001	sls_soilCoreCollection	remarks					Exclude
+DP1.10086.001	sls_soilCoreCollection	collectedBy					Exclude
+DP1.10086.001	sls_soilCoreCollection	dataQF					
+DP1.10086.001	sls_soilMoisture	uid					Exclude
+DP1.10086.001	sls_soilMoisture	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	startDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	collectDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	sampleID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	sampleCode					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	moistureSampleID					
+DP1.10086.001	sls_soilMoisture	samplingProtocolVersion					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	horizon					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilMoisture	ovenStartDate					
+DP1.10086.001	sls_soilMoisture	ovenEndDate					
+DP1.10086.001	sls_soilMoisture	boatMass					
+DP1.10086.001	sls_soilMoisture	freshMassBoatMass					
+DP1.10086.001	sls_soilMoisture	dryMassBoatMass					
+DP1.10086.001	sls_soilMoisture	soilMoisture	exact_mapping	Biosample	water_content.has_numeric_value		
+DP1.10086.001	sls_soilMoisture	dryMassFraction					
+DP1.10086.001	sls_soilMoisture	sampleCondition					
+DP1.10086.001	sls_soilMoisture	smRemarks					Exclude
+DP1.10086.001	sls_soilMoisture	smMeasuredBy					Exclude
+DP1.10086.001	sls_soilMoisture	smDataQF					
+DP1.10086.001	sls_soilpH	uid					Exclude
+DP1.10086.001	sls_soilpH	domainID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	siteID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	plotID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	namedLocation					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	startDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	collectDate					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	processedDate					
+DP1.10086.001	sls_soilpH	sampleID					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	sampleCode					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	pHSampleID					
+DP1.10086.001	sls_soilpH	samplingProtocolVersion	related_mapping	Biosample	ph_meth.has_raw_value		inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	horizon					inherited from sls_soilCoreCollection
+DP1.10086.001	sls_soilpH	soilInWaterpH	narrow_mapping	Biosample	ph		
+DP1.10086.001	sls_soilpH	soilInCaClpH					
+DP1.10086.001	sls_soilpH	pHSoilInWaterMass					
+DP1.10086.001	sls_soilpH	pHWaterVol					
+DP1.10086.001	sls_soilpH	waterpHRatio					
+DP1.10086.001	sls_soilpH	pHSoilInCaClMass					
+DP1.10086.001	sls_soilpH	pHCaClVol					
+DP1.10086.001	sls_soilpH	caclpHRatio					
+DP1.10086.001	sls_soilpH	pHRemarks					Exclude
+DP1.10086.001	sls_soilpH	pHMeasuredBy					Exclude
+DP1.10086.001	sls_soilpH	pHDataQF					
+DP1.10107.001	mms_metagenomeDnaExtraction	uid					Exclude
+DP1.10107.001	mms_metagenomeDnaExtraction	domainID					inherited from sls_soilCoreCollection/Pooling
+DP1.10107.001	mms_metagenomeDnaExtraction	siteID					inherited from sls_soilCoreCollection/Pooling
+DP1.10107.001	mms_metagenomeDnaExtraction	namedLocation					inherited from sls_soilCoreCollection/Pooling
+DP1.10107.001	mms_metagenomeDnaExtraction	laboratoryName	exact_mapping	Extraction	processing_institution		
+DP1.10107.001	mms_metagenomeDnaExtraction	collectDate	close_mapping	Extraction	start_date		inherited from sls_metagenomicsPooling:collectDate
+DP1.10107.001	mms_metagenomeDnaExtraction	processedDate	exact_mapping	Extraction	end_date		
+DP1.10107.001	mms_metagenomeDnaExtraction	genomicsSampleID	exact_mapping	Extraction	has_input		
+DP1.10107.001	mms_metagenomeDnaExtraction	deprecatedVialID					
+DP1.10107.001	mms_metagenomeDnaExtraction	dnaSampleID	exact_mapping	Extraction	has_output		
+DP1.10107.001	mms_metagenomeDnaExtraction	internalLabID					
+DP1.10107.001	mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type		Exclude "marker_genes", import "metagenomics"
+DP1.10107.001	mms_metagenomeDnaExtraction	testMethod	close_mapping	Extraction	protocol_link		Document library https://data.neonscience.org/documents
+DP1.10107.001	mms_metagenomeDnaExtraction	sampleMaterial	exact_mapping	Biosample	env_package		Need more information/an example of what this looks like.
+DP1.10107.001	mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		
+DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	Extraction	dna_concentration		
+DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidQuantMethod					
+DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidPurity	related_mapping	Extraction	dna_absorb1		
+DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidRange					
+DP1.10107.001	mms_metagenomeDnaExtraction	dnaPooledStatus	narrow_mapping	Extraction	pool_dna_extracts.has_raw_value		NEON field does not look like it includes the number of extracts (NMDC includes this number in slot).
+DP1.10107.001	mms_metagenomeDnaExtraction	qaqcStatus	exact_mapping	Extraction	quality_control_report.status		
+DP1.10107.001	mms_metagenomeDnaExtraction	dnaProcessedBy					Exclude
+DP1.10107.001	mms_metagenomeDnaExtraction	remarks					Exclude
+DP1.10107.001	mms_metagenomeDnaExtraction	dataQF					
+DP1.10107.001	mms_metagenomeSequencing	uid					Exclude
+DP1.10107.001	mms_metagenomeSequencing	domainID					inherited from mms_metagenomeDnaExtraction
+DP1.10107.001	mms_metagenomeSequencing	siteID					inherited from mms_metagenomeDnaExtraction
+DP1.10107.001	mms_metagenomeSequencing	namedLocation					inherited from mms_metagenomeDnaExtraction
+DP1.10107.001	mms_metagenomeSequencing	collectDate	close_mapping	LibraryPreparation	start_date		all Neon's collectDates refer to the Pooling table collect dates.
+DP1.10107.001	mms_metagenomeSequencing	laboratoryName	exact_mapping	LibraryPreparation	processing_institution		
+DP1.10107.001	mms_metagenomeSequencing	sequencingFacilityID	close_mapping	OmicsProcessing	processing_institution		Who sequenced the sample, vs laboratoryName is who processed the sample.
+DP1.10107.001	mms_metagenomeSequencing	processedDate	exact_mapping	LibraryPreparation	end_date		
+DP1.10107.001	mms_metagenomeSequencing	dnaSampleID	exact_mapping	LibraryPreparation	has_input		inherited from mms_metagenomeDnaExtraction
+DP1.10107.001	mms_metagenomeSequencing	internalLabID					
+DP1.10107.001	mms_metagenomeSequencing	barcodeSequence					
+DP1.10107.001	mms_metagenomeSequencing	instrument_model	narrow_mapping	OmicsProcessing	instrument_name		
+DP1.10107.001	mms_metagenomeSequencing	sequencingMethod					Neon data example is "Illumina"
+DP1.10107.001	mms_metagenomeSequencing	investigation_type	close_mapping	OmicsProcessing	omics_type.term.name		
+DP1.10107.001	mms_metagenomeSequencing	sequencingConcentration					
+DP1.10107.001	mms_metagenomeSequencing	labPrepMethod	close_mapping	LibraryPreparation	protocol_link.name		LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
+DP1.10107.001	mms_metagenomeSequencing	sequencingProtocol	close_mapping	LibraryPreparation	protocol_link		LabPrepMethod and SequencingProtocol for NEON appear to be the same thing.
+DP1.10107.001	mms_metagenomeSequencing	illuminaAdapterKit	related_mapping	OmicsProcessing	pcr_primers		
+DP1.10107.001	mms_metagenomeSequencing	illuminaIndex1	broad_mapping	OmicsProcessing	pcr_primers		
+DP1.10107.001	mms_metagenomeSequencing	illuminaIndex2	broad_mapping	OmicsProcessing	pcr_primers		
+DP1.10107.001	mms_metagenomeSequencing	sequencerRunID					
+DP1.10107.001	mms_metagenomeSequencing	sampleTotalReadNumber					
+DP1.10107.001	mms_metagenomeSequencing	sampleFilteredReadNumber					
+DP1.10107.001	mms_metagenomeSequencing	ncbiProjectID	close_mapping	OmicsProcessing	ncbi_project_name		
+DP1.10107.001	mms_metagenomeSequencing	analyzedBy					Exclude
+DP1.10107.001	mms_metagenomeSequencing	remarks					Exclude
+DP1.10107.001	mms_metagenomeSequencing	dataQF					
+DP1.10107.001	mms_rawDataFiles	uid					Exclude
+DP1.10107.001	mms_rawDataFiles	domainID					inherited from sls_soilCoreCollection
+DP1.10107.001	mms_rawDataFiles	siteID					inherited from sls_soilCoreCollection
+DP1.10107.001	mms_rawDataFiles	namedLocation					inherited from sls_soilCoreCollection
+DP1.10107.001	mms_rawDataFiles	laboratoryName					inherited from mms_metagenomeSequencing
+DP1.10107.001	mms_rawDataFiles	sequencingFacilityID					inherited from mms_metagenomeSequencing
+DP1.10107.001	mms_rawDataFiles	startDate					
+DP1.10107.001	mms_rawDataFiles	endDate					
+DP1.10107.001	mms_rawDataFiles	sequencerRunID					inherited from mms_metagenomeSequencing
+DP1.10107.001	mms_rawDataFiles	dnaSampleID					inherited from mms_metagenomeSequencing
+DP1.10107.001	mms_rawDataFiles	dnaSampleCode					
+DP1.10107.001	mms_rawDataFiles	internalLabID					
+DP1.10107.001	mms_rawDataFiles	rawDataFileName	exact_mapping	OmicsProcessing	name		
+DP1.10107.001	mms_rawDataFiles	rawDataFileDescription	exact_mapping	OmicsProcessing	description		
+DP1.10107.001	mms_rawDataFiles	rawDataFilePath	broad_mapping	OmicsProcessing	data_object_type		
+DP1.10107.001	mms_rawDataFiles	remarks					Exclude
+DP1.10107.001	mms_rawDataFiles	dataQF					
+				Biosample	env_broad_scale.term.id	ENVO:00000446	
+				Biosample	env_broad_scale.term.name	terrestrial biome	
+				Biosample	env_medium.term.id	ENVO:00001998	
+				Biosample	env_medium.term.name	soil	


### PR DESCRIPTION
Some changes made to the NEON NMDC mappings TSV file:
* Added _data_product_ and _static_value_ columns to TSV file
* MIXS ENVO fields _env_broad_scale_ and _env_medium_ have static field mappings to certain ENVO terms. _env_local_scale_ will be determined at runtime
* Use dot notation, see changed TSV file for examples, to compactly represent what columns map to slots in the nested class structure for certain object types in NMDC

CC: @brynnz22 @bmeluch