### PR TITLE
Add data_management_plan_doi enum

### DIFF
--- a/src/data/valid/Study-exhaustive.yaml
+++ b/src/data/valid/Study-exhaustive.yaml
@@ -38,6 +38,9 @@ associated_dois:
   - doi_value: doi:10.1126/science.1234545
     doi_provider: jgi
     doi_category: award_doi
+  - doi:value: doi:10.48321/D1Z60Q
+    doi_category: data_management_plan_doi
+    doi_provider: gsc
 title: Sample Exhaustive Biosample instance. Although all of these values should pass
   validation, that does not mean that any Biosample of any type would necessarily
   have this particular combination of values.

--- a/src/data/valid/Study-exhaustive.yaml
+++ b/src/data/valid/Study-exhaustive.yaml
@@ -38,7 +38,7 @@ associated_dois:
   - doi_value: doi:10.1126/science.1234545
     doi_provider: jgi
     doi_category: award_doi
-  - doi:value: doi:10.48321/D1Z60Q
+  - doi_value: doi:10.48321/D1Z60Q
     doi_category: data_management_plan_doi
     doi_provider: gsc
 title: Sample Exhaustive Biosample instance. Although all of these values should pass

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2163,6 +2163,8 @@ enums:
         description: A type of DOI that resolves to generated data.
       publication_doi:
         description: A type of DOI that resolves to a publication.
+      data_management_plan_doi:
+        description: A type of DOI that resolves to a data management plan.
     see_also:
       - https://schema.datacite.org/meta/kernel-4.4/doc/DataCite-MetadataKernel_v4.4.pdf
       - https://api.crossref.org/types
@@ -2772,6 +2774,8 @@ slots:
           doi_category: award_doi
         - doi: doi:10.1101/2022.12.12.520098
           doi_category: publication_doi
+        - doi: doi:10.48321/D1Z60Q
+          doi_category: data_management_plan_doi
       description: Provides a list of two DOIs; specifically, an EMSL award DOI and a publication DOI.
 
   doi_value:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2159,7 +2159,7 @@ enums:
           - GSC
           - Genomic Standards Consortium
         title: GSC
-        
+
 
   DoiCategoryEnum:
     permissible_values:
@@ -2782,6 +2782,7 @@ slots:
           doi_category: publication_doi
         - doi: doi:10.48321/D1Z60Q
           doi_category: data_management_plan_doi
+          doi_provider: gsc
       description: Provides a list of two DOIs; specifically, an EMSL award DOI and a publication DOI.
 
   doi_value:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2154,6 +2154,12 @@ enums:
           - MassIVE
           - Mass Spectrometry Virtual Environment
         title: MassIVE
+      gsc:
+        aliases:
+          - GSC
+          - Genomic Standards Consortium
+        title: GSC
+        
 
   DoiCategoryEnum:
     permissible_values:


### PR DESCRIPTION
regarding https://github.com/microbiomedata/nmdc-schema/issues/108

This PR includes:

- [x] Adding a `data_management_plan_doi` enum to `DoiCategoryEnum`
- [x] Adding a data management plan example for the `associated_dois` slot in the `nmdc.yaml` file
- [x] Add a data management plan example to the `Study-exhaustive.yaml` file
- [x] Add `gsc` enum to `DoiProviderEnum` given the use case in the [initial issue](https://github.com/orgs/microbiomedata/projects/96?pane=issue&itemId=45014738)