### PR TITLE
1432 fix file type enum permissible value msn data

### DIFF
--- a/src/data/valid/DataObject-my_emsl_prefix.yaml
+++ b/src/data/valid/DataObject-my_emsl_prefix.yaml
@@ -4,6 +4,6 @@ description: raw instrument file for nmdc:omprc-11-7nfk8n58
 file_size_bytes: 448727423
 url: https://nmdcdemo.emsl.pnnl.gov/proteomics/raw/Froze_Core_2015_S1_30_40_3_QE_26May16_Pippin_16-03-39.raw
 md5_checksum: ED2BA6CD95CE5D86D8D29A8DD548F48F
-data_object_type: LC-DDA-MS/MS Raw Data
+data_object_type: LC-DDA-MSn Raw Data
 alternative_identifiers:
 - my_emsl:1016236

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2107,7 +2107,7 @@ enums:
           Direct infusion 21 Tesla Fourier Transform ion cyclotron resonance
           mass spectrometry raw data acquired in broadband full scan mode
 
-      LC-DDA-MS/MS Raw Data:
+      LC-DDA-MSn Raw Data:
         description: Liquid chromatographically separated MS1 and Data-Dependent MS2 binary instrument file
 
   credit enum:


### PR DESCRIPTION
Update to FIleTypeEnum permissible values.
Python doesn't like forward slashes in permissible values.