### PR TITLE
1130 emsl data object prefix

### DIFF
--- a/src/data/valid/DataObject-my_emsl_prefix.yaml
+++ b/src/data/valid/DataObject-my_emsl_prefix.yaml
@@ -1,0 +1,9 @@
+id: nmdc:dobj-11-mzxj8743
+name: Froze_Core_2015_S1_30_40_3_QE_26May16_Pippin_16-03-39.raw
+description: raw instrument file for nmdc:omprc-11-7nfk8n58
+file_size_bytes: 448727423
+url: https://nmdcdemo.emsl.pnnl.gov/proteomics/raw/Froze_Core_2015_S1_30_40_3_QE_26May16_Pippin_16-03-39.raw
+md5_checksum: ED2BA6CD95CE5D86D8D29A8DD548F48F
+data_object_type: LC-DDA-MS/MS Raw Data
+alternative_identifiers:
+- my_emsl:1016236

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -96,6 +96,7 @@ prefixes:
   xsd: http://www.w3.org/2001/XMLSchema#
   CHMO: "http://purl.obolibrary.org/obo/CHMO_"
   wikidata: "http://www.wikidata.org/entity/"
+  my_emsl: "https://release.my.emsl.pnnl.gov/released_data/"
 
 
 default_prefix: nmdc


### PR DESCRIPTION
Pull request to add my_emsl prefix. Needed to make resolvable alternative identifiers for new data object records as part of the re-ing effort.