### PR TITLE
Fix spelling of the word, "provenance"

### DIFF
--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -19,7 +19,7 @@ default_range: string
 classes:
 
   Activity:
-    description: "a provence-generating activity"
+    description: "a provenance-generating activity"
     slots:
       - id
       - name


### PR DESCRIPTION
Single-line change.