### PR TITLE
update funding_sources to be more specific

### DIFF
--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -1,0 +1,62 @@
+id: nmdc:sty-11-ab
+name: see also description, title, objective, various alternatives
+description: see also name, title, objective, various alternatives
+related_identifiers: any string R1
+#emsl_proposal_identifier:
+#  - generic:abc1
+#emsl_proposal_doi: any string
+gold_study_identifiers:
+  - GOLD:Gs12345
+  - GOLD:Gs90909
+mgnify_project_identifiers:
+  - mgnify.proj:ABC123
+ecosystem: unconstrained text. should be validated against the controlled vocabulary,
+  by the sample's environmental package. would also be nice to align the CV with MIxS
+  environmental triads
+ecosystem_category: unconstrained text
+ecosystem_type: unconstrained text
+ecosystem_subtype: unconstrained text
+specific_ecosystem: unconstrained text
+principal_investigator:
+  has_raw_value: Craig Venter
+  was_generated_by: nmdc:any_string_1
+  orcid: ORCID:0000-0002-7086-765X
+  profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
+  email: jcventer@jcvi.org
+  name: J. Craig Venter
+  websites:
+    - https://www.jcvi.org/
+    - https://www.jcvi.org/about/j-craig-venter
+title: Sample Exhaustive Biosample instance. Although all of these values should pass
+  validation, that does not mean that any Biosample of any type would necessarily
+  have this particular combination of values.
+alternative_titles:
+  - any string 1
+  - any string 2
+alternative_descriptions:
+  - any string 1
+  - any string 2
+alternative_names:
+  - any string 1
+  - any string 2
+abstract: Nothing was studied.
+objective: This record, an instance of class Study from the nmdc-schema was had authored,
+  so that the NMDC team would have at least one instance, using all slots, with a
+  mixture of reasonable values and minimally compliant values.
+websites:
+  - https://w3id.org/nmdc
+  - https://w3id.org/linkml
+publications:
+  - any string 1
+  - any string 2
+ess_dive_datasets:
+  - any string 1
+  - any string 2
+type: any string
+relevant_protocols:
+  - any string 1
+  - any string 2
+funding_sources:
+  - This is an example of a funding source with too long of a description. Funding sources should be no more than 150 characters. Any longer is unnecessary and excessive.
+  - any string 2
+

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2246,6 +2246,20 @@ slots:
   funding_sources:
     multivalued: true
     range: string
+    description: >-
+      A list of organizations, along with the award numbers, that underwrite financial support for projects of 
+      a particular type. Typically, they process applications and award funds to the chosen qualified 
+      applicants.
+    pattern: ^.{1,150}$
+    comments:
+      - Include only the name of the funding organization and the award or contract number.
+    examples:
+      - value: National Sciences Foundation Dimensions of Biodiversity (award no. 1342701)
+      - value: >-
+          U.S. Department of Energy, Office of Science, Office of Biological and Environmental Research 
+          (BER) under contract DE-AC05-00OR2275
+    close_mappings:
+      - NCIT:C39409
   applied_role:
     domain: CreditAssociation
     range: credit enum


### PR DESCRIPTION
For [microbiomedata/issues#339](https://github.com/microbiomedata/issues/issues/339), I added a description to funding_sources, comments that specify exactly what we would like to see in the value, along with two examples that [@lamccue](https://github.com/lamccue) [@mslarae13](https://github.com/mslarae13) specified were good examples. I also add closing_mappings with a value of the funding agency ncit ontology term that I primarily got the description from. Finally, I added a pattern that limits the value to 150 characters. Let me know if this is too strict.