### PR TITLE
remove `nucleic_acid_concentration` from schema and examples

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -134,10 +134,6 @@ slots:
   protocol_link:
     range: Protocol
 
-
-  #  nucleic_acid_concentration:
-  #    range: InstrumentValue
-
   biomaterial_purity:
     range: QuantityValue
 

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -142,7 +142,6 @@ classes:
       - dna_absorb1
       - dna_concentration
       - external_database_identifiers
-    #      - nucleic_acid_concentration
     slot_usage:
       id:
         required: true

--- a/src/schema/portal/jgi_metagenomics.yaml
+++ b/src/schema/portal/jgi_metagenomics.yaml
@@ -75,8 +75,6 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
   dna_concentration:
-    see_also:
-      nmdc:nucleic_acid_concentration
     title: DNA concentration in ng/ul
     comments:
       - Units must be in ng/uL. Enter the numerical part only. Must be calculated using

--- a/src/schema/portal/jgi_metatranscriptomics.yaml
+++ b/src/schema/portal/jgi_metatranscriptomics.yaml
@@ -97,8 +97,6 @@ slots:
     slot_group: JGI-Metatranscriptomics
     recommended: true
   rna_concentration:
-    see_also:
-      nmdc:nucleic_acid_concentration
     title: RNA concentration in ng/ul
     comments:
       - Units must be in ng/uL. Enter the numerical part only. Must be calculated using


### PR DESCRIPTION
- #1439 