### PR TITLE
increase character limit of funding_sources to 200

### DIFF
--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -57,6 +57,6 @@ relevant_protocols:
   - any string 1
   - any string 2
 funding_sources:
-  - This is an example of a funding source with too long of a description. Funding sources should be no more than 150 characters. Any longer is unnecessary and excessive.
+  - This is an example of a funding source with too long of a description. Funding sources should be no more than 150 characters. Any longer is unnecessary and excessive. Its very very very very very very very very very long.
   - any string 2
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2245,7 +2245,7 @@ slots:
       A list of organizations, along with the award numbers, that underwrite financial support for projects of 
       a particular type. Typically, they process applications and award funds to the chosen qualified 
       applicants.
-    pattern: ^.{1,150}$
+    pattern: ^.{1,200}$
     comments:
       - Include only the name of the funding organization and the award or contract number.
     examples:


### PR DESCRIPTION
`funding_sources` needs a character limit of 200 (instead of 150) so it will not require a database migration. For issue #1078 