### PR TITLE
Update `make` target to run all migrators' doctests (and fix bug in test)

### DIFF
--- a/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
@@ -24,7 +24,7 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         >>> m = Migrator_from_8_1_to_9_0()
         >>> m.process_doi({'id': 123}, [{'id': 123, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` matches
         {'id': 123, 'associated_dois': [{'doi_value': 'a', 'doi_category': 'c', 'doi_provider': 'b'}]}
-        >>> m.process_doi({'id': 555}, [{'id': 123, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` does not match
+        >>> m.process_doi({'id': 123}, [{'id': 555, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` does not match
         {'id': 123}
         >>> m.process_doi(
         ...     {'id': 123, 'associated_dois': [{'doi_value': 'x', 'doi_category': 'y', 'doi_provider': 'z'}]},

--- a/project.Makefile
+++ b/project.Makefile
@@ -570,5 +570,7 @@ validate-polymorphic:
 		--schema src/schema/nmdc.yaml src/data/polymorphic-valid/Database-polymorphic-planned-process-set.yaml
 
 .PHONY: migration-doctests
+
+# Runs all doctests defined within the migrator modules.
 migration-doctests:
-	$(RUN) python -m doctest -v nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
+	$(RUN) python -m doctest -v nmdc_schema/migrators/*.py


### PR DESCRIPTION
### Changes

- Fixed a bug in a doctest
    - I had introduced the bug while swapping the IDs in an attempt to make the test easier to read. Looks like I forgot to re-run the tests after making that change! 😅 
- Changed the `make` target so it runs the doctests defined in _all_ the migrator modules, instead of just the example module
    - This'll catch mistakes like the one I described in the previous bullet point

Fixes https://github.com/microbiomedata/nmdc-schema/issues/1397