### PR TITLE
Simplify migrator creation and usage

### DIFF
--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -166,21 +166,21 @@ def main(schema_path, input_path, output_path, salvage_prefix, migrator_name):
         migrator = current_migrator(logger=logger)
 
         # iterate over collections, applying migration-specific transformations
-        for tdk, tdv in total_dict.items():
+        for collection_name, documents in total_dict.items():
             # If the migration specifies any transformers for this collection,
             # apply them—in order—to each document within this collection.
-            transformers = migrator.get_transformers_for(collection_name=tdk)
+            transformers = migrator.get_transformers_for(collection_name=collection_name)
             if len(transformers) > 0:
                 migrator_class_name = current_migrator.__name__
-                logger.info(f"Starting {tdk}-specific transformations using {migrator_class_name}")
-                for i, document in enumerate(tdv):
+                logger.info(f"Starting {collection_name}-specific transformations using {migrator_class_name}")
+                for i, document in enumerate(documents):
 
                     # Apply the transformation(s).
                     for transformer in transformers:
                         document = transformer(document)
 
                     # Update the collection so it contains the transformed document.
-                    tdv[i] = document
+                    documents[i] = document
 
     # all migrations complete. save data.
     logger.info(f"Saving migrated data to {output_path}")

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -173,9 +173,14 @@ def main(schema_path, input_path, output_path, salvage_prefix, migrator_name):
             if len(transformers) > 0:
                 migrator_class_name = current_migrator.__name__
                 logger.info(f"Starting {tdk}-specific transformations using {migrator_class_name}")
-                for document in tdv:
+                for i, document in enumerate(tdv):
+
+                    # Apply the transformation(s).
                     for transformer in transformers:
-                        transformer(document)  # modifies the document in place
+                        document = transformer(document)
+
+                    # Update the collection so it contains the transformed document.
+                    tdv[i] = document
 
     # all migrations complete. save data.
     logger.info(f"Saving migrated data to {output_path}")

--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -88,11 +88,10 @@ def load_yaml_file(filename):
 @click.option("--salvage-prefix", required=True, type=str,
               help="A prefix, defined in the schema, to force for each value that the schema indicates is a CURIE but that has no prefix")
 @click.option("--migrator-name", type=str, multiple=True,
-              help="The name of a migrator class that you want to use to migrate data. If you specify this option "
-                   "multiple times, the specified migrator classes will be used in the order specified.\n\n"
-                   "A migrator class is a class that inherits from `MigratorBase`. "
-                   "Migrator classes are defined in `nmdc_schema/migrators/` and their names begin with capital "
-                   "`Migrator_` (as opposed to lowercase `migrator_`, which refers to a module).")
+              help="The name of a migrator module that you want to use to migrate data. If you specify this option "
+                   "multiple times, the specified migrator modules will be used in the order specified.\n\n"
+                   "Migrator modules are Python modules residing in the `nmdc_schema/migrators/` directory. "
+                   "Their names begin with `migrator_from_`.")
 def main(schema_path, input_path, output_path, salvage_prefix, migrator_name):
     """
     Generates a data file that conforms to a different schema version than the input data file does.
@@ -104,14 +103,13 @@ def main(schema_path, input_path, output_path, salvage_prefix, migrator_name):
 
     for current_name in migrator_name:
         try:
-            # Import the module whose name matches the specified migrator name (but with a lowercase `migrator_`).
+            # Import the module whose name matches the specified migrator module name.
             # Reference: https://docs.python.org/3/library/importlib.html#importlib.import_module
-            migrator_module_name = current_name.replace("Migrator_", "migrator_", 1)
-            migrator_module = importlib.import_module(f".{migrator_module_name}", package="nmdc_schema.migrators")
+            migrator_module = importlib.import_module(f".{current_name}", package="nmdc_schema.migrators")
 
-            # Get the class (defined in that module) whose name matches the specified migrator name.
+            # Get the `Migrator` class defined in that module.
             # Reference: https://docs.python.org/3/library/inspect.html#inspect.isclass
-            migrator_class = getattr(migrator_module, current_name)
+            migrator_class = getattr(migrator_module, "Migrator")
             if not inspect.isclass(migrator_class):
                 raise TypeError
 
@@ -119,7 +117,7 @@ def main(schema_path, input_path, output_path, salvage_prefix, migrator_name):
             migrators.append(migrator_class)
             logger.info(f"Will use migrator: {current_name}")
         except (KeyError, ImportError, AttributeError, TypeError) as exception:
-            logger.error(f"ERROR: {current_name} is not a valid migrator class name. {exception}.")
+            logger.error(f"ERROR: {current_name} is not a valid migrator module name. {exception}.")
             continue
 
     if len(migrators) == 0:

--- a/nmdc_schema/migrators/README.md
+++ b/nmdc_schema/migrators/README.md
@@ -14,6 +14,7 @@ In this document, I'll refer to those Python classes as "migrators."
 This directory contains the following things:
 
 - `assets/` - data files (not Python code) used by the classes
+- `cli/` - CLI scripts/commands related to the classes
 - `helpers.py` - general-purpose functions used by the classes
 - `migrator_base.py` - definition of the `MigratorBase` class
     - That class is agnostic to schema versions
@@ -25,60 +26,40 @@ This directory contains the following things:
 
 Here's how you can create a new migrator:
 
-1. Create a new migrator module based upon the example one.
-   > In this example, I'll create a migrator that can be used to migrate data from schema version `1.2.3` to schema
-   > version `1.2.4`.
-   ```shell
-   # Run from the same directory as this `README.md` file:
-   cp migrator_from_A_B_C_to_X_Y_Z.py migrator_from_1_2_3_to_1_2_4.py
-   ```
-2. Customize the migrator module according to the instructions in the example migrator module.
-    - Update the `_to_version` and `_from_version` strings:
-      ```diff
-      - _from_version = "A.B.C"
-      - _to_version = "X.Y.Z"
-      + _from_version = "1.2.3"
-      + _to_version = "1.2.4"
-      ```
-    - Remove the definition of the _example_ "transformation" function:
-      ```diff
-      - def allow_multiple_names(self, study: dict) -> dict:
-      -     ...
-      -
-      -     # Return the transformed dictionary.
-      -     return study
-      ```
-    - Remove the _example_ "transformation" function from the agenda:
-      ```diff
-        self._agenda = dict(
-      -     study_set=[self.allow_multiple_names],
-        )      
-      ```
+1. Run `make migrator`.
+    ```shell
+    make migrator
+    ```
+    > Alternatively, you can run `$ poetry run python nmdc_schema/migrators/cli/create_migrator.py`.
+   
+    When prompted, enter the schema version numbers the migrator will migrate data _from_ and _to_. For example:
+    > ```yaml
+    > From schema version: 1.1
+    > To schema version: 1.2
+    > ```
+    By default, the generated migrator is a "no-op," meaning that it has no operations (i.e. doesn't do anything).
+2. Customize the newly-generated migrator.
     - Define the "transformation" function(s) that are part of this migration. Ensure each "transformation" function:
-        - **Accepts** a Python `dict`
-            - For example:
-                ```diff
-                + def add_name(self, person: dict) -> dict:
-                ```
-        - Has a **docstring** that summarizes what the function does (optional)
-            - For example:
-              ```diff
-                """
-              + Adds a `name` key and sets its value to "Anonymous".
-              ```
-        - Has at least one **[doctest](https://docs.python.org/3/library/doctest.html)** that demonstrates what the function does (optional)
-            - For example:
-              ```diff
-              + >>> migrator = Migrator()
-              + >>> migrator.add_name({'id': 123})
-              + {'id': 123, 'name': 'Anonymous'}
-                """
-              ```
-        - **Returns** a Python `dict`
-            - For example:
-              ```diff
-              + return person
-              ```
+        - **Accepts** a Python `dict`; for example:
+            ```diff
+            + def add_name(self, person: dict) -> dict:
+            ```
+        - Has a **docstring** that summarizes what the function does (optional); for example:
+            ```diff
+                  """
+            +     Adds a `name` key and sets its value to "Anonymous".
+            ```
+        - Has at least one **[doctest](https://docs.python.org/3/library/doctest.html)** that demonstrates what the function does (optional); for example:
+            ```diff
+            +     >>> migrator = Migrator()
+            +     >>> migrator.add_name({'id': 123})
+            +     {'id': 123, 'name': 'Anonymous'}
+                  """
+            ```
+        - **Returns** a Python `dict`; for example:
+            ```diff
+            +     return person
+            ```
     - Add the "transformation" function(s) to the agenda:
         - For example:
           ```diff
@@ -86,4 +67,5 @@ Here's how you can create a new migrator:
           +     person_set=[self.add_name],
             )
           ```
+    You can refer to the example migrator (i.e. `migrator_from_A_B_C_to_X_Y_Z.py`) as a guide.
 3. Done.

--- a/nmdc_schema/migrators/README.md
+++ b/nmdc_schema/migrators/README.md
@@ -33,12 +33,12 @@ Here's how you can create a new migrator:
    cp migrator_from_A_B_C_to_X_Y_Z.py migrator_from_1_2_3_to_1_2_4.py
    ```
 2. Customize the migrator module according to the instructions in the example migrator module.
-    - Update the `__to_version` and `__from_version` strings:
+    - Update the `_to_version` and `_from_version` strings:
       ```diff
-      - __from_version = "A.B.C"
-      - __to_version = "X.Y.Z"
-      + __from_version = "1.2.3"
-      + __to_version = "1.2.4"
+      - _from_version = "A.B.C"
+      - _to_version = "X.Y.Z"
+      + _from_version = "1.2.3"
+      + _to_version = "1.2.4"
       ```
     - Remove the definition of the _example_ "transformation" function:
       ```diff
@@ -50,7 +50,7 @@ Here's how you can create a new migrator:
       ```
     - Remove the _example_ "transformation" function from the agenda:
       ```diff
-        self.agenda = dict(
+        self._agenda = dict(
       -     study_set=[self.allow_multiple_names],
         )      
       ```
@@ -82,7 +82,7 @@ Here's how you can create a new migrator:
     - Add the "transformation" function(s) to the agenda:
         - For example:
           ```diff
-            self.agenda = dict(
+            self._agenda = dict(
           +     person_set=[self.add_name],
             )
           ```

--- a/nmdc_schema/migrators/README.md
+++ b/nmdc_schema/migrators/README.md
@@ -17,8 +17,8 @@ This directory contains the following things:
 - `helpers.py` - general-purpose functions used by the classes
 - `migrator_base.py` - definition of the `MigratorBase` class
     - That class is agnostic to schema versions
-- `migrator_from_A_B_C_to_X_Y_Z.py` - definition of the `Migrator_from_A_B_C_to_X_Y_Z` class
-    - That class is used to migrate data from schema version `A.B.C` to schema version `X.Y.Z`
+- `migrator_from_A_B_C_to_X_Y_Z.py` - definition of an example `Migrator` class
+    - That class is specific to a pair of schema versions (i.e. it migrates data from schema version `A.B.C` to schema version `X.Y.Z`)
 - Other `migrator_*.py` modules (they are analogous to `migrator_from_A_B_C_to_X_Y_Z.py`)
 
 ## Creating a migrator
@@ -33,10 +33,12 @@ Here's how you can create a new migrator:
    cp migrator_from_A_B_C_to_X_Y_Z.py migrator_from_1_2_3_to_1_2_4.py
    ```
 2. Customize the migrator module according to the instructions in the example migrator module.
-    - Update the class name:
+    - Update the `__to_version` and `__from_version` strings:
       ```diff
-      - class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
-      + class Migrator_from_1_2_3_to_1_2_4(MigratorBase):
+      - __from_version = "A.B.C"
+      - __to_version = "X.Y.Z"
+      + __from_version = "1.2.3"
+      + __to_version = "1.2.4"
       ```
     - Remove the definition of the _example_ "transformation" function:
       ```diff
@@ -67,7 +69,7 @@ Here's how you can create a new migrator:
         - Has at least one **[doctest](https://docs.python.org/3/library/doctest.html)** that demonstrates what the function does (optional)
             - For example:
               ```diff
-              + >>> migrator = Migrator_from_1_2_3_to_1_2_4()
+              + >>> migrator = Migrator()
               + >>> migrator.add_name({'id': 123})
               + {'id': 123, 'name': 'Anonymous'}
                 """

--- a/nmdc_schema/migrators/README.md
+++ b/nmdc_schema/migrators/README.md
@@ -32,12 +32,17 @@ Here's how you can create a new migrator:
     ```
     > Alternatively, you can run `$ poetry run python nmdc_schema/migrators/cli/create_migrator.py`.
    
-    When prompted, enter the schema version numbers the migrator will migrate data _from_ and _to_. For example:
+    When prompted, enter the [schema version numbers](../../CHANGELOG.md) the migrator will migrate data _from_ and _to_. For example:
     > ```yaml
     > From schema version: 1.1
     > To schema version: 1.2
     > ```
-    By default, the generated migrator is a "no-op," meaning that it has no operations (i.e. doesn't do anything).
+
+    By default, the generated migrator is a "no-op," meaning that it performs **no** **op**erations (i.e. doesn't do
+    anything).
+
+    > If the corresponding schema changes don't require that any data be migrated, you can skip the steps
+    below. The existence of a "no-op" migrator indicates that no migration is necessary.
 2. Customize the newly-generated migrator.
     - Define the "transformation" function(s) that are part of this migration. Ensure each "transformation" function:
         - **Accepts** a Python `dict`; for example:

--- a/nmdc_schema/migrators/cli/create_migrator.py
+++ b/nmdc_schema/migrators/cli/create_migrator.py
@@ -1,0 +1,108 @@
+import re
+from pathlib import Path
+import click
+
+# TODO: Determine directory path dynamically, instead of hard-coding it.
+MIGRATOR_DIRECTORY = "nmdc_schema/migrators"
+
+
+def click_option_validator(function_to_decorate):
+    r"""
+    This decorator wraps a function in another function, which strips away the
+    first two arguments and then passes the third argument to the wrapped function.
+    """
+    def wrapper(click_context, param, param_value):
+        return function_to_decorate(param_value)
+
+    return wrapper
+
+
+@click_option_validator
+def validate_version_identifier(version_identifier: str) -> str:
+    r"""
+    Validates a version identifier, raising an exception if it's invalid.
+
+    Reference: https://click.palletsprojects.com/en/8.1.x/options/#callbacks-for-validation
+
+    >>> validate_version_identifier("1.2.3")
+    True
+    >>> validate_version_identifier("1.2.")  # doesn't end with a number
+    False
+    >>> validate_version_identifier("1.2")
+    True
+    >>> validate_version_identifier("123.456.789")
+    True
+    >>> validate_version_identifier("123.456.789.1")  # 4 parts
+    False
+    >>> validate_version_identifier("123")
+    True
+    """
+    if re.fullmatch(r"^(\d+)(\.\d+){0,2}$", version_identifier) is None:
+        raise click.BadParameter("Invalid format.")
+
+    return version_identifier
+
+
+@click.command()
+@click.option(
+    "--from-version",
+    "--from",
+    type=str,
+    required=True,
+    help='Schema version from which the migrator will migrate data (e.g. "1.0").',
+    prompt="From schema version",
+    callback=validate_version_identifier,
+)
+@click.option(
+    "--to-version",
+    "--to",
+    type=str,
+    required=True,
+    prompt="To schema version",
+    help='Schema version to which the migrator will migrate data (e.g. "1.1").',
+    callback=validate_version_identifier,
+)
+def create_migrator(from_version: str, to_version: str) -> None:
+    """
+    Create a migrator class based upon the specified version identifiers.
+    """
+
+    # Generate the migrator module name.
+    from_version_snake = from_version.replace(".", "_")
+    to_version_snake = to_version.replace(".", "_")
+    file_name = f"migrator_from_{from_version_snake}_to_{to_version_snake}.py"
+
+    # Generate the migrator file contents.
+    # TODO: Move this to a dedicated template file to facilitate maintenance.
+    file_contents = f'''
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates data from schema version `{from_version}` to `{to_version}`."""
+    
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._agenda = dict()
+
+'''
+
+    # Create and populate the file (unless it already exists).
+    file_path = Path(MIGRATOR_DIRECTORY) / Path(file_name)
+
+    try:
+        # Note: The "x" stands for "exclusive creation" mode, a mode in
+        #       which an exception is thrown if the file already exists.
+        with file_path.open("x") as file:
+            file.write(file_contents)
+        click.echo(f"Created '{file_name}' successfully.")
+    except FileExistsError:
+        click.echo(f"Error: File '{file_name}' already exists: {file_path}", err=True)
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+
+    return None
+
+
+if __name__ == "__main__":
+    create_migrator()

--- a/nmdc_schema/migrators/cli/create_migrator.py
+++ b/nmdc_schema/migrators/cli/create_migrator.py
@@ -79,7 +79,10 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
 class Migrator(MigratorBase):
-    r"""Migrates data from schema version `{from_version}` to `{to_version}`."""
+    r"""Migrates data between two schema versions."""
+
+    _from_version = "{from_version}"
+    _to_version = "{to_version}"    
     
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/nmdc_schema/migrators/helpers.py
+++ b/nmdc_schema/migrators/helpers.py
@@ -26,7 +26,7 @@ def get_migrator_module_names() -> List[str]:
 
 def get_migrator_to(destination_version: str) -> Optional[Type[MigratorBase]]:
     """
-    Returns the first migrator class that migrates data to the specified schema version.
+    Returns a migrator class, if any, that migrates data to the specified schema version.
     """
 
     matching_migrator_class = None

--- a/nmdc_schema/migrators/helpers.py
+++ b/nmdc_schema/migrators/helpers.py
@@ -1,57 +1,14 @@
 import logging
-from typing import Any, Type, Optional, List
+from typing import Any
 from importlib import resources
 from pathlib import Path
-from migrator_base import MigratorBase
 import yaml
-import pkgutil
-import importlib
 
 logger = logging.getLogger(__name__)
 
 # TODO: Determine directory path and package path dynamically, instead of hard-coding them.
 MIGRATOR_DIRECTORY = "nmdc_schema/migrators"
 MIGRATOR_PACKAGE = "nmdc_schema.migrators"
-
-
-def get_migrator_module_names() -> List[str]:
-    """
-    Returns a list of all migrator module names.
-    """
-
-    module_names = [name for _, name, _ in pkgutil.iter_modules([MIGRATOR_DIRECTORY])]
-    migrator_module_names = [s for s in module_names if s.startswith("migrator_from_")]  # filters the list
-    return migrator_module_names
-
-
-def get_migrator_to(destination_version: str) -> Optional[Type[MigratorBase]]:
-    """
-    Returns a migrator class, if any, that migrates data to the specified schema version.
-    """
-
-    matching_migrator_class = None
-    for module_name in get_migrator_module_names():
-        try:
-            # Import the module having that name.
-            # Reference: https://docs.python.org/3/library/importlib.html#importlib.import_module
-            migrator_module = importlib.import_module(f".{module_name}", package=MIGRATOR_PACKAGE)
-
-            # Get the `Migrator` class defined in that module.
-            # Reference: https://docs.python.org/3/library/inspect.html#inspect.isclass
-            migrator_class = getattr(migrator_module, "Migrator")
-            if not issubclass(migrator_class, MigratorBase):
-                raise TypeError
-
-            # If that migrator class migrates data to the specified version, return the class.
-            if migrator_class.get_destination_version() == destination_version:
-                matching_migrator_class = migrator_class
-                break  # no need to check other classes
-
-        except (KeyError, ImportError, AttributeError, TypeError) as exception:
-            logger.exception(f"Failed to get migrator. {exception}.")
-
-    logger.warning(f"No compatible migrator found.")
-    return matching_migrator_class
 
 
 def load_yaml_asset(path_to_asset_file: str) -> Any:

--- a/nmdc_schema/migrators/helpers.py
+++ b/nmdc_schema/migrators/helpers.py
@@ -1,7 +1,57 @@
-from typing import Any
+import logging
+from typing import Any, Type, Optional, List
 from importlib import resources
 from pathlib import Path
+from migrator_base import MigratorBase
 import yaml
+import pkgutil
+import importlib
+
+logger = logging.getLogger(__name__)
+
+# TODO: Determine directory path and package path dynamically, instead of hard-coding them.
+MIGRATOR_DIRECTORY = "nmdc_schema/migrators"
+MIGRATOR_PACKAGE = "nmdc_schema.migrators"
+
+
+def get_migrator_module_names() -> List[str]:
+    """
+    Returns a list of all migrator module names.
+    """
+
+    module_names = [name for _, name, _ in pkgutil.iter_modules([MIGRATOR_DIRECTORY])]
+    migrator_module_names = [s for s in module_names if s.startswith("migrator_from_")]  # filters the list
+    return migrator_module_names
+
+
+def get_migrator_to(destination_version: str) -> Optional[Type[MigratorBase]]:
+    """
+    Returns the first migrator class that migrates data to the specified schema version.
+    """
+
+    matching_migrator_class = None
+    for module_name in get_migrator_module_names():
+        try:
+            # Import the module having that name.
+            # Reference: https://docs.python.org/3/library/importlib.html#importlib.import_module
+            migrator_module = importlib.import_module(f".{module_name}", package=MIGRATOR_PACKAGE)
+
+            # Get the `Migrator` class defined in that module.
+            # Reference: https://docs.python.org/3/library/inspect.html#inspect.isclass
+            migrator_class = getattr(migrator_module, "Migrator")
+            if not issubclass(migrator_class, MigratorBase):
+                raise TypeError
+
+            # If that migrator class migrates data to the specified version, return the class.
+            if migrator_class.get_destination_version() == destination_version:
+                matching_migrator_class = migrator_class
+                break  # no need to check other classes
+
+        except (KeyError, ImportError, AttributeError, TypeError) as exception:
+            logger.exception(f"Failed to get migrator. {exception}.")
+
+    logger.warning(f"No compatible migrator found.")
+    return matching_migrator_class
 
 
 def load_yaml_asset(path_to_asset_file: str) -> Any:
@@ -19,8 +69,7 @@ def load_yaml_asset(path_to_asset_file: str) -> Any:
     - https://realpython.com/python-yaml/#load-a-document-from-a-string-a-file-or-a-stream
     """
     # Define the Python path someone could use to `import` the package containing the `assets` directory.
-    # TODO: Determine package base name dynamically, instead of hard-coding it.
-    package_import_path = "nmdc_schema.migrators"
+    package_import_path = MIGRATOR_PACKAGE
 
     # Define the filesystem path to the `assets` directory (relative to that package).
     path_to_assets_directory = "assets"
@@ -33,7 +82,6 @@ def load_yaml_asset(path_to_asset_file: str) -> Any:
 
     # Use `resources.as_file()` to get an `open()`-able path to the asset file.
     with resources.as_file(traversable_resource_container) as file_path:
-
         # Finally, open the asset file and parse its contents as YAML.
         with open(file_path, "r") as f:
             obj = yaml.safe_load(f)  # the object type depends upon the YAML data

--- a/nmdc_schema/migrators/migrator_base.py
+++ b/nmdc_schema/migrators/migrator_base.py
@@ -9,13 +9,13 @@ class MigratorBase:
     #
     # Note: This string is empty here. It will be populated within the migration-specific classes.
     #
-    __from_version: str = ""
+    _from_version: str = ""
 
     # The schema version to which this class migrates data.
     #
     # Note: This string is empty here. It will be populated within the migration-specific classes.
     #
-    __to_version: str = ""
+    _to_version: str = ""
 
     def __init__(self, logger=None):
         # If a logger was specified, use it; otherwise, initialize one and use that.
@@ -32,16 +32,16 @@ class MigratorBase:
         # Note: This dictionary is empty here. It will be populated within the "constructor" functions
         #       of the migration-specific classes (i.e. the classes that inherit from this base class).
         #
-        self.agenda: Dict[str, List[callable]] = dict()
+        self._agenda: Dict[str, List[callable]] = dict()
 
     def get_from_version(self) -> str:
         """Returns the schema version this class migrates data from."""
-        return self.__from_version
+        return self._from_version
 
     def get_to_version(self) -> str:
         """Returns the schema version this class migrates data to."""
-        return self.__to_version
+        return self._to_version
 
     def get_transformers_for(self, collection_name: str) -> List[callable]:
         """Returns the list of transformers defined for the specified collection."""
-        return self.agenda.get(collection_name, [])
+        return self._agenda.get(collection_name, [])

--- a/nmdc_schema/migrators/migrator_base.py
+++ b/nmdc_schema/migrators/migrator_base.py
@@ -34,13 +34,15 @@ class MigratorBase:
         #
         self._agenda: Dict[str, List[callable]] = dict()
 
-    def get_from_version(self) -> str:
+    @classmethod
+    def get_origin_version(cls) -> str:
         """Returns the schema version this class migrates data from."""
-        return self._from_version
+        return cls._from_version
 
-    def get_to_version(self) -> str:
+    @classmethod
+    def get_destination_version(cls) -> str:
         """Returns the schema version this class migrates data to."""
-        return self._to_version
+        return cls._to_version
 
     def get_transformers_for(self, collection_name: str) -> List[callable]:
         """Returns the list of transformers defined for the specified collection."""

--- a/nmdc_schema/migrators/migrator_base.py
+++ b/nmdc_schema/migrators/migrator_base.py
@@ -3,9 +3,18 @@ from logging import getLogger
 
 
 class MigratorBase:
-    """Base class containing properties and methods related to migrating data between schema versions."""
+    """Base class containing properties and methods related to migrating data between two schema versions."""
 
+    # The schema version from which this class migrates data.
+    #
+    # Note: This string is empty here. It will be populated within the migration-specific classes.
+    #
     __from_version: str = ""
+
+    # The schema version to which this class migrates data.
+    #
+    # Note: This string is empty here. It will be populated within the migration-specific classes.
+    #
     __to_version: str = ""
 
     def __init__(self, logger=None):

--- a/nmdc_schema/migrators/migrator_base.py
+++ b/nmdc_schema/migrators/migrator_base.py
@@ -5,6 +5,9 @@ from logging import getLogger
 class MigratorBase:
     """Base class containing properties and methods related to migrating data between schema versions."""
 
+    __from_version: str = ""
+    __to_version: str = ""
+
     def __init__(self, logger=None):
         # If a logger was specified, use it; otherwise, initialize one and use that.
         self.logger = getLogger(__name__) if logger is None else logger
@@ -21,6 +24,14 @@ class MigratorBase:
         #       of the migration-specific classes (i.e. the classes that inherit from this base class).
         #
         self.agenda: Dict[str, List[callable]] = dict()
+
+    def get_from_version(self) -> str:
+        """Returns the schema version this class migrates data from."""
+        return self.__from_version
+
+    def get_to_version(self) -> str:
+        """Returns the schema version this class migrates data to."""
+        return self.__to_version
 
     def get_transformers_for(self, collection_name: str) -> List[callable]:
         """Returns the list of transformers defined for the specified collection."""

--- a/nmdc_schema/migrators/migrator_from_7_7_2_to_7_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_7_2_to_7_8_0.py
@@ -5,8 +5,11 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 DOI_URL_PATTERN = r"^https?:\/\/[a-zA-Z\.]+\/10\."
 
 
-class Migrator_from_7_7_2_to_7_8_0(MigratorBase):
-    """Migrates data from schema 7.7.2 to 7.8.0"""
+class Migrator(MigratorBase):
+    """Migrates data between two schema versions."""
+
+    __from_version = "7.7.2"
+    __to_version = "7.8.0"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -23,7 +26,7 @@ class Migrator_from_7_7_2_to_7_8_0(MigratorBase):
         Removes the `doi` field. If `doi.has_raw_value` contained a specific type of URL string, this function also adds
         an `award_dois` field whose value is a list containing a CURIE string derived from that URL string.
 
-        >>> m = Migrator_from_7_7_2_to_7_8_0()
+        >>> m = Migrator()
         >>> m.replace_doi_field_with_award_dois_list_field({'id': 123})  # no `doi` field
         {'id': 123}
         >>> m.replace_doi_field_with_award_dois_list_field({'id': 123, 'doi': {'has_raw_value': 'not-a-url'}})

--- a/nmdc_schema/migrators/migrator_from_7_7_2_to_7_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_7_2_to_7_8_0.py
@@ -8,8 +8,8 @@ DOI_URL_PATTERN = r"^https?:\/\/[a-zA-Z\.]+\/10\."
 class Migrator(MigratorBase):
     """Migrates data between two schema versions."""
 
-    __from_version = "7.7.2"
-    __to_version = "7.8.0"
+    _from_version = "7.7.2"
+    _to_version = "7.8.0"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -17,7 +17,7 @@ class Migrator(MigratorBase):
         super().__init__(*args, **kwargs)
 
         # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
+        self._agenda = dict(
             study_set=[self.replace_doi_field_with_award_dois_list_field],
         )
 

--- a/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
@@ -2,8 +2,11 @@ from typing import List
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
-class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
-    """Migrates data from schema 7.8.0 to 8.0.0"""
+class Migrator(MigratorBase):
+    """Migrates data between two schema versions."""
+
+    __from_version = "7.8.0"
+    __to_version = "8.0.0"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -22,7 +25,7 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         r"""
         Renames the `sample_mass` field to `input_mass`.
 
-        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m = Migrator()
         >>> m.rename_sample_mass_field({'id': 123})  # no `sample_mass` field
         {'id': 123}
         >>> m.rename_sample_mass_field({'id': 123, 'sample_mass': 456})  # test: renames field and preserves value
@@ -38,7 +41,7 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         r"""
         Replaces the prefix `GOLD:` with `gold:` in the list of identifiers.
 
-        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m = Migrator()
         >>> m.standardize_letter_casing_of_gold_identifiers(['GOLD:prefix_was_uppercase'])
         ['gold:prefix_was_uppercase']
         >>> m.standardize_letter_casing_of_gold_identifiers(['gold:prefix_was_lowercase'])
@@ -76,7 +79,7 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         r"""
         Converts uppercase "GOLD:" prefixes into lowercase "gold:" prefixes, in `gold_biosample_identifiers` values.
 
-        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m = Migrator()
         >>> m.standardize_letter_casing_of_gold_biosample_identifiers({'id': 123})
         {'id': 123, 'gold_biosample_identifiers': []}
         >>> m.standardize_letter_casing_of_gold_biosample_identifiers(
@@ -96,7 +99,7 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         r"""
         Converts uppercase "GOLD:" prefixes in `gold_sequencing_project_identifiers` values into lowercase "gold:".
 
-        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m = Migrator()
         >>> m.standardize_letter_casing_of_gold_sequencing_project_identifiers({'id': 123})
         {'id': 123, 'gold_sequencing_project_identifiers': []}
         >>> m.standardize_letter_casing_of_gold_sequencing_project_identifiers(
@@ -116,7 +119,7 @@ class Migrator_from_7_8_0_to_8_0_0(MigratorBase):
         r"""
         Converts uppercase "GOLD:" prefixes in `gold_study_identifiers` values into lowercase "gold:".
 
-        >>> m = Migrator_from_7_8_0_to_8_0_0()
+        >>> m = Migrator()
         >>> m.standardize_letter_casing_of_gold_study_identifier({'id': 123})
         {'id': 123, 'gold_study_identifiers': []}
         >>> m.standardize_letter_casing_of_gold_study_identifier(

--- a/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
+++ b/nmdc_schema/migrators/migrator_from_7_8_0_to_8_0_0.py
@@ -5,8 +5,8 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 class Migrator(MigratorBase):
     """Migrates data between two schema versions."""
 
-    __from_version = "7.8.0"
-    __to_version = "8.0.0"
+    _from_version = "7.8.0"
+    _to_version = "8.0.0"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -14,7 +14,7 @@ class Migrator(MigratorBase):
         super().__init__(*args, **kwargs)
 
         # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
+        self._agenda = dict(
             biosample_set=[self.standardize_letter_casing_of_gold_biosample_identifiers],
             extraction_set=[self.rename_sample_mass_field],
             omics_processing_set=[self.standardize_letter_casing_of_gold_sequencing_project_identifiers],

--- a/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
+++ b/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
@@ -4,8 +4,8 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 class Migrator(MigratorBase):
     """Migrates data between two schema versions."""
 
-    __from_version = "8.0"
-    __to_version = "8.1"
+    _from_version = "8.0"
+    _to_version = "8.1"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -13,7 +13,7 @@ class Migrator(MigratorBase):
         super().__init__(*args, **kwargs)
 
         # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
+        self._agenda = dict(
             study_set=[self.force_research_study_study_category],
         )
 

--- a/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
+++ b/nmdc_schema/migrators/migrator_from_8_0_to_8_1.py
@@ -1,8 +1,11 @@
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
-class Migrator_from_8_0_to_8_1(MigratorBase):
-    """previously: Migrates data from schema 8.0.0 to 8.1.0"""
+class Migrator(MigratorBase):
+    """Migrates data between two schema versions."""
+
+    __from_version = "8.0"
+    __to_version = "8.1"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -18,7 +21,7 @@ class Migrator_from_8_0_to_8_1(MigratorBase):
         r"""
         If the study lacks a field named `study_category`, creates it and assigns it the value "research_study".
 
-        >>> m = Migrator_from_8_0_to_8_1()
+        >>> m = Migrator()
         >>> m.force_research_study_study_category({'id': 123})  # field doesn't exist yet
         {'id': 123, 'study_category': 'research_study'}
         >>> m.force_research_study_study_category({'id': 123, 'study_category': 'preserve_me'})  # field already exists

--- a/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
@@ -2,8 +2,11 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 from nmdc_schema.migrators.helpers import load_yaml_asset
 
 
-class Migrator_from_8_1_to_9_0(MigratorBase):
-    """previously: Migrates data from schema 8.1.0 to 9.0.0"""
+class Migrator(MigratorBase):
+    """Migrates data between two schema versions."""
+
+    __from_version = "8.1"
+    __to_version = "9.0"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -21,7 +24,7 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         For each update descriptor in the `doi_list` list; if the specified study's `id` matches that descriptor's `id`,
         this function appends a DOI dictionary to the study's `associated_dois` list (creating the list if necessary).
 
-        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m = Migrator()
         >>> m.process_doi({'id': 123}, [{'id': 123, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` matches
         {'id': 123, 'associated_dois': [{'doi_value': 'a', 'doi_category': 'c', 'doi_provider': 'b'}]}
         >>> m.process_doi({'id': 123}, [{'id': 555, 'doi': 'a', 'doi_prov': 'b'}], 'c')  # `id` does not match
@@ -63,7 +66,7 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         r"""
         Copies `publication_dois` values into a new slot named `associated_dois`.
 
-        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m = Migrator()
         >>> m.fix_pub_dois({'id': 1, 'publication_dois': ['a']})  # test: a single DOI
         {'id': 1, 'publication_dois': ['a'], 'associated_dois': [{'doi_value': 'a', 'doi_category': 'publication_doi'}]}
         """
@@ -79,7 +82,7 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         r"""
         Changes the one `massive_study_identifiers` value into a DOI and moves it to a new `associated_dois` slot.
 
-        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m = Migrator()
         >>> m.fix_massive({'id': 123})
         {'id': 123, 'associated_dois': []}
         >>> m.fix_massive({'id': 123, 'massive_study_identifiers': ['not-the-one']})
@@ -105,7 +108,7 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         r"""
         Copies `ess_dive_datasets` values into a new slot named `associated_dois`.
 
-        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m = Migrator()
         >>> m.fix_ess_dive({'id': 1, 'ess_dive_datasets': ['a']})  # test: a single DOI
         {'id': 1, 'ess_dive_datasets': ['a'], 'associated_dois': [{'doi_value': 'a', 'doi_category': 'dataset_doi', 'doi_provider': 'ess_dive'}]}
         """
@@ -121,7 +124,7 @@ class Migrator_from_8_1_to_9_0(MigratorBase):
         r"""
         Removes slots that are no longer needed because their values have been moved to the `associated_dois` slot.
 
-        >>> m = Migrator_from_8_1_to_9_0()
+        >>> m = Migrator()
         >>> m.remove_doi_slots({'id': 123, 'associated_dois': []})  # empty `associated_dois` list gets removed
         {'id': 123}
         >>> m.remove_doi_slots({

--- a/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_8_1_to_9_0.py
@@ -5,8 +5,8 @@ from nmdc_schema.migrators.helpers import load_yaml_asset
 class Migrator(MigratorBase):
     """Migrates data between two schema versions."""
 
-    __from_version = "8.1"
-    __to_version = "9.0"
+    _from_version = "8.1"
+    _to_version = "9.0"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -14,7 +14,7 @@ class Migrator(MigratorBase):
         super().__init__(*args, **kwargs)
 
         # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
+        self._agenda = dict(
             study_set=[self.fix_award_dois, self.fix_pub_dois,
                        self.fix_massive, self.fix_ess_dive, self.remove_doi_slots],
         )

--- a/nmdc_schema/migrators/migrator_from_9_1_to_9_2.py
+++ b/nmdc_schema/migrators/migrator_from_9_1_to_9_2.py
@@ -1,8 +1,12 @@
 from nmdc_schema.migrators.migrator_base import MigratorBase
 from nmdc_schema.migrators.helpers import load_yaml_asset
 
-class Migrator_from_9_1_to_9_2(MigratorBase):
-    """Migrates data from schema 9.1.0 to 9.2.0"""
+
+class Migrator(MigratorBase):
+    """Migrates data between two schema versions."""
+
+    __from_version = "9.1"
+    __to_version = "9.2"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -19,7 +23,7 @@ class Migrator_from_9_1_to_9_2(MigratorBase):
         Transforms `websites` values that are dois into curies and moves them into the `associated_dois slot
         Removes the doi website values from the `websites slot.
         
-        >>> m = Migrator_from_9_1_to_9_2()
+        >>> m = Migrator()
         >>> m.move_doi_from_websites({'id': 123, 'websites': ['a', 'https://doi.org/10.25982/109073.30/1895615'], 'associated_dois': 
         ...     [{'doi_value': 'j', 'doi_provider': 'k', 'doi_category': 'i'}]})
         {'id': 123, 'websites': ['a'], 'associated_dois': [{'doi_value': 'j', 'doi_provider': 'k', 'doi_category': 'i'}, {'doi_value': 'doi:10.25982/109073.30/1895615', 'doi_category': 'dataset_doi', 'doi_provider': 'kbase'}]}

--- a/nmdc_schema/migrators/migrator_from_9_1_to_9_2.py
+++ b/nmdc_schema/migrators/migrator_from_9_1_to_9_2.py
@@ -5,8 +5,8 @@ from nmdc_schema.migrators.helpers import load_yaml_asset
 class Migrator(MigratorBase):
     """Migrates data between two schema versions."""
 
-    __from_version = "9.1"
-    __to_version = "9.2"
+    _from_version = "9.1"
+    _to_version = "9.2"
 
     def __init__(self, *args, **kwargs) -> None:
         """Invokes parent constructor and populates collection-to-transformations map."""
@@ -14,7 +14,7 @@ class Migrator(MigratorBase):
         super().__init__(*args, **kwargs)
 
         # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
+        self._agenda = dict(
             study_set=[self.move_doi_from_websites],
         )
 

--- a/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
+++ b/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
@@ -15,10 +15,10 @@ class Migrator(MigratorBase):
               "migrator" class was designed to migrate data between.
               
               -->  As part of creating a new "migrator" class, you will
-                   populate its `__from_version` and `__to_version` strings.
+                   populate its `_from_version` and `_to_version` strings.
     """
-    __from_version = "A.B.C"
-    __to_version = "X.Y.Z"
+    _from_version = "A.B.C"
+    _to_version = "X.Y.Z"
 
     def __init__(self, *args, **kwargs) -> None:
         """
@@ -46,7 +46,7 @@ class Migrator(MigratorBase):
         super().__init__(*args, **kwargs)
 
         # Populate the "collection-to-transformers" map for this specific migration.
-        self.agenda = dict(
+        self._agenda = dict(
             study_set=[self.allow_multiple_names],
         )
 

--- a/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
+++ b/nmdc_schema/migrators/migrator_from_A_B_C_to_X_Y_Z.py
@@ -1,14 +1,24 @@
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
-class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
+class Migrator(MigratorBase):
     """
-    Migrates data from schema A.B.C to X.Y.Z
+    Migrates data between two schema versions.
 
     TUTORIAL: This is an example of a "migrator" class.
               It was designed for use during developer training and
               to serve as a template for production "migrator" classes.
     """
+
+    """
+    TUTORIAL: These two strings tell people the versions of the schema this
+              "migrator" class was designed to migrate data between.
+              
+              -->  As part of creating a new "migrator" class, you will
+                   populate its `__from_version` and `__to_version` strings.
+    """
+    __from_version = "A.B.C"
+    __to_version = "X.Y.Z"
 
     def __init__(self, *args, **kwargs) -> None:
         """
@@ -27,7 +37,7 @@ class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
                      security guards at marathons say, "If it ain't
                      part of the plan, it ain't gonna be ran."
 
-             -->  As part of creating a new "migration" class, you will
+             -->  As part of creating a new "migrator" class, you will
                   populate its "agenda."
         """
 
@@ -54,7 +64,7 @@ class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
                   2. It transforms that dictionary.
                   3. It returns the transformed dictionary.
 
-              --> As part of creating a new "migration" class, you will
+              --> As part of creating a new "migrator" class, you will
                   typically implement one or more "transformation" functions.
                   You will also add them to the "agenda" of the class.
 
@@ -72,7 +82,7 @@ class Migrator_from_A_B_C_to_X_Y_Z(MigratorBase):
               --> As part of implementing a "transformation" function, you will
                   typically write a few doctests in the docstring of that function.
 
-        >>> mig = Migrator_from_A_B_C_to_X_Y_Z()  # creates a class instance on which we can call this function (method)
+        >>> mig = Migrator()  # creates a class instance on which we can call this function (method)
         >>> mig.allow_multiple_names({'id': 123, 'name': 'My project'})  # test: transfers existing name to `names` list
         {'id': 123, 'names': ['My project']}
         >>> mig.allow_multiple_names({'id': 123, 'name': 'My project', 'foo': 'bar'})  # test: preserves other keys

--- a/project.Makefile
+++ b/project.Makefile
@@ -549,5 +549,6 @@ migration-doctests:
 	$(RUN) python -m doctest -v nmdc_schema/migrators/cli/*.py
 
 # Generates a migrator skeleton for the specified schema versions.
+# Note: `create-migrator` is a Poetry script registered in `pyproject.toml`.
 migrator:
-	$(RUN) python nmdc_schema/migrators/cli/create_migrator.py
+	$(RUN) create-migrator

--- a/project.Makefile
+++ b/project.Makefile
@@ -543,9 +543,10 @@ assets/filtered-api-requests/filtered-request-result.yaml
 
 .PHONY: migration-doctests migrator
 
-# Runs all doctests defined within the migrator modules.
+# Runs all doctests defined within the migrator modules and CLI scripts.
 migration-doctests:
 	$(RUN) python -m doctest -v nmdc_schema/migrators/*.py
+	$(RUN) python -m doctest -v nmdc_schema/migrators/cli/*.py
 
 # Generates a migrator skeleton for the specified schema versions.
 migrator:

--- a/project.Makefile
+++ b/project.Makefile
@@ -541,8 +541,12 @@ assets/filtered-api-requests/filtered-request-validation-log.txt: nmdc_schema/nm
 assets/filtered-api-requests/filtered-request-result.yaml
 	- $(RUN) linkml-validate --schema $^ > $@
 
-.PHONY: migration-doctests
+.PHONY: migration-doctests migrator
 
 # Runs all doctests defined within the migrator modules.
 migration-doctests:
 	$(RUN) python -m doctest -v nmdc_schema/migrators/*.py
+
+# Generates a migrator skeleton for the specified schema versions.
+migrator:
+	$(RUN) python nmdc_schema/migrators/cli/create_migrator.py

--- a/project.Makefile
+++ b/project.Makefile
@@ -466,7 +466,7 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 local/mongo_as_nmdc_database_rdf_safe.yaml: nmdc_schema/nmdc_schema_accepting_legacy_ids.yaml local/mongo_as_unvalidated_nmdc_database.yaml
 	date # 449.56 seconds on 2023-08-30 without functional_annotation_agg or metaproteomics_analysis_activity_set
 	time $(RUN) migration-recursion \
-		--migrator-name Migrator_from_9_1_to_9_2 \
+		--migrator-name migrator_from_9_1_to_9_2 \
 		--schema-path $(word 1,$^) \
 		--input-path $(word 2,$^) \
 		--salvage-prefix generic \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ get-mixs-slots-matching-slot-list = "nmdc_schema.get_mixs_slots_matching_slot_li
 get-mixs-slots-used-in-schema = "nmdc_schema.get_mixs_slots_used_in_schema:main" # see nmdc_schema/generate_import_slots_regardless.py
 get-slots-from-class = "nmdc_schema.get_slots_from_class:main" # see tests/test_getters.py
 migration-recursion = 'nmdc_schema.migration_recursion:main'
+create-migrator = 'nmdc_schema.migrators.cli.create_migrator:create_migrator'
 nmdc-data = "nmdc_schema.nmdc_data:cli"
 nmdc-version = "nmdc_schema.nmdc_version:cli"
 pure-export = "nmdc_schema.mongo_dump_api_emph:cli"


### PR DESCRIPTION
### Summary of changes

1. `migrators/*.py`
    1. Rename migrator classes from `Migrator_from_...` to `Migrator`.
        1. Update all references accordingly.
    1. Add `_from_version` and `_to_version` attributes. They will enable future automation.
    1. Change `self.agenda` to `self._agenda` (making it "private-by-convention").
        1. Update all references accordingly.
1. `migrators/cli`
    1. Implement CLI command that generates a no-op migrator.
        1. Add a `migrator` target to `project.Makefile`.
        1. Update a target in `project.Makefile` to run the associated doctests.
        1. Document this in `migrators/README.md`
1. `migrators/README.md`
    1. Add a link to the version numbering guide residing in `CHANGELOG.md`.
1. `migration_recursion.py`
    1. Update CLI option to be a migrator _module_ name instead of a _class_ name.
    1. Instead of assuming transformer functions modify the dictionary in place, assume they return the transformed dictionary. The former was never a requirement placed upon them, whereas the latter has always been.

#### Demo

Here's what it looks like when I run `$ make migrator`:

```shell
$ make migrator
poetry run python nmdc_schema/migrators/cli/create_migrator.py
From schema version: 1.2.4
To schema version: 2.6
Created 'migrator_from_1_2_4_to_2_6.py' successfully.
```