### PR TITLE
include 'umbrella' in part_of Study slot usage definition for clarity

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1509,7 +1509,8 @@ classes:
       #        description: The DOI for the EMSL awarded study that relates to the NMDC submitted study
       part_of:
         description: Links a study or consortium to a parent (or umbrella) study or consortium.
-        comments: Value is the id of the umbrella study or consortium.
+        comments: 
+          - Value is the id of the umbrella study or consortium.
         range: Study
     exact_mappings:
       - OBI:0000066

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1508,8 +1508,8 @@ classes:
       #      emsl_proposal_doi:
       #        description: The DOI for the EMSL awarded study that relates to the NMDC submitted study
       part_of:
-        description: Links a study or consortium to a parent study or consortium.
-        comments: Value is the id of the parent study or consortium.
+        description: Links a study or consortium to a parent (or umbrella) study or consortium.
+        comments: Value is the id of the umbrella study or consortium.
         range: Study
     exact_mappings:
       - OBI:0000066


### PR DESCRIPTION
Regarding https://github.com/microbiomedata/nmdc-schema/issues/1170, I added "umbrella" to the `slot_usage` of the `part_of` slot for the `Study` class. 