### PR TITLE
Fix broken URI links on enum documentation pages

### DIFF
--- a/src/doc-templates/common_metadata.md.jinja2
+++ b/src/doc-templates/common_metadata.md.jinja2
@@ -1,0 +1,78 @@
+{% if element.aliases %}
+## Aliases
+
+{% for alias in element.aliases %}
+* {{ alias }}
+{%- endfor %}
+{% endif %}
+
+
+{% if element.examples %}
+## Examples
+
+| Value |
+| --- |
+{% for x in element.examples -%}
+| {{ x.value }} |
+{% endfor %}
+{% endif -%}
+
+{% if element.comments -%}
+## Comments
+
+{% for x in element.comments -%}
+* {{x}}
+{% endfor %}
+{% endif -%}
+
+{% if element.todos -%}
+## TODOs
+
+{% for x in element.todos -%}
+* {{x}}
+{% endfor %}
+{% endif -%}
+
+{% if element.see_also -%}
+## See Also
+
+{% for x in element.see_also -%}
+* {{ gen.uri_link(x) }}
+{% endfor %}
+{% endif -%}
+
+## Identifier and Mapping Information
+
+{% if element.id_prefixes %}
+### Valid ID Prefixes
+
+Instances of this class *should* have identifiers with one of the following prefixes:
+{% for p in element.id_prefixes %}
+* {{p}}
+{% endfor %}
+
+{% endif %}
+
+
+{% if element.annotations %}
+### Annotations
+
+| property | value |
+| --- | --- |
+{% for a in element.annotations -%}
+{%- if a|string|first != '_' -%}
+| {{ a }} | {{ element.annotations[a].value }} |
+{%- endif -%}
+{% endfor %}
+{% endif %}
+
+{% if element.from_schema or element.imported_from %}
+### Schema Source
+
+{% if element.from_schema %}
+* from schema: {{ element.from_schema }}
+{% endif %}
+{% if element.imported_from %}
+* imported from: {{ element.imported_from }}
+{% endif %}
+{% endif %}

--- a/src/doc-templates/enum.md.jinja2
+++ b/src/doc-templates/enum.md.jinja2
@@ -1,0 +1,43 @@
+# Enum: {{ gen.name(element) }}
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+URI: {{ gen.link(element) }}
+
+{% if element.permissible_values -%}
+## Permissible Values
+
+| Value | Meaning | Description |
+| --- | --- | --- |
+{% for pv in element.permissible_values.values() -%}
+| {{pv.text}} | {{pv.meaning}} | {{pv.description|enshorten}} |
+{% endfor %}
+{% else %}
+_This is a dynamic enum_
+{% endif %}
+
+{% set slots_for_enum = schemaview.get_slots_by_enum(element.name) %}
+{% if slots_for_enum is defined and slots_for_enum|length > 0 -%}
+## Slots
+
+| Name | Description |
+| ---  | --- |
+{% for s in schemaview.get_slots_by_enum(element.name) -%}
+| {{gen.link(s)}} | {{s.description|enshorten}} |
+{% endfor %}
+{% endif %}
+
+{% include "common_metadata.md.jinja2" %}
+
+## LinkML Source
+
+<details>
+```yaml
+{{gen.yaml(element)}}
+```
+</details>

--- a/src/doc-templates/subset.md.jinja2
+++ b/src/doc-templates/subset.md.jinja2
@@ -1,0 +1,106 @@
+# Subset: {{ gen.name(element) }}
+
+{%- if header -%}
+{{ header }}
+{%- endif -%}
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+URI: {{ gen.link(element) }}
+
+{% include "common_metadata.md.jinja2" %}
+
+{% set classes_in_subset = [] %}
+{% set slots_in_subset = [] %}
+{% set enums_in_subset = [] %}
+
+{# Collect classes, slots, and enumerations in subset #}
+{% for c in gen.all_class_objects() %}
+    {%- if element.name in c.in_subset %}
+        {% set _ = classes_in_subset.append(c) %}
+    {%- endif %}
+{% endfor %}
+
+{% for s in gen.all_slot_objects() %}
+    {%- if element.name in s.in_subset %}
+        {% set _ = slots_in_subset.append(s) %}
+    {%- endif %}
+{% endfor %}
+
+{% for e in schemaview.all_enums().values() %}
+    {%- if element.name in e.in_subset %}
+        {% set _ = enums_in_subset.append(e) %}
+    {%- endif %}
+{% endfor %}
+
+{% if classes_in_subset %}
+## Classes in subset
+
+| Class | Description |
+| --- | --- |
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
+{%- if element.name in c.in_subset -%}
+| {{gen.link(c)}} | {{c.description|enshorten}} |
+{% endif -%}
+{% endfor %}
+
+{% for c in gen.all_class_objects()|sort(attribute=sort_by) -%}
+{%- if element.name in c.in_subset -%}
+### {{ gen.name(c) }}
+
+{{c.description}}
+
+{%- set filtered_slots = [] -%}
+
+{%- for s in induced_slots|sort(attribute=sort_by) -%}
+    {%- if element.name in s.in_subset or element.name in schemaview.get_slot(s.name).in_subset -%}
+        {% set _ = filtered_slots.append(s) %}
+    {%- endif -%}
+{%- endfor %}
+
+{%- if filtered_slots|length > 0 -%}
+| Name | Cardinality and Range  | Description  |
+| ---  | ---  | --- |
+{% for s in filtered_slots -%}
+| {{gen.link(s)}} | {{ gen.cardinality(s) }} <br/> {{gen.link(s.range)}}  | {{s.description|enshorten}} {% if s.identifier %}**identifier**{% endif %}  |
+{% endfor %}
+{%- endif %}
+
+
+{%- endif %}
+{% endfor %}
+
+{%- endif %}
+
+
+{% if slots_in_subset %}
+## Slots in subset
+
+| Slot | Description |
+| --- | --- |
+{% for s in slots_in_subset|sort(attribute=sort_by) -%}
+{%- if element.name in s.in_subset -%}
+| {{ gen.link(s) }} | {{ s.description|enshorten }} |
+{%- endif %}
+{% endfor %}
+
+{%- endif %}
+
+
+{% if enums_in_subset %}
+## Enumerations in subset
+
+| Enumeration | Description |
+| --- | --- |
+{% for e in enums_in_subset|sort(attribute='name') -%}
+{%- if element.name in e.in_subset %}
+| {{ gen.link(e) }} | {{ e.description|enshorten }} |
+{%- endif %}
+{% endfor %}
+
+{%- endif %}


### PR DESCRIPTION
Fixes #870 

Note that this change has been made in the linkml library as well, so when we update the linkml dependency version in this schema repo, we can delete the custom enum jinja being introduced in this PR and use the base template from linkml.