### PR TITLE
Finalize name of class that migrates data from `8.0.0` to `8.1.0`

### DIFF
--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -17,7 +17,7 @@ curie_pattern = r'^[a-zA-Z_][a-zA-Z0-9_-]*:[a-zA-Z0-9_][a-zA-Z0-9_.-]*$'
 
 
 class MigratorBase:
-    """Base class containing properties and methods useful to its descendants."""
+    """Base class containing properties and methods related to migrating data between schema versions."""
 
     def __init__(self):
         self.forced_prefix = None
@@ -93,7 +93,7 @@ class MigratorBase:
 
 
 class Migrator_from_7_7_2_to_7_8_0(MigratorBase):
-    """Methods related to migrating documents from schema 7.7.2 to 7.8.0"""
+    """Migrates data from schema 7.7.2 to 7.8.0"""
 
     def __init__(self) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -118,7 +118,7 @@ class Migrator_from_7_7_2_to_7_8_0(MigratorBase):
 
 
 class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
-    """Methods related to migrating documents from schema 7.8.0 to 8.0.0"""
+    """Migrates data from schema 7.8.0 to 8.0.0"""
 
     def __init__(self) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -193,6 +193,8 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
 
 class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
     """
+    Migrates data from schema A.B.C to X.Y.Z
+
     TUTORIAL: This is an example of a "migrator" class.
               It was designed for use during developer training and
               to serve as a template for production "migrator" classes.
@@ -266,7 +268,9 @@ class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
         return study
 
 
-class Migrator_from_8_0_0_to_research_study_study_category(MigratorBase):
+class Migrator_from_8_0_0_to_8_1_0(MigratorBase):
+    """Migrates data from schema 8.0.0 to 8.1.0"""
+
     def __init__(self) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
 
@@ -301,7 +305,7 @@ def main(schema_path, input_path, output_path, salvage_prefix):
     See source code for initial and final schema versions.
     """
 
-    migrator = Migrator_from_8_0_0_to_research_study_study_category()
+    migrator = Migrator_from_8_0_0_to_8_1_0()
     migrator.forced_prefix = salvage_prefix
 
     # Load the schema and determine which of its slots we can migrate.

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -92,6 +92,83 @@ class MigratorBase:
         return data
 
 
+class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
+    """
+    Migrates data from schema A.B.C to X.Y.Z
+
+    TUTORIAL: This is an example of a "migrator" class.
+              It was designed for use during developer training and
+              to serve as a template for production "migrator" classes.
+    """
+
+    def __init__(self) -> None:
+        """
+        TUTORIAL: This is the "constructor" function of the class.
+                  As is true about the "constructor" function of any class,
+                  it runs whenever that class is instantiated, and its job
+                  is to initialize the newly-created instance of that class.
+                  
+                  When this "constructor" function runs, it does two things:
+                  1. It invokes the base class's "constructor" function; and
+                  2. It populates a dictionary that keeps track of which
+                     transformation functions will be applied to objects
+                     from which collections. You can think of this as the
+                     "agenda", "itinerary", "plan", or "registry" of
+                     transformations that make up this migration. As
+                     security guards at marathons say, "If it ain't
+                     part of the plan, it ain't gonna be ran."
+
+             -->  As part of creating a new "migration" class, you will
+                  populate its "agenda."
+        """
+
+        # Invoke the base class's "constructor" function.
+        super().__init__()
+
+        # Populate the "collection-to-transformers" map for this specific migration.
+        self.agenda = dict(
+            study_set=[self.allow_multiple_names],
+        )
+
+    def allow_multiple_names(self, study: dict) -> dict:
+        """
+        TUTORIAL: This is an example "transformation" function within the class.
+                  Its jobs is to transform a dictionary that conforms to the
+                  initial schema version (in this case, version "A.B.C"), into one
+                  that conforms to the target schema version (in this case,
+                  version "X.Y.Z"). That might involve adding a field,
+                  converting a string into a list of strings, etc.
+                  
+                  When this "transformation" function runs, it does three things:
+                  1. It accepts a single dictionary as a parameter.
+                  2. It transforms that dictionary.
+                  3. It returns the transformed dictionary.
+
+              --> As part of creating a new "migration" class, you will
+                  typically implement one or more "transformation" functions.
+                  You will also add them to the "agenda" of the class.
+        """
+
+        logger.info(f"Transforming study having id: {study['id']}")  # optional log message
+
+        # Transform the dictionary.
+        #
+        # TUTORIAL: In this example scenario, I am pretending that:
+        #           1. In schema version "A.B.C", the `Study` class has a `name` slot,
+        #              which contain a single string.
+        #           2. In schema version "X.Y.Z", the `Study` class no longer has that
+        #              `name` slot. Instead, it has a `names` slot, which contains
+        #              a list of strings.
+        #
+        original_name = study["name"]  # preserve the original value
+        study["names"] = []  # create a new key, whose value is an empty list of names
+        study["names"].append(original_name)  # add the original value to that list
+        del study["name"]  # delete the obsolete key
+
+        # Return the transformed dictionary.
+        return study
+
+
 class Migrator_from_7_7_2_to_7_8_0(MigratorBase):
     """Migrates data from schema 7.7.2 to 7.8.0"""
 
@@ -188,83 +265,6 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
             study[field_name] = self.standardize_letter_casing_of_gold_identifiers(study[field_name])
         else:
             study[field_name] = []
-        return study
-
-
-class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
-    """
-    Migrates data from schema A.B.C to X.Y.Z
-
-    TUTORIAL: This is an example of a "migrator" class.
-              It was designed for use during developer training and
-              to serve as a template for production "migrator" classes.
-    """
-
-    def __init__(self) -> None:
-        """
-        TUTORIAL: This is the "constructor" function of the class.
-                  As is true about the "constructor" function of any class,
-                  it runs whenever that class is instantiated, and its job
-                  is to initialize the newly-created instance of that class.
-                  
-                  When this "constructor" function runs, it does two things:
-                  1. It invokes the base class's "constructor" function; and
-                  2. It populates a dictionary that keeps track of which
-                     transformation functions will be applied to objects
-                     from which collections. You can think of this as the
-                     "agenda", "itinerary", "plan", or "registry" of
-                     transformations that make up this migration. As
-                     security guards at marathons say, "If it ain't
-                     part of the plan, it ain't gonna be ran."
-
-             -->  As part of creating a new "migration" class, you will
-                  populate its "agenda."
-        """
-
-        # Invoke the base class's "constructor" function.
-        super().__init__()
-
-        # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
-            study_set=[self.allow_multiple_names],
-        )
-
-    def allow_multiple_names(self, study: dict) -> dict:
-        """
-        TUTORIAL: This is an example "transformation" function within the class.
-                  Its jobs is to transform a dictionary that conforms to the
-                  initial schema version (in this case, version "A.B.C"), into one
-                  that conforms to the target schema version (in this case,
-                  version "X.Y.Z"). That might involve adding a field,
-                  converting a string into a list of strings, etc.
-                  
-                  When this "transformation" function runs, it does three things:
-                  1. It accepts a single dictionary as a parameter.
-                  2. It transforms that dictionary.
-                  3. It returns the transformed dictionary.
-
-              --> As part of creating a new "migration" class, you will
-                  typically implement one or more "transformation" functions.
-                  You will also add them to the "agenda" of the class.
-        """
-
-        logger.info(f"Transforming study having id: {study['id']}")  # optional log message
-
-        # Transform the dictionary.
-        #
-        # TUTORIAL: In this example scenario, I am pretending that:
-        #           1. In schema version "A.B.C", the `Study` class has a `name` slot,
-        #              which contain a single string.
-        #           2. In schema version "X.Y.Z", the `Study` class no longer has that
-        #              `name` slot. Instead, it has a `names` slot, which contains
-        #              a list of strings.
-        #
-        original_name = study["name"]  # preserve the original value
-        study["names"] = []  # create a new key, whose value is an empty list of names
-        study["names"].append(original_name)  # add the original value to that list
-        del study["name"]  # delete the obsolete key
-
-        # Return the transformed dictionary.
         return study
 
 


### PR DESCRIPTION
### Summary of changes

- Renamed migration class to indicate the target schema version
- Moved example (tutorial) migration class above all the real ones (so it doesn't interrupt the reader's flow, once they've started reading the real ones). No changes to this code -- just relocation.
- Simplified docstrings of migration classes