### PR TITLE
Allow tables to be sorted in schema documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,8 @@ gendoc: $(DOCDIR)
 	cp $(SRC)/docs/*md $(DOCDIR) ; \
 	cp -r $(SRC)/docs/images $(DOCDIR) ; \
 	$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) $(SOURCE_SCHEMA_PATH)
+	mkdir -p $(DOCDIR)/javascripts
+	$(RUN) cp $(SRC)/scripts/javascripts/* $(DOCDIR)/javascripts/
 
 testdoc: gendoc serve
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,11 @@ plugins:
       redirect_maps:
         'home.md': 'index.md'  # redirects "/home" to "/"
 markdown_extensions:
+  - tables
   - pymdownx.magiclink
+extra_javascript:
+  - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
+  - javascripts/tablesort.js
 nav:
   - About: about.md
   - Identifiers in NMDC: identifiers.md

--- a/src/scripts/javascripts/tablesort.js
+++ b/src/scripts/javascripts/tablesort.js
@@ -1,0 +1,6 @@
+document$.subscribe(function () {
+    var tables = document.querySelectorAll("article table:not([class])");
+    tables.forEach(function (table) {
+      new Tablesort(table);
+    });
+  });


### PR DESCRIPTION
All tables in the NMDC schema docs should have the table sorting feature enabled.