### PR TITLE
1338 add slots infiltration 1 infiltration 2 infiltration notes

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -3039,6 +3039,21 @@ slots:
       description: The conductivity measurement was 0.017 millisiemens per centimeter.
     range: QuantityValue
 
+  infiltrations:
+    annotations:
+      expected_value:
+        tag: expected_value
+        value: first infiltration time;second infiltration time;notes
+    description: The amount of time it takes to accomplish the first and second infiltration activities, and any details, issues, or context needed to understand the infiltration activity.
+    examples:
+      - value: 40 minutes;50 minutes;2017-08-24
+    aliases:
+      - infiltration_1
+      - infiltration_2
+      - infiltration_notes
+    multivalued: true
+    list_elements_ordered: true
+    range: TextValue
 
   filter_material:
     description: "A porous material on which solid particles present in air or other fluid which flows through it are largely caught and retained."

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1100,6 +1100,7 @@ classes:
 
       ## EMSL slots
       - bulk_elect_conductivity
+      - infiltrations
 
       ## bioscales slots
       - zinc


### PR DESCRIPTION
Adding "infiltrations" as a multivalued slot encompassing the EMSL metadata headers "infiltration_1", "infiltration_2", and "infiltration_notes"