### PR TITLE
update nucleicAcidConcentration and purity mappings

### DIFF
--- a/assets/misc/neon_nmdc_term_mapping.tsv
+++ b/assets/misc/neon_nmdc_term_mapping.tsv
@@ -306,9 +306,9 @@ DP1.10107.001	mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Bio
 DP1.10107.001	mms_metagenomeDnaExtraction	testMethod	close_mapping	Extraction	protocol_link.name				Document library https://data.neonscience.org/documents
 DP1.10107.001	mms_metagenomeDnaExtraction	sampleMaterial	exact_mapping	Biosample	env_package				Need more information/an example of what this looks like.
 DP1.10107.001	mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		g		
-DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	Extraction	dna_concentration		ng/uL		
+DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
 DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidQuantMethod	exact_mapping	ProcessedSample	nucleic_acid_concentration.instrument_name				Mapping added by Brynn on 06/26/2023
-DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidPurity	related_mapping	Extraction	dna_absorb1				
+DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidPurity	close_mapping	ProcessedSample	biomaterial_purity.has_numeric_value				
 DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidRange							
 DP1.10107.001	mms_metagenomeDnaExtraction	dnaPooledStatus	narrow_mapping	Extraction	pool_dna_extracts.has_raw_value				NEON field does not look like it includes the number of extracts (NMDC includes this number in slot).
 DP1.10107.001	mms_metagenomeDnaExtraction	qaqcStatus	exact_mapping	Extraction	quality_control_report.status				
@@ -440,7 +440,7 @@ DP1.20281.00	mms_swMetagenomeDnaExtraction	testMethod	exact_mapping	Extraction	p
 DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMaterial							Captured from fieldGenetic table and will map to env_package in the Biosample class.
 DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		g		
 DP1.20281.00	mms_swMetagenomeDnaExtraction	samplePercent							
-DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidConcentration	exact_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
 DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidQuantMethod							
 DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidPurity	exact_mapping	ProcessedSample	biomaterial_purity.has_numeric_value				
 DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidRange							
@@ -556,7 +556,7 @@ DP1.20279.00	mms_benthicMetagenomeDnaExtraction	sampleMass	exact_mapping	Extract
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	samplePercent					percent		
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidConcentration	exact_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidQuantMethod							
-DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidPurity	exact_mapping	ProcessedSample	biomaterial_purity				
+DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidPurity	exact_mapping	ProcessedSample	biomaterial_purity.has_numeric.value				
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidRange							
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	dnaPooledStatus	broad_mapping	ProcessedSample	pool_dna_extracts				NEON field does not look like it includes the number of extracts (NMDC includes this number in slot).
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	qaqcStatus	exact_mapping	Extraction	quality_control_report.status				


### PR DESCRIPTION
I updated the mappings for neon's `nucleicAcidPurity` and `nucliecAcidConcentration` since these were added before the schema updates were complete. Both should map to the `ProcessedSample` class now. @sujaypatil96 