### PR TITLE
update elev comments for Biosample slot usage

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1039,7 +1039,9 @@ classes:
         title: elevation, meters
         range: float
         comments:
-          - All elevations must be reported in meters. Provide the numerical portion only.
+          - All elevations must be reported in meters. Provide the numerical portion only. Please use 
+          https://www.advancedconverter.com/map-tools/find-altitude-by-coordinates, if needed, to help calculate
+          the evelvation based on latitude and longitude coordinates.
         examples:
           value: 100
       oxy_stat_samp:


### PR DESCRIPTION
For [issue 1053](https://github.com/microbiomedata/nmdc-schema/issues/1053), this updates the slot usage for `elev` in the Biosample class to indicate how to calculate elevation using latitude and longitude. Since this is for guidance in the submission schema, I did not update the `elev` slot globally. But let me know if it makes more sense to update it that way.