### PR TITLE
remove abstract slot globally from schema

### DIFF
--- a/src/data/invalid/Study-include-abstract.yaml
+++ b/src/data/invalid/Study-include-abstract.yaml
@@ -1,68 +1,27 @@
-id: nmdc:sty-11-ab
-name: see also description, title, objective, various alternatives
-abstract: This study is about a thing.
-description: see also name, title, objective, various alternatives
-alternative_identifiers:
-  - generic:abc1
-related_identifiers: any string R1
-#emsl_proposal_identifier:
-#  - generic:abc1
-#emsl_proposal_doi: any string
-gold_study_identifiers:
-  - GOLD:Gs12345
-  - GOLD:Gs90909
-mgnify_project_identifiers:
-  - mgnify.proj:ABC123
-ecosystem: unconstrained text. should be validated against the controlled vocabulary,
-  by the sample's environmental package. would also be nice to align the CV with MIxS
-  environmental triads
-ecosystem_category: unconstrained text
-ecosystem_type: unconstrained text
-ecosystem_subtype: unconstrained text
-specific_ecosystem: unconstrained text
-principal_investigator:
-  has_raw_value: Craig Venter
-  was_generated_by: nmdc:any_string_1
-  orcid: ORCID:0000-0002-7086-765X
-  profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
-  email: jcventer@jcvi.org
-  name: J. Craig Venter
-  websites:
-    - https://www.jcvi.org/
-    - https://www.jcvi.org/about/j-craig-venter
-title: Sample Exhaustive Biosample instance. Although all of these values should pass
-  validation, that does not mean that any Biosample of any type would necessarily
-  have this particular combination of values.
-alternative_titles:
-  - any string 1
-  - any string 2
-alternative_descriptions:
-  - any string 1
-  - any string 2
-alternative_names:
-  - any string 1
-  - any string 2
-objective: This record, an instance of class Study from the nmdc-schema was had authored,
-  so that the NMDC team would have at least one instance, using all slots, with a
-  mixture of reasonable values and minimally compliant values.
-websites:
-  - https://w3id.org/nmdc
-  - https://w3id.org/linkml
-publications:
-  - any string 1
-  - any string 2
-ess_dive_datasets:
-  - any string 1
-  - any string 2
-type: any string
-relevant_protocols:
-  - any string 1
-  - any string 2
-funding_sources:
-  - any string 1
-  - any string 2
-has_credit_associations:
-  - applies_to_person:
+study_set:
+  - id: nmdc:sty-11-ab
+    name: see also description, title, objective, various alternatives
+    abstract: This study is about a thing.
+    description: see also name, title, objective, various alternatives
+    alternative_identifiers:
+      - generic:abc1
+    related_identifiers: any string R1
+    #emsl_proposal_identifier:
+    #  - generic:abc1
+    #emsl_proposal_doi: any string
+    gold_study_identifiers:
+      - GOLD:Gs12345
+      - GOLD:Gs90909
+    mgnify_project_identifiers:
+      - mgnify.proj:ABC123
+    ecosystem: unconstrained text. should be validated against the controlled vocabulary,
+      by the sample's environmental package. would also be nice to align the CV with MIxS
+      environmental triads
+    ecosystem_category: unconstrained text
+    ecosystem_type: unconstrained text
+    ecosystem_subtype: unconstrained text
+    specific_ecosystem: unconstrained text
+    principal_investigator:
       has_raw_value: Craig Venter
       was_generated_by: nmdc:any_string_1
       orcid: ORCID:0000-0002-7086-765X
@@ -72,13 +31,55 @@ has_credit_associations:
       websites:
         - https://www.jcvi.org/
         - https://www.jcvi.org/about/j-craig-venter
-    applied_roles:
-      - Supervision
-      - Conceptualization
-    applied_role: Funding acquisition
+    title: Sample Exhaustive Biosample instance. Although all of these values should pass
+      validation, that does not mean that any Biosample of any type would necessarily
+      have this particular combination of values.
+    alternative_titles:
+      - any string 1
+      - any string 2
+    alternative_descriptions:
+      - any string 1
+      - any string 2
+    alternative_names:
+      - any string 1
+      - any string 2
+    objective: This record, an instance of class Study from the nmdc-schema was had authored,
+      so that the NMDC team would have at least one instance, using all slots, with a
+      mixture of reasonable values and minimally compliant values.
+    websites:
+      - https://w3id.org/nmdc
+      - https://w3id.org/linkml
+    publications:
+      - any string 1
+      - any string 2
+    ess_dive_datasets:
+      - any string 1
+      - any string 2
     type: any string
-  - applies_to_person:
-      name: Tanja Davidsen
-    applied_roles:
-      - Investigation
-      - Supervision
+    relevant_protocols:
+      - any string 1
+      - any string 2
+    funding_sources:
+      - any string 1
+      - any string 2
+    has_credit_associations:
+      - applies_to_person:
+          has_raw_value: Craig Venter
+          was_generated_by: nmdc:any_string_1
+          orcid: ORCID:0000-0002-7086-765X
+          profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
+          email: jcventer@jcvi.org
+          name: J. Craig Venter
+          websites:
+            - https://www.jcvi.org/
+            - https://www.jcvi.org/about/j-craig-venter
+        applied_roles:
+          - Supervision
+          - Conceptualization
+        applied_role: Funding acquisition
+        type: any string
+      - applies_to_person:
+          name: Tanja Davidsen
+        applied_roles:
+          - Investigation
+          - Supervision

--- a/src/data/invalid/Study-include-abstract.yaml
+++ b/src/data/invalid/Study-include-abstract.yaml
@@ -1,0 +1,84 @@
+id: nmdc:sty-11-ab
+name: see also description, title, objective, various alternatives
+abstract: This study is about a thing.
+description: see also name, title, objective, various alternatives
+alternative_identifiers:
+  - generic:abc1
+related_identifiers: any string R1
+#emsl_proposal_identifier:
+#  - generic:abc1
+#emsl_proposal_doi: any string
+gold_study_identifiers:
+  - GOLD:Gs12345
+  - GOLD:Gs90909
+mgnify_project_identifiers:
+  - mgnify.proj:ABC123
+ecosystem: unconstrained text. should be validated against the controlled vocabulary,
+  by the sample's environmental package. would also be nice to align the CV with MIxS
+  environmental triads
+ecosystem_category: unconstrained text
+ecosystem_type: unconstrained text
+ecosystem_subtype: unconstrained text
+specific_ecosystem: unconstrained text
+principal_investigator:
+  has_raw_value: Craig Venter
+  was_generated_by: nmdc:any_string_1
+  orcid: ORCID:0000-0002-7086-765X
+  profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
+  email: jcventer@jcvi.org
+  name: J. Craig Venter
+  websites:
+    - https://www.jcvi.org/
+    - https://www.jcvi.org/about/j-craig-venter
+title: Sample Exhaustive Biosample instance. Although all of these values should pass
+  validation, that does not mean that any Biosample of any type would necessarily
+  have this particular combination of values.
+alternative_titles:
+  - any string 1
+  - any string 2
+alternative_descriptions:
+  - any string 1
+  - any string 2
+alternative_names:
+  - any string 1
+  - any string 2
+objective: This record, an instance of class Study from the nmdc-schema was had authored,
+  so that the NMDC team would have at least one instance, using all slots, with a
+  mixture of reasonable values and minimally compliant values.
+websites:
+  - https://w3id.org/nmdc
+  - https://w3id.org/linkml
+publications:
+  - any string 1
+  - any string 2
+ess_dive_datasets:
+  - any string 1
+  - any string 2
+type: any string
+relevant_protocols:
+  - any string 1
+  - any string 2
+funding_sources:
+  - any string 1
+  - any string 2
+has_credit_associations:
+  - applies_to_person:
+      has_raw_value: Craig Venter
+      was_generated_by: nmdc:any_string_1
+      orcid: ORCID:0000-0002-7086-765X
+      profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
+      email: jcventer@jcvi.org
+      name: J. Craig Venter
+      websites:
+        - https://www.jcvi.org/
+        - https://www.jcvi.org/about/j-craig-venter
+    applied_roles:
+      - Supervision
+      - Conceptualization
+    applied_role: Funding acquisition
+    type: any string
+  - applies_to_person:
+      name: Tanja Davidsen
+    applied_roles:
+      - Investigation
+      - Supervision

--- a/src/data/valid/Study-exhaustive.yaml
+++ b/src/data/valid/Study-exhaustive.yaml
@@ -43,7 +43,6 @@ alternative_descriptions:
 alternative_names:
   - any string 1
   - any string 2
-abstract: Nothing was studied.
 objective: This record, an instance of class Study from the nmdc-schema was had authored,
   so that the NMDC team would have at least one instance, using all slots, with a
   mixture of reasonable values and minimally compliant values.

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -683,13 +683,6 @@ slots:
     range: string
     description: >-
       MD5 checksum of file (pre-compressed)
-  
-  abstract:
-    range: string
-    description: >-
-      The abstract of manuscript/grant associated with the entity; i.e., a summary of the resource.
-    exact_mappings:
-      - dcterms:abstract
 
   keywords:
     range: string

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1344,7 +1344,6 @@ classes:
       ## Related IDs
       #- insdc_bioproject_identifiers
       #- insdc_sra_ena_study_identifiers
-      - abstract
       - alternative_descriptions
       - alternative_names
       - alternative_titles


### PR DESCRIPTION
I removed the `abstract` slot globally from the schema. It was only be used in the `Study` class and was not used at all in MongoDb. So it does not get confused with the `description` slot in the future, where it is interchangeable, we are removing it.