### PR TITLE
Add `doctest`s to example transformation function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ create-data-harmonizer:
 	npm init data-harmonizer $(SOURCE_SCHEMA_PATH)
 
 all: site
-site: clean site-clean gen-project gendoc nmdc_schema/gold-to-mixs.sssom.tsv
+site: clean site-clean gen-project gendoc migration-doctests nmdc_schema/gold-to-mixs.sssom.tsv
 # may change files in nmdc_schema/ or project/. uncommitted changes are not tolerated by mkd-gh-deploy
 
 %.yaml: gen-project

--- a/nmdc_schema/migrators/README.md
+++ b/nmdc_schema/migrators/README.md
@@ -33,9 +33,56 @@ Here's how you can create a new migrator:
    cp migrator_from_A_B_C_to_X_Y_Z.py migrator_from_1_2_3_to_1_2_4.py
    ```
 2. Customize the migrator module according to the instructions in the example migrator module.
-   - Update the class name (to `Migrator_from_1_2_3_to_1_2_4`)
-   - Implement the transformation functions (ensure each one accepts and returns a Python dictionary)
-   - Add the transformation functions to the agenda
-   > TODO: Replace this step with more detailed instructions; possibly enough that we can replace the current example
-   > migrator module with one that lacks tutorial comments and is more ready-to-populate.
+    - Update the class name:
+      ```diff
+      - class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
+      + class Migrator_from_1_2_3_to_1_2_4(MigratorBase):
+      ```
+    - Remove the definition of the _example_ "transformation" function:
+      ```diff
+      - def allow_multiple_names(self, study: dict) -> dict:
+      -     ...
+      -
+      -     # Return the transformed dictionary.
+      -     return study
+      ```
+    - Remove the _example_ "transformation" function from the agenda:
+      ```diff
+        self.agenda = dict(
+      -     study_set=[self.allow_multiple_names],
+        )      
+      ```
+    - Define the "transformation" function(s) that are part of this migration. Ensure each "transformation" function:
+        - **Accepts** a Python `dict`
+            - For example:
+                ```diff
+                + def add_name(self, person: dict) -> dict:
+                ```
+        - Has a **docstring** that summarizes what the function does (optional)
+            - For example:
+              ```diff
+                """
+              + Adds a `name` key and sets its value to "Anonymous".
+              ```
+        - Has at least one **[doctest](https://docs.python.org/3/library/doctest.html)** that demonstrates what the function does (optional)
+            - For example:
+              ```diff
+              + >>> migrator = Migrator_from_1_2_3_to_1_2_4()
+              + >>> migrator.add_name({'id': 123})
+              + {'id': 123, 'name': 'Anonymous'}
+                """
+              ```
+        - **Returns** a Python `dict`
+            - For example:
+              ```diff
+              + return person
+              ```
+    - Add the "transformation" function(s) to the agenda:
+        - For example:
+          ```diff
+            self.agenda = dict(
+          +     person_set=[self.add_name, self.convert_age_into_years],
+          +     lab_set=[self.add_country_code]
+            )
+          ```
 3. Done.

--- a/nmdc_schema/migrators/README.md
+++ b/nmdc_schema/migrators/README.md
@@ -81,8 +81,7 @@ Here's how you can create a new migrator:
         - For example:
           ```diff
             self.agenda = dict(
-          +     person_set=[self.add_name, self.convert_age_into_years],
-          +     lab_set=[self.add_country_code]
+          +     person_set=[self.add_name],
             )
           ```
 3. Done.

--- a/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
+++ b/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
@@ -57,6 +57,26 @@ class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
               --> As part of creating a new "migration" class, you will
                   typically implement one or more "transformation" functions.
                   You will also add them to the "agenda" of the class.
+
+        TUTORIAL: The remaining part of this comment consists of several "doctests".
+                  You can read more about doctests in the official Python documentation:
+                  https://docs.python.org/3/library/doctest.html
+
+                  Each doctest consists of (a) a snippet of Python code that calls this
+                  function, followed on the next line by (b) whatever the author of the
+                  test expects this function to return, if anything.
+
+                  People can then read and run those doctests in order to learn about
+                  what this function does / how this function behaves.
+
+              --> As part of implementing a "transformation" function, you will
+                  typically write a few doctests in the docstring of that function.
+
+        >>> mig = Migrator_from_A_B_C_to_X_Y_Z()  # creates a class instance on which we can call this method (function)
+        >>> mig.allow_multiple_names({'id': 123, 'name': 'My project'})  # test: transfers existing name to `names` list
+        {'id': 123, 'names': ['My project']}
+        >>> mig.allow_multiple_names({'id': 123, 'name': 'My project', 'foo': 'bar'})  # test: preserves other keys
+        {'id': 123, 'foo': 'bar', 'names': ['My project']}
         """
 
         # optional log message

--- a/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
+++ b/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
@@ -72,7 +72,7 @@ class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
               --> As part of implementing a "transformation" function, you will
                   typically write a few doctests in the docstring of that function.
 
-        >>> mig = Migrator_from_A_B_C_to_X_Y_Z()  # creates a class instance on which we can call this method (function)
+        >>> mig = Migrator_from_A_B_C_to_X_Y_Z()  # creates a class instance on which we can call this function (method)
         >>> mig.allow_multiple_names({'id': 123, 'name': 'My project'})  # test: transfers existing name to `names` list
         {'id': 123, 'names': ['My project']}
         >>> mig.allow_multiple_names({'id': 123, 'name': 'My project', 'foo': 'bar'})  # test: preserves other keys

--- a/project.Makefile
+++ b/project.Makefile
@@ -568,3 +568,7 @@ validate-polymorphic:
 	$(RUN) linkml-validate \
 		--include-range-class-descendants \
 		--schema src/schema/nmdc.yaml src/data/polymorphic-valid/Database-polymorphic-planned-process-set.yaml
+
+.PHONY: migration-doctests
+migration-doctests:
+	$(RUN) python -m doctest -v nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py


### PR DESCRIPTION
### Summary of changes

- Added `doctest`s to the example transformation function in the tutorial class
- Added details to the "Creating a migrator" instructions