### PR TITLE
Add doctests to existing migration classes

### DIFF
--- a/nmdc_schema/migrators/migrator_from_7_7_2_to_7_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_7_2_to_7_8_0.py
@@ -19,6 +19,21 @@ class Migrator_from_7_7_2_to_7_8_0(MigratorBase):
         )
 
     def replace_doi_field_with_award_dois_list_field(self, study: dict) -> dict:
+        r"""
+        Removes the `doi` field. If `doi.has_raw_value` contained a specific type of URL string, this function also adds
+        an `award_dois` field whose value is a list containing a CURIE string derived from that URL string.
+
+        >>> m = Migrator_from_7_7_2_to_7_8_0()
+        >>> m.replace_doi_field_with_award_dois_list_field({'id': 123})  # no `doi` field
+        {'id': 123}
+        >>> m.replace_doi_field_with_award_dois_list_field({'id': 123, 'doi': {'has_raw_value': 'not-a-url'}})
+        {'id': 123}
+        >>> m.replace_doi_field_with_award_dois_list_field(
+        ...     {'id': 123, 'doi': {'has_raw_value': 'https://example.com/10.other_stuff'}}
+        ... )
+        {'id': 123, 'award_dois': ['doi:10.other_stuff']}
+        """
+
         self.logger.info(f"Starting migration of {study['id']}")
         if "doi" in study:
             match = re.search(DOI_URL_PATTERN, study["doi"]["has_raw_value"])

--- a/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
@@ -74,7 +74,7 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
 
     def standardize_letter_casing_of_gold_biosample_identifiers(self, biosample: dict) -> dict:
         r"""
-        Converts uppercase "GOLD:" prefixes in `gold_biosample_identifiers` values into lowercase "gold:".
+        Converts uppercase "GOLD:" prefixes into lowercase "gold:" prefixes, in `gold_biosample_identifiers` values.
 
         >>> m = Migrator_from_7_8_0_to_8_0_0()
         >>> m.standardize_letter_casing_of_gold_biosample_identifiers({'id': 123})

--- a/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
@@ -19,17 +19,38 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         )
 
     def rename_sample_mass_field(self, extraction: dict) -> dict:
+        r"""
+        Renames the `sample_mass` field to `input_mass`.
+
+        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m.rename_sample_mass_field({'id': 123})  # no `sample_mass` field
+        {'id': 123}
+        >>> m.rename_sample_mass_field({'id': 123, 'sample_mass': 456})  # test: renames field and preserves value
+        {'id': 123, 'input_mass': 456}
+        """
+
         self.logger.info(f"Starting migration of {extraction['id']}")
         if "sample_mass" in extraction:
             extraction["input_mass"] = extraction.pop("sample_mass")
         return extraction
 
     def standardize_letter_casing_of_gold_identifiers(self, identifiers: List[str]) -> List[str]:
-        """
+        r"""
         Replaces the prefix `GOLD:` with `gold:` in the list of identifiers.
+
+        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m.standardize_letter_casing_of_gold_identifiers(['GOLD:prefix_was_uppercase'])
+        ['gold:prefix_was_uppercase']
+        >>> m.standardize_letter_casing_of_gold_identifiers(['gold:prefix_was_lowercase'])
+        ['gold:prefix_was_lowercase']
 
         Note: If the identifier contains more than one colon, everything after the second
               colon will be discarded.
+
+        >>> m.standardize_letter_casing_of_gold_identifiers(['Gold:prefix_remains_mixed_case'])
+        ['Gold:prefix_remains_mixed_case']
+        >>> m.standardize_letter_casing_of_gold_identifiers(['GOLD:truncates_identifier:at_second_colon'])
+        ['gold:truncates_identifier']
         """
 
         standardized_identifiers = []
@@ -52,6 +73,18 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         return standardized_identifiers
 
     def standardize_letter_casing_of_gold_biosample_identifiers(self, biosample: dict) -> dict:
+        r"""
+        Converts uppercase "GOLD:" prefixes in `gold_biosample_identifiers` values into lowercase "gold:".
+
+        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m.standardize_letter_casing_of_gold_biosample_identifiers({'id': 123})
+        {'id': 123, 'gold_biosample_identifiers': []}
+        >>> m.standardize_letter_casing_of_gold_biosample_identifiers(
+        ...     {'id': 123, 'gold_biosample_identifiers': ['GOLD:foo', 'gold:bar']}
+        ... )
+        {'id': 123, 'gold_biosample_identifiers': ['gold:foo', 'gold:bar']}
+        """
+
         field_name = "gold_biosample_identifiers"
         if field_name in biosample and biosample[field_name]:
             biosample[field_name] = self.standardize_letter_casing_of_gold_identifiers(biosample[field_name])
@@ -60,6 +93,18 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         return biosample
 
     def standardize_letter_casing_of_gold_sequencing_project_identifiers(self, omics_processing: dict) -> dict:
+        r"""
+        Converts uppercase "GOLD:" prefixes in `gold_sequencing_project_identifiers` values into lowercase "gold:".
+
+        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m.standardize_letter_casing_of_gold_sequencing_project_identifiers({'id': 123})
+        {'id': 123, 'gold_sequencing_project_identifiers': []}
+        >>> m.standardize_letter_casing_of_gold_sequencing_project_identifiers(
+        ...     {'id': 123, 'gold_sequencing_project_identifiers': ['GOLD:foo', 'gold:bar']}
+        ... )
+        {'id': 123, 'gold_sequencing_project_identifiers': ['gold:foo', 'gold:bar']}
+        """
+
         field_name = "gold_sequencing_project_identifiers"
         if field_name in omics_processing and omics_processing[field_name]:
             omics_processing[field_name] = self.standardize_letter_casing_of_gold_identifiers(omics_processing[field_name])
@@ -68,6 +113,18 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         return omics_processing
 
     def standardize_letter_casing_of_gold_study_identifier(self, study: dict) -> dict:
+        r"""
+        Converts uppercase "GOLD:" prefixes in `gold_study_identifiers` values into lowercase "gold:".
+
+        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m.standardize_letter_casing_of_gold_study_identifier({'id': 123})
+        {'id': 123, 'gold_study_identifiers': []}
+        >>> m.standardize_letter_casing_of_gold_study_identifier(
+        ...     {'id': 123, 'gold_study_identifiers': ['GOLD:foo', 'gold:bar']}
+        ... )
+        {'id': 123, 'gold_study_identifiers': ['gold:foo', 'gold:bar']}
+        """
+
         field_name = "gold_study_identifiers"
         if field_name in study and study[field_name]:
             study[field_name] = self.standardize_letter_casing_of_gold_identifiers(study[field_name])

--- a/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
@@ -43,14 +43,14 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         ['gold:prefix_was_uppercase']
         >>> m.standardize_letter_casing_of_gold_identifiers(['gold:prefix_was_lowercase'])
         ['gold:prefix_was_lowercase']
-
-        Note: If the identifier contains more than one colon, everything after the second
-              colon will be discarded.
-
         >>> m.standardize_letter_casing_of_gold_identifiers(['Gold:prefix_remains_mixed_case'])
         ['Gold:prefix_remains_mixed_case']
-        >>> m.standardize_letter_casing_of_gold_identifiers(['GOLD:truncates_identifier:at_second_colon'])
-        ['gold:truncates_identifier']
+
+        Note: If the identifier contains more than one colon, everything after and including
+              the second colon will be discarded.
+
+        >>> m.standardize_letter_casing_of_gold_identifiers(['GOLD:preserves_this:but_not_this'])
+        ['gold:preserves_this']
         """
 
         standardized_identifiers = []

--- a/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
+++ b/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
@@ -16,7 +16,7 @@ class Migrator_from_8_0_to_8_1(MigratorBase):
 
     def force_research_study_study_category(self, study: dict) -> dict:
         r"""
-        If the study lacks a field named` study_category`, creates it and assigns it the value "research_study".
+        If the study lacks a field named `study_category`, creates it and assigns it the value "research_study".
 
         >>> m = Migrator_from_8_0_to_8_1()
         >>> m.force_research_study_study_category({'id': 123})  # field doesn't exist yet

--- a/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
+++ b/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
@@ -15,6 +15,16 @@ class Migrator_from_8_0_to_8_1(MigratorBase):
         )
 
     def force_research_study_study_category(self, study: dict) -> dict:
+        r"""
+        If the study lacks a field named` study_category`, creates it and assigns it the value "research_study".
+
+        >>> m = Migrator_from_8_0_to_8_1()
+        >>> m.force_research_study_study_category({'id': 123})  # field doesn't exist yet
+        {'id': 123, 'study_category': 'research_study'}
+        >>> m.force_research_study_study_category({'id': 123, 'study_category': 'preserve_me'})  # field already exists
+        {'id': 123, 'study_category': 'preserve_me'}
+        """
+
         if "study_category" not in study:
             self.logger.info(f"Forcing 'study_category: research_study' on {study['id']}")
             study["study_category"] = "research_study"

--- a/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
@@ -17,6 +17,22 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         )
 
     def process_doi(self, study: dict, doi_list: list, doi_category: str):
+        r"""
+        For each update descriptor in the `doi_list` list; if the specified study's `id` matches that descriptor's `id`,
+        this function appends a DOI dictionary to the study's `associated_dois` list (creating the list if necessary).
+
+        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m.process_doi({'id': 123}, [{'id': 123, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` matches
+        {'id': 123, 'associated_dois': [{'doi_value': 'a', 'doi_category': 'c', 'doi_provider': 'b'}]}
+        >>> m.process_doi({'id': 555}, [{'id': 123, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` does not match
+        {'id': 123}
+        >>> m.process_doi(
+        ...     {'id': 123, 'associated_dois': [{'doi_value': 'x', 'doi_category': 'y', 'doi_provider': 'z'}]},
+        ...     [{'id': 123, 'doi': 'a', 'doi_prov': 'b'}], 'c'
+        ... )  # study already has an `associated_dois` field
+        {'id': 123, 'associated_dois': [{'doi_value': 'x', 'doi_category': 'y', 'doi_provider': 'z'}, {'doi_value': 'a', 'doi_category': 'c', 'doi_provider': 'b'}]}
+        """
+
         id_value = study['id']
         for doi_updates in doi_list:
             if id_value == doi_updates['id']:
@@ -44,7 +60,13 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         return study
 
     def fix_pub_dois(self, study: dict):
-        """Move publication_dois values to new associated_dois slot"""
+        r"""
+        Copies `publication_dois` values into a new slot named `associated_dois`.
+
+        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m.fix_pub_dois({'id': 1, 'publication_dois': ['a']})  # test: a single DOI
+        {'id': 1, 'publication_dois': ['a'], 'associated_dois': [{'doi_value': 'a', 'doi_category': 'publication_doi'}]}
+        """
 
         study.setdefault('associated_dois', []).extend(
             {'doi_value': pub_doi, 'doi_category': 'publication_doi'}
@@ -54,7 +76,17 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         return study
 
     def fix_massive(self, study: dict):
-        """Change the one massive_study_identifiers value to a doi and move under new associated_dois slot"""
+        r"""
+        Changes the one `massive_study_identifiers` value into a DOI and moves it to a new `associated_dois` slot.
+
+        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m.fix_massive({'id': 123})
+        {'id': 123, 'associated_dois': []}
+        >>> m.fix_massive({'id': 123, 'massive_study_identifiers': ['not-the-one']})
+        {'id': 123, 'massive_study_identifiers': ['not-the-one'], 'associated_dois': []}
+        >>> m.fix_massive({'id': 123, 'massive_study_identifiers': ['MASSIVE:MSV000090886']})  # this is the one!
+        {'id': 123, 'associated_dois': [{'doi_value': 'doi:10.25345/C58K7520G', 'doi_category': 'dataset_doi', 'doi_provider': 'massive'}]}
+        """
 
         mass_id = 'MASSIVE:MSV000090886'
         mass_doi = 'doi:10.25345/C58K7520G'
@@ -70,7 +102,13 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         return study
 
     def fix_ess_dive(self, study: dict):
-        """Move ess_dive_datasets values to associated_dois slot"""
+        r"""
+        Copies `ess_dive_datasets` values into a new slot named `associated_dois`.
+
+        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m.fix_ess_dive({'id': 1, 'ess_dive_datasets': ['a']})  # test: a single DOI
+        {'id': 1, 'ess_dive_datasets': ['a'], 'associated_dois': [{'doi_value': 'a', 'doi_category': 'dataset_doi', 'doi_provider': 'ess_dive'}]}
+        """
 
         study.setdefault('associated_dois', []).extend(
             {'doi_value': dataset_doi, 'doi_category': 'dataset_doi',
@@ -80,7 +118,19 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         return study
 
     def remove_doi_slots(self, study: dict):
-        """Remove slots that are no longer needed because their values have been moved to the associated_dois slot"""
+        r"""
+        Removes slots that are no longer needed because their values have been moved to the `associated_dois` slot.
+
+        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m.remove_doi_slots({'id': 123, 'associated_dois': []})  # empty `associated_dois` list gets removed
+        {'id': 123}
+        >>> m.remove_doi_slots({
+        ...    'id': 123,
+        ...    'associated_dois': [{'doi_value': 'a', 'doi_category': 'c', 'doi_provider': 'b'}],
+        ...    'publication_dois': ['a'],
+        ... })  # lists in which all values match an `associated_dois[].doi_value` get removed
+        {'id': 123, 'associated_dois': [{'doi_value': 'a', 'doi_category': 'c', 'doi_provider': 'b'}]}
+        """
 
         removal_slots = ['publication_dois', 'dataset_dois',
                          'award_dois', 'ess_dive_datasets', 'massive_study_identifiers']


### PR DESCRIPTION
### Progress

- [x] Add doctests to `Migrator_from_7_7_2_to_7_8_0` class
- [x] Add doctests to `Migrator_from_7_8_0_to_8_0_0` class
- [x] Add doctests to `Migrator_from_8_0_to_8_1` class
- [x] Add doctests to `Migrator_from_8_1_to_9_0` class (except the function that uses the YAML data file)

Fixes: https://github.com/microbiomedata/nmdc-schema/issues/1383

Related: https://github.com/microbiomedata/nmdc-schema/issues/1291