### PR TITLE
Fix issue where NMDC logo image would not appear on PyPI page and was distorted on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="images/nmdc_logo_long.jpeg" width="100" height="40"/>
+    <img src="https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/images/nmdc_logo_long.jpeg" width="100" height="40"/>
 </p>
 
 # National Microbiome Data Collaborative Schema

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/images/nmdc_logo_long.jpeg" width="100" height="40"/>
+    <img src="https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/images/nmdc_logo_long.jpeg" width="119" height="40"/>
 </p>
 
 # National Microbiome Data Collaborative Schema


### PR DESCRIPTION
### Summary of changes

- Replaced relative image URL with absolute URL (required by PyPI, according to [this Stack Overflow answer](https://stackoverflow.com/a/46875147) and other unofficial sources—I don't see the topic addressed in the official [PyPI Help](https://pypi.org/help/))
- Updated displayed width of image so the dimensions with which the image is displayed are closer to the dimensions of the underlying image file, which reduces visual distortion

Fixes #1293 