### PR TITLE
Deprecated emsl_proect_dois and removed from Study class usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versioning for this project is based on [Semantic Versioning](https://semver.org
 - Remove incorrect description of `lat_lon` slot
 - Remove non-monotonic range override on `used` slot of `MetaproteomicsAnalysisActivity` class.
 
+### Removed
+
+- `emsl_project_dois` slot from `Study` class usage. Added deprecation to global slot. 
+
 ## 8.0.0 - 2023-09-21
 
 ### Overhaul of the definition and usage of CURIe prefixes. 

--- a/src/data/invalid/Study-include-emsl_project_dois.yaml
+++ b/src/data/invalid/Study-include-emsl_project_dois.yaml
@@ -1,0 +1,85 @@
+id: nmdc:sty-11-ab
+name: see also description, title, objective, various alternatives
+emsl_project_dois: 
+  - "doi:10.25585/1487763"
+description: see also name, title, objective, various alternatives
+alternative_identifiers:
+  - generic:abc1
+related_identifiers: any string R1
+#emsl_proposal_identifier:
+#  - generic:abc1
+#emsl_proposal_doi: any string
+gold_study_identifiers:
+  - gold:Gs12345
+  - gold:Gs90909
+mgnify_project_identifiers:
+  - mgnify.proj:ABC123
+ecosystem: unconstrained text. should be validated against the controlled vocabulary,
+  by the sample's environmental package. would also be nice to align the CV with MIxS
+  environmental triads
+ecosystem_category: unconstrained text
+ecosystem_type: unconstrained text
+ecosystem_subtype: unconstrained text
+specific_ecosystem: unconstrained text
+principal_investigator:
+  has_raw_value: Craig Venter
+  was_generated_by: nmdc:any_string_1
+  orcid: ORCID:0000-0002-7086-765X
+  profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
+  email: jcventer@jcvi.org
+  name: J. Craig Venter
+  websites:
+    - https://www.jcvi.org/
+    - https://www.jcvi.org/about/j-craig-venter
+title: Sample Exhaustive Biosample instance. Although all of these values should pass
+  validation, that does not mean that any Biosample of any type would necessarily
+  have this particular combination of values.
+alternative_titles:
+  - any string 1
+  - any string 2
+alternative_descriptions:
+  - any string 1
+  - any string 2
+alternative_names:
+  - any string 1
+  - any string 2
+objective: This record, an instance of class Study from the nmdc-schema was had authored,
+  so that the NMDC team would have at least one instance, using all slots, with a
+  mixture of reasonable values and minimally compliant values.
+websites:
+  - https://w3id.org/nmdc
+  - https://w3id.org/linkml
+publications:
+  - any string 1
+  - any string 2
+ess_dive_datasets:
+  - any string 1
+  - any string 2
+type: any string
+relevant_protocols:
+  - any string 1
+  - any string 2
+funding_sources:
+  - any string 1
+  - any string 2
+has_credit_associations:
+  - applies_to_person:
+      has_raw_value: Craig Venter
+      was_generated_by: nmdc:any_string_1
+      orcid: ORCID:0000-0002-7086-765X
+      profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
+      email: jcventer@jcvi.org
+      name: J. Craig Venter
+      websites:
+        - https://www.jcvi.org/
+        - https://www.jcvi.org/about/j-craig-venter
+    applied_roles:
+      - Supervision
+      - Conceptualization
+    applied_role: Funding acquisition
+    type: any string
+  - applies_to_person:
+      name: Tanja Davidsen
+    applied_roles:
+      - Investigation
+      - Supervision

--- a/src/data/valid/Database-study_set-emsl_project_doi.yaml
+++ b/src/data/valid/Database-study_set-emsl_project_doi.yaml
@@ -1,9 +1,0 @@
-study_set:
-  - id: nmdc:sty-11-ab
-    #prefix for https://doi.org/ is registered at identifiers.org and bioregisty.io as 'doi'
-    #ie https://bioregistry.io/doi:10.46936/intm.proj.2021.60141/60000423 resolves to https://doi.org/10.46936/intm.proj.2021.60141/60000423
-    # which then resolves to https://www.osti.gov/award-doi-service/biblio/10.46936/intm.proj.2021.60141/60000423
-    #per EMSL NEXUS team suggested terminology is emsl_project_doi not emsl_proposal_doi
-    emsl_project_dois:
-      - doi:10.46936/intm.proj.2021.60141/60000423
-    study_category: research_study

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1390,7 +1390,7 @@ classes:
         data submitted to ENA
     
     slots:
-      - emsl_project_dois
+      ## emsl_project_dois
 
       - neon_study_identifiers
       - jgi_portal_study_identifiers
@@ -2714,22 +2714,6 @@ slots:
   add_date:
     range: string
     description: The date on which the information was added to the database.
-
-  # moving emsl_project_dois from external_identifiers.yaml to nmdc.yaml and re-rooting in `dois` with new pattern
-  emsl_project_dois:
-    is_a: dois
-    #    is_a: study_identifiers
-    mixins:
-      - emsl_identifiers
-    title: EMSL Project DOI
-    description: One or more DOIs that links to an EMSL Research Campaign page.
-    examples:
-      - value: doi:10.46936/intm.proj.2021.6014
-        description:
-          emsl_project_dois link to the document outlining the EMSL specific award for the project.
-          Should not be used to link to datasets or publications.
-    todos:
-      - Make as a subproperty of award_dois
 
   mod_date:
     range: string

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2728,8 +2728,6 @@ slots:
         description:
           emsl_project_dois link to the document outlining the EMSL specific award for the project.
           Should not be used to link to datasets or publications.
-    todos:
-      - Make as a subproperty of award_dois
     deprecated_element_has_exact_replacement: nmdc:award_dois
   mod_date:
     range: string

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2715,6 +2715,23 @@ slots:
     range: string
     description: The date on which the information was added to the database.
 
+  # moving emsl_project_dois from external_identifiers.yaml to nmdc.yaml and re-rooting in `dois` with new pattern
+  emsl_project_dois:
+    is_a: dois
+    #    is_a: study_identifiers
+    mixins:
+      - emsl_identifiers
+    title: EMSL Project DOI
+    description: One or more DOIs that links to an EMSL Research Campaign page.
+    examples:
+      - value: doi:10.46936/intm.proj.2021.6014
+        description:
+          emsl_project_dois link to the document outlining the EMSL specific award for the project.
+          Should not be used to link to datasets or publications.
+    todos:
+      - Make as a subproperty of award_dois
+    deprecated: deprecated on 10/05/2023. Used by `Study` class and not needed moving forward. All emsl_project_dois are listed under the slot award_dois.
+
   mod_date:
     range: string
     description: The last date on which the database information was modified.

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1390,7 +1390,7 @@ classes:
         data submitted to ENA
     
     slots:
-      ## emsl_project_dois
+      ## emsl_project_dois - slot was deprecated 10/04/2023
 
       - neon_study_identifiers
       - jgi_portal_study_identifiers

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2730,8 +2730,7 @@ slots:
           Should not be used to link to datasets or publications.
     todos:
       - Make as a subproperty of award_dois
-    deprecated: deprecated on 10/05/2023. Used by `Study` class and not needed moving forward. All emsl_project_dois are listed under the slot award_dois.
-
+    deprecated_element_has_exact_replacement: nmdc:award_dois
   mod_date:
     range: string
     description: The last date on which the database information was modified.


### PR DESCRIPTION
Addressing https://github.com/microbiomedata/issues/issues/405, (also involves this issue https://github.com/microbiomedata/issues/issues/404) this PR removed the slot `emsl_project_dois` from the schema since `award_dois` is being used generally to capture this information. 

Keeping as a draft until approved by everyone in the metadata meeting.