### PR TITLE
add edi and zenodo permissible values

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2159,7 +2159,16 @@ enums:
           - GSC
           - Genomic Standards Consortium
         title: GSC
-
+      zenodo:
+        aliases:
+          - Zenodo
+        title: Zenodo
+      edi:
+        aliases:
+          - EDI
+          - Environmental Data Initiative 
+        title: EDI
+        meaning: https://ror.org/0330j0z60
 
   DoiCategoryEnum:
     permissible_values:


### PR DESCRIPTION
For issue #1403 

Added `edi` and `zenodo` as permissible values for `DoiProviderEnum` in order to move the dois out of the `websites` slot from issue #1350.