### PR TITLE
1525 add slots to material processing classes that were on omics processing

### DIFF
--- a/src/data/valid/ChromatographicSeparationProcess-SPE.yaml
+++ b/src/data/valid/ChromatographicSeparationProcess-SPE.yaml
@@ -1,4 +1,4 @@
-id: nmdc:psp-99-oW43DzG0 
+id: nmdc:matprc-99-oW43DzG0 
 has_input: 
   - nmdc:procsm-11-9gjxns61
 has_output:

--- a/src/data/valid/ChromatographicSeparationProcess-compilation_example.yaml
+++ b/src/data/valid/ChromatographicSeparationProcess-compilation_example.yaml
@@ -1,4 +1,4 @@
-id: nmdc:psp-99-oW43DzG0 
+id: nmdc:matprc-99-oW43DzG0 
 has_input: 
   - nmdc:procsm-11-9gjxns61
 has_output:

--- a/src/data/valid/FiltrationProcess-minimal_pressurized.yaml
+++ b/src/data/valid/FiltrationProcess-minimal_pressurized.yaml
@@ -1,4 +1,4 @@
-id: nmdc:fp-2
+id: nmdc:matprc-22-32G2BS
 has_input:
   - nmdc:processed-sample-3
 has_output:

--- a/src/data/valid/MixingProcess-minimal.yaml
+++ b/src/data/valid/MixingProcess-minimal.yaml
@@ -1,4 +1,4 @@
-id: nmdc:mp-1
+id: nmdc:matprc-11-A74
 has_input:
   - nmdc:biosample-1 #This is an example biosample ID and does not represent a real biosample
   - nmdc:processed-sample-2

--- a/src/data/valid/SubSamplingProcess-minimal.yaml
+++ b/src/data/valid/SubSamplingProcess-minimal.yaml
@@ -1,4 +1,4 @@
-id: nmdc:sops-99-oW43DzG0 
+id: nmdc:matprc-99-oW43DzG0 
 has_input: 
   - nmdc:bsm-99-oW43DzG1 #This is an example biosample ID and does not represent a real biosample
 container_size:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -99,12 +99,15 @@ slots:
     maximum_value: 2000
 
   extraction_target:
+    description: Provides the target biomolecule that has been separated from a sample during an extraction process.
     rank: 1000
     domain_of:
       - Extraction
     range: ExtractionTargetEnum
     notes:
       - todos, remove nucl_acid_ext from OmicsProcessing (DataGeneration)
+      - todos, remove phenol/chloroform extraction from ExtractionTargetEnum. Is this used anywhere?
+      - todos, deprecate extraction_method from nmdc.yaml
     narrow_mappings:
       - NCIT:C177560
       - MIXS:0000037

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -97,11 +97,18 @@ slots:
     recommended: true
     minimum_value: 0
     maximum_value: 2000
+
   extraction_target:
     rank: 1000
     domain_of:
       - Extraction
     range: ExtractionTargetEnum
+    notes:
+      - todos, remove nucl_acid_ext from OmicsProcessing (DataGeneration)
+    narrow_mappings:
+      - NCIT:C177560
+      - MIXS:0000037
+
   id:
     required: true
     identifier: true

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2357,13 +2357,8 @@ slots:
   extraction_method:
     domain: Extraction
     range: ExtractionTargetEnum
-    description: Any procedure used to separate parts of a sample.
     notes:
-      - todos, confirm definition based on an existing too specific definition "Any procedure used to purify nucleic acids (DNA or RNA) from a biological sample"
-      - todos, remove nucl_acid_ext from OmicsProcessing (DataGeneration)
-    narrow_mappings:
-      - NCIT:C177560
-      - MIXS:0000037
+      - todos, deprecate this once protocol_link on ProtocolExecution is complete
 
   quality_control_report:
     domain: PlannedProcess

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -195,7 +195,7 @@ classes:
 
   Pooling:
     class_uri: nmdc:Pooling
-    is_a: BiosampleProcessing
+    is_a: MaterialProcessing
     description: physical combination of several instances of like material.
     slots:
     exact_mappings:
@@ -214,7 +214,7 @@ classes:
 
   Extraction:
     class_uri: nmdc:Extraction
-    is_a: PlannedProcess # from core.yaml
+    is_a: MaterialProcessing
     description: A material separation in which a desired component of an input material is separated from the remainder.
     exact_mappings:
       - OBI:0302884
@@ -225,11 +225,6 @@ classes:
       - input_mass
       - quality_control_report
     slot_usage:
-      has_input:
-        required: true
-        any_of:
-          - range: Biosample
-          - range: ProcessedSample
       has_output:
         required: true
       id:
@@ -275,7 +270,7 @@ classes:
     class_uri: nmdc:LibraryPreparation
     aliases:
       - LibraryConstruction
-    is_a: BiosampleProcessing
+    is_a: MaterialProcessing
     slots:
       - library_preparation_kit
       - library_type
@@ -285,8 +280,6 @@ classes:
     comments:
       - OBI:0000711 specifies a DNA input (but not ONLY a DNA input)
     slot_usage:
-      has_input:
-        required: true
       has_output:
         required: true
       id:
@@ -1524,24 +1517,27 @@ classes:
       - "sample mgnify link https://www.ebi.ac.uk/metagenomics/studies/MGYS00005757"
       - "GOLD, insdc.srs and mgnify are reasonable prefixes for alternative study identifiers, but no longer for the Study.id"
 
-  BiosampleProcessing:
-    aliases:
-      - material processing
+  MaterialProcessing:
     is_a: PlannedProcess
     description:
-      A process that takes one or more biosamples as inputs and generates
-      one or more biosamples as outputs. An example of an output includes samples cultivated from another
-      sample.
+      A process that takes one or more samples as inputs and generates
+      one or more samples as outputs. 
     slots:
       - has_input
+    notes: 
+      - This class is a replacement for BiosampleProcessing.
     slot_usage:
       id:
         required: true
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:bsmprc-{id_shoulder}-{id_blade}{id_version}{id_locus}"
+          syntax: "{id_nmdc_prefix}:matprc-{id_shoulder}-{id_blade}{id_version}{id_locus}"
           interpolated: true
       has_input:
-        range: Biosample
+        any_of:
+          - range: Biosample
+          - range: ProcessedSample
+      has_output:
+        range: ProcessedSample
     broad_mappings:
       - OBI:0000094
 
@@ -1564,7 +1560,7 @@ classes:
       - ORCID:0000-0002-8683-0050 #Montana Smith
       - ORCID:0000-0001-9076-6066 #Mark Miller
       - ORCID:0009-0008-4013-7737 #James Tessmer
-    is_a: PlannedProcess
+    is_a: MaterialProcessing
     slots:
       - container_size
       - contained_in
@@ -1576,10 +1572,6 @@ classes:
         description: The output volume of the SubSampling Process.
       mass:
         description: The output mass of the SubSampling Process.
-      has_input:
-        any_of:
-          - range: Biosample
-          - range: ProcessedSample
       has_output:
         range: ProcessedSample
         description: The subsample.
@@ -1590,7 +1582,7 @@ classes:
     contributors:
       - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
       - ORCID:0000-0002-8683-0050 #Montana Smith
-    is_a: PlannedProcess
+    is_a: MaterialProcessing
     comments:
       - The mixing may be achieved manually or mechanically by shifting the material with stirrers or pumps
         or by revolving or shaking the container.
@@ -1600,10 +1592,6 @@ classes:
     slots:
       - duration
     slot_usage:
-      has_input:
-        any_of:
-          - range: Biosample
-          - range: ProcessedSample
       has_output:
         range: ProcessedSample
         description: The mixed sample.
@@ -1618,7 +1606,7 @@ classes:
       - ORCID:0000-0002-8683-0050 #Montana Smith
       - ORCID:0000-0001-9076-6066 #Mark Miller
       - ORCID:0009-0008-4013-7737 #James Tessmer
-    is_a: PlannedProcess
+    is_a: MaterialProcessing
     slots:
       - conditionings
       - container_size
@@ -1638,16 +1626,11 @@ classes:
     contributors:
       - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
       - ORCID:0000-0002-1368-8217 #Yuri Corilo
-    is_a: PlannedProcess
+    is_a: MaterialProcessing
     slots:
       - ordered_mobile_phases
       - stationary_phase
       - temperature
-    slot_usage:
-      has_input:
-        any_of:
-          - range: Biosample
-          - range: ProcessedSample
 
   OmicsProcessing:
     aliases:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2343,6 +2343,8 @@ slots:
 
   library_preparation_kit:
     range: string
+
+ ## WHY ARE THESE COMMENTED OUT?
   #    exact_mappings:
   #      - GENEPIO:0001450
   #  processed_date: # can we move this or infer this from the date of some other process?
@@ -2351,9 +2353,17 @@ slots:
   #  extraction_date: # replacing with start_ and end_date
   #    #    range: date
   #    range: string
+
   extraction_method:
     domain: Extraction
     range: ExtractionTargetEnum
+    description: Any procedure used to separate parts of a sample.
+    notes:
+      - todos, confirm definition based on an existing too specific definition "Any procedure used to purify nucleic acids (DNA or RNA) from a biological sample"
+      - todos, remove nucl_acid_ext from OmicsProcessing (DataGeneration)
+    narrow_mappings:
+      - NCIT:C177560
+      - MIXS:0000037
 
   quality_control_report:
     domain: PlannedProcess


### PR DESCRIPTION
nucl_acid_ext exists on OmicsProcessing (DataGeneration) and Biosample

This PR is adding MIXS slot nucl_acid_ext as a narrow_mapping for extraction_method and extraction_target as it's providing BOTH
This PR also adds http://purl.obolibrary.org/obo/NCIT_C177560 as a narrow_mapping for both extraction_method and extraction_target as this is also a more specific way of identifying BOTH.