### PR TITLE
Issue1031 input sample mass

### DIFF
--- a/assets/misc/neon_nmdc_term_mapping.tsv
+++ b/assets/misc/neon_nmdc_term_mapping.tsv
@@ -305,7 +305,7 @@ DP1.10107.001	mms_metagenomeDnaExtraction	internalLabID
 DP1.10107.001	mms_metagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type				"Exclude ""marker_genes"", import ""metagenomics"""
 DP1.10107.001	mms_metagenomeDnaExtraction	testMethod	close_mapping	Extraction	protocol_link.name				Document library https://data.neonscience.org/documents
 DP1.10107.001	mms_metagenomeDnaExtraction	sampleMaterial	exact_mapping	Biosample	env_package				Need more information/an example of what this looks like.
-DP1.10107.001	mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		g		
+DP1.10107.001	mms_metagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	input_mass.has_numeric_value		g		
 DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
 DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidQuantMethod	exact_mapping	ProcessedSample	nucleic_acid_concentration.instrument_name				Mapping added by Brynn on 06/26/2023
 DP1.10107.001	mms_metagenomeDnaExtraction	nucleicAcidPurity	close_mapping	ProcessedSample	biomaterial_purity.has_numeric_value				
@@ -421,7 +421,7 @@ DP1.20281.00	mms_swMetagenomeDnaExtraction	internalLabID
 DP1.20281.00	mms_swMetagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type				"Exclude ""marker_genes"", import ""metagenomics"""
 DP1.20281.00	mms_swMetagenomeDnaExtraction	testMethod	exact_mapping	Extraction	protocol_link.name				Document library https://data.neonscience.org/documents
 DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMaterial							Captured from fieldGenetic table and will map to env_package in the Biosample class.
-DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		g		
+DP1.20281.00	mms_swMetagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	input_mass.has_numeric_value		g		
 DP1.20281.00	mms_swMetagenomeDnaExtraction	samplePercent							
 DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidConcentration	broad_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
 DP1.20281.00	mms_swMetagenomeDnaExtraction	nucleicAcidQuantMethod							
@@ -518,7 +518,7 @@ DP1.20279.00	mms_benthicMetagenomeDnaExtraction	internalLabID
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	sequenceAnalysisType	exact_mapping	Biosample	analysis_type				"Exclude ""marker_genes"", import ""metagenomics"""
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	testMethod	exact_mapping	Extraction	protocol_link.name				Document library https://data.neonscience.org/documents
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	sampleMaterial							Inherited from amb_fieldParent
-DP1.20279.00	mms_benthicMetagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	sample_mass.has_numeric_value		g		
+DP1.20279.00	mms_benthicMetagenomeDnaExtraction	sampleMass	exact_mapping	Extraction	input_mass.has_numeric_value		g		
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	samplePercent					percent		
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidConcentration	exact_mapping	ProcessedSample	nucleic_acid_concentration.has_numeric_value		ng/uL		
 DP1.20279.00	mms_benthicMetagenomeDnaExtraction	nucleicAcidQuantMethod							

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -35,7 +35,7 @@ def migrate_studies_7_7_2_to_7_8(retrieved_study):
         del retrieved_study["doi"]
     return retrieved_study
 
-def migrate_extractions_7_8_to_NEXT(retrieved_extraction):
+def migrate_extractions_7_8_0_to_NEXT(retrieved_extraction):
     logger.info(f"Starting migration of {retrieved_extraction['id']}")
 
     # change slot name from sample_mass to input_mass
@@ -138,7 +138,7 @@ def main(schema_path, input_path, output_path):
         if tdk == "extraction_set":
             logger.info(f"Would start {tdk}-specific migrations")
             for current_extraction in tdv:
-                migrate_extractions_7_8_to_NEXT(current_extraction)
+                migrate_extractions_7_8_0_to_NEXT(current_extraction)
 
     logger.info(f"Saving migrated data to {output_path}")
     with open(output_path, "w") as f:

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -63,7 +63,7 @@ def is_valid_curie(curie_string):
 
 def normalize_curie(curie_string, forced_prefix="nmdc"):
     # Remove any characters that are not allowed in a CURIE
-    curie_cleaned = re.sub(r'[^a-zA-Z0-9:_.-]', '', curie_string)
+    curie_cleaned = re.sub(r'[^a-zA-Z0-9:_./-]', '', curie_string)
 
     # Add the "nmdc" prefix if no prefix is present
     if ':' not in curie_cleaned:

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -35,6 +35,13 @@ def migrate_studies_7_7_2_to_7_8(retrieved_study):
         del retrieved_study["doi"]
     return retrieved_study
 
+def migrate_extractions_7_9_to_NEXT(retrieved_extraction):
+    logger.info(f"Starting migration of {retrieved_extraction['id']}")
+
+    # change slot name from sample_mass to input_mass
+    if "sample_mass" in retrieved_extraction:
+        retrieved_extraction['input_mass'] = retrieved_extraction.pop('sample_mass')
+        return retrieved_extraction
 
 def check_and_normalize_one_curie(curie_string):
     if not is_valid_curie(curie_string):
@@ -128,6 +135,10 @@ def main(schema_path, input_path, output_path):
             logger.info(f"Would start {tdk}-specific migrations")
             for current_study in tdv:
                 migrate_studies_7_7_2_to_7_8(current_study)
+        if tdk == "extraction_set":
+            logger.info(f"Would start {tdk}-specific migrations")
+            for current_extraction in tdv:
+                migrate_extractions_7_9_to_NEXT(current_extraction)
 
     logger.info(f"Saving migrated data to {output_path}")
     with open(output_path, "w") as f:

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -41,7 +41,7 @@ def migrate_extractions_7_8_to_NEXT(retrieved_extraction):
     # change slot name from sample_mass to input_mass
     if "sample_mass" in retrieved_extraction:
         retrieved_extraction['input_mass'] = retrieved_extraction.pop('sample_mass')
-        return retrieved_extraction
+    return retrieved_extraction
 
 def check_and_normalize_one_curie(curie_string):
     if not is_valid_curie(curie_string):

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -35,7 +35,7 @@ def migrate_studies_7_7_2_to_7_8(retrieved_study):
         del retrieved_study["doi"]
     return retrieved_study
 
-def migrate_extractions_7_9_to_NEXT(retrieved_extraction):
+def migrate_extractions_7_8_to_NEXT(retrieved_extraction):
     logger.info(f"Starting migration of {retrieved_extraction['id']}")
 
     # change slot name from sample_mass to input_mass
@@ -138,7 +138,7 @@ def main(schema_path, input_path, output_path):
         if tdk == "extraction_set":
             logger.info(f"Would start {tdk}-specific migrations")
             for current_extraction in tdv:
-                migrate_extractions_7_9_to_NEXT(current_extraction)
+                migrate_extractions_7_8_to_NEXT(current_extraction)
 
     logger.info(f"Saving migrated data to {output_path}")
     with open(output_path, "w") as f:

--- a/src/data/invalid/Database-Extraction-invalid-sample_mass.yaml
+++ b/src/data/invalid/Database-Extraction-invalid-sample_mass.yaml
@@ -1,0 +1,22 @@
+extraction_set:
+  - id: nmdc:extrp-99-abcdef
+    name: DNA extraction of NEON sample WREF_072-O-20190618-COMP
+    description: DNA extraction of NEON sample WREF_072-O-20190618-COMP using SOP BMI_dnaExtractionSOP_v7
+    has_input:
+      - generic:xxx
+    has_output:
+      - generic:xxx
+    processing_institution: Battelle
+    protocol_link:
+      name: BMI_dnaExtractionSOP_v7
+      url: https://data.neonscience.org/documents/10179/2431540/BMI_dnaExtractionSOP_v7/61204962-bb01-a0b9-3354-ccdaab5132c3
+    start_date: "2019-11-08"
+    end_date: "2019-11-08"
+    sample_mass:
+      has_numeric_value: 0.25
+      has_unit: gram 
+    quality_control_report:
+      status: pass
+    extraction_method: phenol/chloroform extraction
+    extraction_target: DNA
+    

--- a/src/data/valid/Database-extraction_set-exhaustive.yaml
+++ b/src/data/valid/Database-extraction_set-exhaustive.yaml
@@ -21,8 +21,8 @@ extraction_set:
     # extraction_date: "2019-11-08"
     start_date: "2019-11-08"
     end_date: "2019-11-08"
-    #range for sample_mass should be QuantityValue for more generic modeling. ie soil will be in gram, water in gram/ml
-    sample_mass: #http://purl.obolibrary.org/obo/MS_1000004
+    #range for input_mass should be QuantityValue for more generic modeling. ie soil will be in gram, water in gram/ml
+    input_mass: #http://purl.obolibrary.org/obo/MS_1000004
       has_numeric_value: 0.25
       has_unit: gram #http://purl.obolibrary.org/obo/UO_0000021
     #based on qaqc criteria for a given process does the output 'Pass' or 'Failed' https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Fdata_3914&lang=en&viewMode=All&siblings=false

--- a/src/data/valid/Database-nucleic-extraction.yaml
+++ b/src/data/valid/Database-nucleic-extraction.yaml
@@ -31,7 +31,7 @@ extraction_set:
     start_date: '2019-11-08'
     end_date: '2019-11-08'
 
-    sample_mass: #http://purl.obolibrary.org/obo/MS_1000004
+    input_mass: #http://purl.obolibrary.org/obo/MS_1000004
       has_numeric_value: 0.25
       has_unit: gram #http://purl.obolibrary.org/obo/UO_0000021
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -175,7 +175,7 @@ classes:
       - processing_institution
       - protocol_link
       - quality_control_report
-      - sample_mass
+      - input_mass
     slot_usage:
       has_input:
         required: true
@@ -2034,7 +2034,16 @@ slots:
     range: integer
     exact_mappings:
       - OBI:0002475
-  sample_mass:
+
+  input_mass:
+    title: sample mass used
+    description: Total mass of sample used in activity.
+    aliases: 
+      - sample mass
+      - sample weight
+    exact_mappings:
+      - MS:1000004
+      - AFO:/result#AFR_0001982
     range: QuantityValue
 
   library_type:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2043,7 +2043,6 @@ slots:
       - sample weight
     exact_mappings:
       - MS:1000004
-      - AFO:/result#AFR_0001982
     range: QuantityValue
 
   library_type:


### PR DESCRIPTION
Issue: https://github.com/microbiomedata/nmdc-schema/issues/1031

Updated the `sample_mass` slot to be called `input_mass` as it is being used in the `Extraction` class (a process) in order to clarify if the mass is consumed or generated. This process involved:

- updating the `nmdc.yaml` file to change slot name and add additional annotations.
- updating the `neon_nmdc_term_mapping.tsv` file to change the mapping to `input_mass`. Changed from `sample_mass`
- updating the valid `extraction_set` example data files to validate with the newly named `input_mass` slot
- Including a new invalid `extraction_set` sample data file with the old slot name of `sample_mass`
- Updating the `migration_recursion.py` file to include a function for migrating the `extraction_set` collections to change the slot name. Note that the function uses the word `NEXT` in the name to specify the next version number, which will need to be updated when we know the release version.
- Copy and paste Eric's jupyter notebook in the `nmdc-runtime` repo and add migration changes to this migration. See PR https://github.com/microbiomedata/nmdc-runtime/pull/305