### PR TITLE
Implement a container-based development environment for `nmdc-schema`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,93 @@
+# Development
+
+## Development environment
+
+This repository includes a container-based development environment. That environment consists of a single container—running Linux—in which all the dependencies of this project are present (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)).
+
+Here's a diagram showing how a developer can access various parts of the development environment from a terminal running in the host environment (i.e. the environment _hosting_ the container). 
+
+```mermaid
+---
+title: Development environment
+---
+graph BT
+    %% Nodes:
+    dir["Repository<br>root directory"]
+    host["Terminal<br>(You are here)"]
+    
+    %% Links:
+    host -- "$ curl http://localhost:8000" --> mkdocs
+    host -- "$ docker compose exec app bash" --> bash
+    bash -- "# cd /nmdc-schema" --> dir
+    host -- "$ cd ." --> dir
+    
+    subgraph Container["Container"]
+        %% Nodes:
+        mkdocs["MkDocs dev-server"]
+        bash["bash shell"]
+    end
+```
+
+### Usage
+
+Here's how you can instantiate the development environment on your computer.
+
+#### Prerequisites
+
+- [Docker](https://www.docker.com/products/docker-desktop/) is installed on your computer.
+  - For example, version 24:
+    ```shell
+    $ docker --version
+    Docker version 24.0.6, build ed223bc
+    ```
+
+#### Procedure
+
+1. In the root folder of the repository, run the container.
+   ```shell
+   docker compose up --detach
+   ```
+   > The first time you run that, it will take several **minutes** to finish. During that time, Docker will be _building_ a container image. When you run the command in the future, Docker will reuse that container image (unless you append `--build`).
+   >
+   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then change the command to `DOCS_PORT=1234 docker compose up --detach` and re-run it (you can replace `1234` with any other port number between `1024`-`65535`, inclusive). You can try different port numbers until that error message stops appearing.
+2. Connect to a bash shell running within the container.
+   ```shell
+   docker compose exec app bash
+   ```
+   > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container running on your computer, and you are using something other than `ssh` to communicate with it.
+3. (Optional) Explore the container!
+   ```shell
+   $ whoami
+   $ hostname
+   $ uname -a
+   # ...
+   $ yq --version
+   $ jena --version
+   $ make --version
+   $ python --version
+   $ poetry --version
+   $ ls /nmdc-schema
+   ```
+   > The root directory of the repository is mounted at `/nmdc-schema` within the container. Changes you make in that directory on your computer will show up within the container, and vice versa. 
+4. (Optional) Generate the MkDocs docs.
+   ```shell
+   $ make gendoc
+   ```
+5. (Optional) Visit the MkDocs dev-server.
+   - In your web browser, visit http://localhost:8000
+     > Note: If you customized `DOCS_PORT` earlier, use that port number instead of `8000` here.
+6. Use the container as your `nmdc-schema` development environment.
+   ```shell
+   $ poetry install
+   $ make squeaky-clean
+   $ poetry shell
+   # etc.
+   ```
+7. (Optional) Done working on this project (e.g. for the day)? Stop the container.
+   ```shell
+   # (Optional) Disconnect from the container.
+   $ exit
+   
+   # Stop the container.
+   docker compose down
+   ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,6 @@ RUN poetry install
 ENV BANNER_BASE64="4paR4paI4paR4paI4paR4paI4paA4paA4paR4paI4paR4paR4paR4paI4paA4paA4paR4paI4paA4paI4paR4paI4paE4paI4paR4paI4paA4paA4paR4paICuKWkeKWiOKWhOKWiOKWkeKWiOKWgOKWgOKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWgOKWgOKWkeKWgArilpHiloDilpHiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDilpHiloDilpHiloDiloDiloDilpHiloAK"
 RUN echo "echo ${BANNER_BASE64} | base64 --decode" >> /root/.bashrc
 
-# Run the MkDocs dev-server and configure it to accepts HTTP requests from outside the container.
+# Run the MkDocs dev-server, configuring it to accept HTTP requests from outside the container.
 # Reference: https://github.com/mkdocs/mkdocs/issues/1239#issuecomment-354491734
 CMD ["poetry", "run", "mkdocs", "serve", "--dev-addr", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
 # Download and install a Java Development Kit >= 11.
 # Note: This is a dependency of Apache Jena.
 RUN wget -P /downloads/tmp "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-aarch64_bin.tar.gz"
-RUN mkdir /downloads/openjdk && \
+RUN mkdir -p /downloads/openjdk && \
     tar -xvzf /downloads/tmp/openjdk-21.0.1_linux-aarch64_bin.tar.gz -C /downloads/openjdk
+RUN rm -rf /downloads/tmp/openjdk-21.0.1_linux-aarch64_bin.tar.gz
 ENV JAVA_HOME="/downloads/openjdk/jdk-21.0.1/"
 
 # Download and install Apache Jena.
@@ -26,7 +27,9 @@ ENV JAVA_HOME="/downloads/openjdk/jdk-21.0.1/"
 # - https://archive.apache.org/dist/jena/binaries/ (older binaries)
 # - https://dlcdn.apache.org/jena/binaries/ (newest binaries, but download URL changes when new version is released).
 RUN wget -P /downloads/tmp "https://archive.apache.org/dist/jena/binaries/apache-jena-4.9.0.zip"
-RUN unzip /downloads/tmp/apache-jena-4.9.0.zip -d /downloads/apache-jena
+RUN mkdir -p /downloads/apache-jena && \
+    unzip /downloads/tmp/apache-jena-4.9.0.zip -d /downloads/apache-jena
+RUN rm -rf /downloads/tmp/apache-jena-4.9.0.zip
 ENV JENAROOT="/downloads/apache-jena/apache-jena-4.9.0"
 ENV PATH="$JENAROOT/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,14 @@ ADD ./poetry.lock    /nmdc-schema/poetry.lock
 ADD ./pyproject.toml /nmdc-schema/pyproject.toml
 RUN poetry install
 
-# Define a "WELCOME!" banner that will be displayed when accessing the bash shell.
+# Configure the container to display a "WELCOME!" message and the OS name whenever
+# someone starts an interactive shell session (i.e. "connects to the shell").
 # Reference: https://www.asciiart.eu/text-to-ascii-art (Pagga font)
 ENV BANNER_BASE64="4paR4paI4paR4paI4paR4paI4paA4paA4paR4paI4paR4paR4paR4paI4paA4paA4paR4paI4paA4paI4paR4paI4paE4paI4paR4paI4paA4paA4paR4paICuKWkeKWiOKWhOKWiOKWkeKWiOKWgOKWgOKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWgOKWgOKWkeKWgArilpHiloDilpHiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDilpHiloDilpHiloDiloDiloDilpHiloAK"
-RUN echo "echo ${BANNER_BASE64} | base64 --decode" >> /root/.bashrc
+RUN echo "echo ''"                                                        >> /etc/bash.bashrc
+RUN echo "echo ${BANNER_BASE64} | base64 --decode"                        >> /etc/bash.bashrc
+RUN echo "cat /etc/os-release | sed -n 's/PRETTY_NAME=\"\(.*\)\"/\\\1/p'" >> /etc/bash.bashrc
+RUN echo "echo ''"                                                        >> /etc/bash.bashrc
 
 # Run the MkDocs dev-server, configuring it to accept HTTP requests from outside the container.
 # Reference: https://github.com/mkdocs/mkdocs/issues/1239#issuecomment-354491734

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
 RUN wget -P /downloads/tmp "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-aarch64_bin.tar.gz"
 RUN mkdir /downloads/openjdk && \
     tar -xvzf /downloads/tmp/openjdk-21.0.1_linux-aarch64_bin.tar.gz -C /downloads/openjdk
-ENV JAVA_HOME=/downloads/openjdk/jdk-21.0.1/
+ENV JAVA_HOME="/downloads/openjdk/jdk-21.0.1/"
 
 # Download and install Apache Jena.
 # References:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,31 @@
+# Use Python 3.9 because that's the Python version listed in `pyproject.toml`.
 FROM python:3.9
 
-ADD . /src/
+WORKDIR /src
 
-RUN \
-    pip install poetry && \
-    cd /src && poetry install 
+# Download and install pandoc.
+RUN apt update && \
+    apt install -y \
+      pandoc
+
+# Download and install yq.
+# Reference: https://github.com/mikefarah/yq#install
+RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+    chmod +x /usr/bin/yq
+
+# Download and install Apache Jena.
+# References:
+# - https://sparrowflights.blogspot.com/2012/12/how-to-install-jena-command-line-tools.html
+# - https://archive.apache.org/dist/jena/binaries/ (older binaries)
+# - https://dlcdn.apache.org/jena/binaries/ (newest binaries, but download URL changes when new version is released).
+RUN wget -P /downloads/tmp "https://archive.apache.org/dist/jena/binaries/apache-jena-4.9.0.zip"
+RUN unzip /downloads/tmp/apache-jena-4.9.0.zip -d /downloads/apache-jena
+ENV JENAROOT="/downloads/apache-jena/apache-jena-4.9.0"
+ENV PATH="$JENAROOT/bin:$PATH"
+
+RUN pip install poetry
+
+ADD . /src/
+RUN poetry install
+
+CMD ["echo", "Hello and goodbye."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,6 @@ FROM python:3.9
 
 WORKDIR /nmdc-schema
 
-# Download and install pandoc.
-RUN apt update && \
-    apt install -y \
-      pandoc
-
 # Download and install yq.
 # Reference: https://github.com/mikefarah/yq#install
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,9 @@ ENV PATH="$JENAROOT/bin:$PATH"
 # Install Poetry, a package manager for Python (an alternative to pip).
 RUN pip install poetry
 
-# Install the project dependencies.
-ADD . /nmdc-schema/
+# Install the project's Python dependencies.
+ADD ./poetry.lock    /nmdc-schema/poetry.lock
+ADD ./pyproject.toml /nmdc-schema/pyproject.toml
 RUN poetry install
 
 # Run the MkDocs dev-server and configure it to accepts HTTP requests from outside the container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,14 +48,13 @@ ADD ./poetry.lock    /nmdc-schema/poetry.lock
 ADD ./pyproject.toml /nmdc-schema/pyproject.toml
 RUN poetry install
 
-# Configure the container to display a "WELCOME!" message and the OS name whenever
+# Configure the container to display a welcome message and the OS name whenever
 # someone starts an interactive shell session (i.e. "connects to the shell").
-# Reference: https://www.asciiart.eu/text-to-ascii-art (Pagga font)
-ENV BANNER_BASE64="4paR4paI4paR4paI4paR4paI4paA4paA4paR4paI4paR4paR4paR4paI4paA4paA4paR4paI4paA4paI4paR4paI4paE4paI4paR4paI4paA4paA4paR4paICuKWkeKWiOKWhOKWiOKWkeKWiOKWgOKWgOKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWgOKWgOKWkeKWgArilpHiloDilpHiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDilpHiloDilpHiloDiloDiloDilpHiloAK"
-RUN echo "echo ''"                                                        >> /etc/bash.bashrc
-RUN echo "echo ${BANNER_BASE64} | base64 --decode"                        >> /etc/bash.bashrc
-RUN echo "cat /etc/os-release | sed -n 's/PRETTY_NAME=\"\(.*\)\"/\\\1/p'" >> /etc/bash.bashrc
-RUN echo "echo ''"                                                        >> /etc/bash.bashrc
+RUN echo "OS_NAME=\$(cat /etc/os-release | sed -n 's/PRETTY_NAME=\"\(.*\)\"/\\\1/p')" >> /etc/bash.bashrc
+RUN echo "echo \"\""                                                                  >> /etc/bash.bashrc
+RUN echo "echo \"    Welcome to this nmdc-schema development container,\""            >> /etc/bash.bashrc
+RUN echo "echo \"    which is running \${OS_NAME}\"."                                 >> /etc/bash.bashrc
+RUN echo "echo \"\""                                                                  >> /etc/bash.bashrc
 
 # Run the MkDocs dev-server, configuring it to accept HTTP requests from outside the container.
 # Reference: https://github.com/mkdocs/mkdocs/issues/1239#issuecomment-354491734

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use Python 3.9 because that's the Python version listed in `pyproject.toml`.
 FROM python:3.9
 
-WORKDIR /src
+WORKDIR /nmdc-schema
 
 # Download and install pandoc.
 RUN apt update && \
@@ -23,9 +23,13 @@ RUN unzip /downloads/tmp/apache-jena-4.9.0.zip -d /downloads/apache-jena
 ENV JENAROOT="/downloads/apache-jena/apache-jena-4.9.0"
 ENV PATH="$JENAROOT/bin:$PATH"
 
+# Install Poetry, a package manager for Python (an alternative to pip).
 RUN pip install poetry
 
-ADD . /src/
+# Install the project dependencies.
+ADD . /nmdc-schema/
 RUN poetry install
 
-CMD ["echo", "Hello and goodbye."]
+# Run the MkDocs dev-server and configure it to accepts HTTP requests from outside the container.
+# Reference: https://github.com/mkdocs/mkdocs/issues/1239#issuecomment-354491734
+CMD ["poetry", "run", "mkdocs", "serve", "--dev-addr", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ ADD ./poetry.lock    /nmdc-schema/poetry.lock
 ADD ./pyproject.toml /nmdc-schema/pyproject.toml
 RUN poetry install
 
+# Display a welcome banner to people when they access the bash shell.
+# Reference: https://www.asciiart.eu/text-to-ascii-art (Pagga font)
+ENV BANNER_BASE64="4paR4paI4paR4paI4paR4paI4paA4paA4paR4paI4paR4paR4paR4paI4paA4paA4paR4paI4paA4paI4paR4paI4paE4paI4paR4paI4paA4paA4paR4paICuKWkeKWiOKWhOKWiOKWkeKWiOKWgOKWgOKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWgOKWgOKWkeKWgArilpHiloDilpHiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDilpHiloDilpHiloDiloDiloDilpHiloAK"
+RUN echo "echo ${BANNER_BASE64} | base64 --decode" >> /root/.bashrc
+
 # Run the MkDocs dev-server and configure it to accepts HTTP requests from outside the container.
 # Reference: https://github.com/mkdocs/mkdocs/issues/1239#issuecomment-354491734
 CMD ["poetry", "run", "mkdocs", "serve", "--dev-addr", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,13 @@ RUN apt update && \
 RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
     chmod +x /usr/bin/yq
 
+# Download and install a Java Development Kit >= 11.
+# Note: This is a dependency of Apache Jena.
+RUN wget -P /downloads/tmp "https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-aarch64_bin.tar.gz"
+RUN mkdir /downloads/openjdk && \
+    tar -xvzf /downloads/tmp/openjdk-21.0.1_linux-aarch64_bin.tar.gz -C /downloads/openjdk
+ENV JAVA_HOME=/downloads/openjdk/jdk-21.0.1/
+
 # Download and install Apache Jena.
 # References:
 # - https://sparrowflights.blogspot.com/2012/12/how-to-install-jena-command-line-tools.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ADD ./poetry.lock    /nmdc-schema/poetry.lock
 ADD ./pyproject.toml /nmdc-schema/pyproject.toml
 RUN poetry install
 
-# Display a welcome banner to people when they access the bash shell.
+# Define a "WELCOME!" banner that will be displayed when accessing the bash shell.
 # Reference: https://www.asciiart.eu/text-to-ascii-art (Pagga font)
 ENV BANNER_BASE64="4paR4paI4paR4paI4paR4paI4paA4paA4paR4paI4paR4paR4paR4paI4paA4paA4paR4paI4paA4paI4paR4paI4paE4paI4paR4paI4paA4paA4paR4paICuKWkeKWiOKWhOKWiOKWkeKWiOKWgOKWgOKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWkeKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWkeKWiOKWgOKWgOKWkeKWgArilpHiloDilpHiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDiloDiloDilpHiloDilpHiloDilpHiloDiloDiloDilpHiloAK"
 RUN echo "echo ${BANNER_BASE64} | base64 --decode" >> /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,16 +22,23 @@ RUN rm -rf /downloads/tmp/openjdk-21.0.1_linux-aarch64_bin.tar.gz
 ENV JAVA_HOME="/downloads/openjdk/jdk-21.0.1/"
 
 # Download and install Apache Jena.
+#
+# Note: The path, `~/apache-jena/bin`, is currently hard-coded in `project.Makefile`. So, here,
+#       we create a symbolic link (i.e. filesystem shortcut) from that hard-coded path to where
+#       we are storing Apache Jena, which is `/downloads/apache-jena/apache-jena-4.9.0/bin`.
+#
 # References:
-# - https://sparrowflights.blogspot.com/2012/12/how-to-install-jena-command-line-tools.html
-# - https://archive.apache.org/dist/jena/binaries/ (older binaries)
-# - https://dlcdn.apache.org/jena/binaries/ (newest binaries, but download URL changes when new version is released).
+# - https://archive.apache.org/dist/jena/binaries/ (older binaries, but download URLs remain constant)
+# - https://dlcdn.apache.org/jena/binaries/        (newer binaries, but download URLs change over time)
+#
 RUN wget -P /downloads/tmp "https://archive.apache.org/dist/jena/binaries/apache-jena-4.9.0.zip"
 RUN mkdir -p /downloads/apache-jena && \
     unzip /downloads/tmp/apache-jena-4.9.0.zip -d /downloads/apache-jena
 RUN rm -rf /downloads/tmp/apache-jena-4.9.0.zip
 ENV JENAROOT="/downloads/apache-jena/apache-jena-4.9.0"
 ENV PATH="$JENAROOT/bin:$PATH"
+RUN mkdir -p /root/apache-jena && \
+    ln --symbolic "${JENAROOT}/bin" /root/apache-jena/bin
 
 # Install Poetry, a package manager for Python (an alternative to pip).
 RUN pip install poetry

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Some optional components use the Java-based [ROBOT](http://robot.obolibrary.org/
 Jena riot is also a part of the MongoDB dumping, repairing and validation workflow, if the user wishes
 to generate and validate RDF/TTL.
 
-See [MAINTAINERS.md](MAINTAINERS.md) for instructions on maintaining and updating the schema.
+See [DEVELOPMENT.md](DEVELOPMENT.md) for instructions on setting up a development environment.
+
+See [MAINTAINERS.md](MAINTAINERS.md) for instructions on using that development environment to maintain the schema.
 
 ## Makefiles
 
@@ -69,95 +71,3 @@ at https://api.microbiomedata.org/docs#/metadata/list_from_collection_nmdcschema
 Or use the API programmatically! Note that some collections are large, so the responses are paged.
 
 You can learn about the other available collections at https://microbiomedata.github.io/nmdc-schema/Database/
-
-## Development
-
-This repository includes a container-based development environment. That environment consists of a single container—running Linux—in which all the dependencies of this project are present (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)).
-
-Here's a diagram showing how a developer can access various parts of the development environment from a terminal running in the host environment (i.e. the environment _hosting_ the container). 
-
-```mermaid
----
-title: Development environment
----
-graph BT
-    %% Nodes:
-    dir["Repository<br>root directory"]
-    host["Terminal<br>(You are here)"]
-    
-    %% Links:
-    host -- "$ curl http://localhost:8000" --> mkdocs
-    host -- "$ docker compose exec app bash" --> bash
-    bash -- "# cd /nmdc-schema" --> dir
-    host -- "$ cd ." --> dir
-    
-    subgraph Container["Container"]
-        %% Nodes:
-        mkdocs["MkDocs dev-server"]
-        bash["bash shell"]
-    end
-```
-
-### Usage
-
-Here's how you can instantiate the development environment on your computer.
-
-#### Prerequisites
-
-- [Docker](https://www.docker.com/products/docker-desktop/) is installed on your computer.
-  - For example, version 24:
-    ```shell
-    $ docker --version
-    Docker version 24.0.6, build ed223bc
-    ```
-
-#### Procedure
-
-1. In the root folder of the repository, run the container.
-   ```shell
-   docker compose up --detach
-   ```
-   > The first time you run that, it will take several **minutes** to finish. During that time, Docker will be _building_ a container image. When you run the command in the future, Docker will reuse that container image (unless you append `--build`).
-   >
-   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then change the command to `DOCS_PORT=1234 docker compose up --detach` and re-run it (you can replace `1234` with any other port number between `1024`-`65535`, inclusive). You can try different port numbers until that error message stops appearing.
-2. Connect to a bash shell running within the container.
-   ```shell
-   docker compose exec app bash
-   ```
-   > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container running on your computer, and you are using something other than `ssh` to communicate with it.
-3. (Optional) Explore the container!
-   ```shell
-   $ whoami
-   $ hostname
-   $ uname -a
-   # ...
-   $ yq --version
-   $ jena --version
-   $ make --version
-   $ python --version
-   $ poetry --version
-   $ ls /nmdc-schema
-   ```
-   > The root directory of the repository is mounted at `/nmdc-schema` within the container. Changes you make in that directory on your computer will show up within the container, and vice versa. 
-4. (Optional) Generate the MkDocs docs.
-   ```shell
-   $ make gendoc
-   ```
-5. (Optional) Visit the MkDocs dev-server.
-   - In your web browser, visit http://localhost:8000
-     > Note: If you customized `DOCS_PORT` earlier, use that port number instead of `8000` here.
-6. Use the container as your `nmdc-schema` development environment.
-   ```shell
-   $ poetry install
-   $ make squeaky-clean
-   $ poetry shell
-   # etc.
-   ```
-7. (Optional) Done working on this project (e.g. for the day)? Stop the container.
-   ```shell
-   # (Optional) Disconnect from the container.
-   $ exit
-   
-   # Stop the container.
-   docker compose down
-   ```

--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ primer provides some the context for this project.
 
 ## Maintaining the Schema
 
-**New system requirement: [Mike Farah's GO-based yq](https://github.com/mikefarah/yq)**
-
-Some optional components use the Java-based [ROBOT](http://robot.obolibrary.org/) or Jena arq.
-Jena riot is also a part of the MongoDB dumping, repairing and validation workflow, if the user wishes
-to generate and validate RDF/TTL.
-
 See [DEVELOPMENT.md](DEVELOPMENT.md) for instructions on setting up a development environment.
 
 See [MAINTAINERS.md](MAINTAINERS.md) for instructions on using that development environment to maintain the schema.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ You can learn about the other available collections at https://microbiomedata.gi
 
 This repository includes a Docker-based development environment. That environment consists of a single container running Linux. All the dependencies of this project (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)) are present within that container.
 
+```mermaid
+graph BT
+    host["Host<br>(e.g. laptop)"]
+    host -- "$ curl http://localhost:8000" --> mkdocs
+    host -- "$ docker compose exec app bash" --> bash
+    subgraph Container["Container"]
+        mkdocs["MkDocs dev-server"]
+        bash["bash shell"]
+    end
+```
+
 ### Usage
 
 Here's how you can instantiate the development environment on your computer.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can learn about the other available collections at https://microbiomedata.gi
 
 ## Development
 
-This repository includes a Docker-based development environment. That environment consists of a single container running Linux. All the dependencies of this project (e.g. Apache Jena, yq) are present within that container.
+This repository includes a Docker-based development environment. That environment consists of a single container running Linux. All the dependencies of this project (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)) are present within that container.
 
 ### Usage
 
@@ -95,7 +95,7 @@ Here's how you can instantiate the development environment on your computer.
    ```
    > The first time you run that, it will take several **minutes** to finish. During that time, Docker will be _building_ a container image. When you run the command in the future, Docker will reuse that container image (unless you append `--build`).
    >
-   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then append `--env DOCS_PORT=1234` to the command and re-run it (you can replace `1234` with any other port number available on your computer). Try different port numbers until that error message stops appearing.
+   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then change the command to `DOCS_PORT=1234 docker compose up --detach` and re-run it (you can replace `1234` with any other port number between `1024`-`65535`, inclusive). You can try different port numbers until that error message stops appearing.
 2. Connect to a bash shell running within the container.
    ```shell
    docker exec app bash
@@ -107,8 +107,9 @@ Here's how you can instantiate the development environment on your computer.
    $ hostname
    $ uname -a
    # ...
-   $ make --version
    $ yq --version
+   $ jena --version
+   $ make --version
    $ python --version
    $ poetry --version
    $ ls /nmdc-schema

--- a/README.md
+++ b/README.md
@@ -72,16 +72,27 @@ You can learn about the other available collections at https://microbiomedata.gi
 
 ## Development
 
-This repository includes a Docker-based development environment. That environment consists of a single container running Linux. All the dependencies of this project (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)) are present within that container.
+This repository includes a container-based development environment. That environment consists of a single container—running Linux—in which all the dependencies of this project are present (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)).
+
+Here's a diagram showing how a developer can access various parts of the development environment from a terminal running in the host environment (i.e. the environment _hosting_ the container). 
 
 ```mermaid
+---
+title: Development environment
+---
 graph BT
-    host["Host terminal"]
+    %% Nodes:
+    dir["Repository<br>root directory"]
+    host["Terminal<br><small>(You are here)</small>"]
+    
+    %% Nodes:
     host -- "$ curl http://localhost:8000" --> mkdocs
     host -- "$ docker compose exec app bash" --> bash
-    bash -- "# cd /nmdc-schema" --> dir(("Repository<br>root<br>directory"))
+    bash -- "# cd /nmdc-schema" --> dir
     host -- "$ cd ." --> dir
+    
     subgraph Container["Container"]
+        %% Nodes:
         mkdocs["MkDocs dev-server"]
         bash["bash shell"]
     end

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Here's how you can instantiate the development environment on your computer.
 
 #### Procedure
 
-1. In the root folder of the repository, run the container (building it if it doesn't exist).
+1. In the root folder of the repository, run the container (building the container image if it doesn't exist yet).
    ```shell
    docker compose up --detach
    ```
@@ -130,7 +130,7 @@ Here's how you can instantiate the development environment on your computer.
    ```shell
    $ make gendoc
    ```
-5. (Optional) Visit the MkDocs server.
+5. (Optional) Visit the MkDocs dev-server.
    - In your web browser, visit http://localhost:8000
      > Note: If you customized `DOCS_PORT` earlier, use that port number instead of `8000` here.
 6. Use the container as your `nmdc-schema` development environment.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Here's how you can instantiate the development environment on your computer.
 
 #### Procedure
 
-1. In the root folder of the repository, run the container (building the container image if it doesn't exist yet).
+1. In the root folder of the repository, run the container.
    ```shell
    docker compose up --detach
    ```
@@ -124,7 +124,7 @@ Here's how you can instantiate the development environment on your computer.
    ```shell
    docker compose exec app bash
    ```
-   > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container, and your computer is not using the SSH protocol, specifically.
+   > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container running on your computer, and you are using something other than `ssh` to communicate with it.
 3. (Optional) Explore the container!
    ```shell
    $ whoami

--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ This repository includes a Docker-based development environment. That environmen
 
 ```mermaid
 graph BT
-    host["Host<br>(e.g. laptop)"]
+    host["Host"]
     host -- "$ curl http://localhost:8000" --> mkdocs
     host -- "$ docker compose exec app bash" --> bash
+    bash -- "# cd /nmdc-schema" --> dir["Repository<br>file tree"]
+    host -- "$ cd ." --> dir
     subgraph Container["Container"]
         mkdocs["MkDocs dev-server"]
         bash["bash shell"]

--- a/README.md
+++ b/README.md
@@ -69,3 +69,57 @@ at https://api.microbiomedata.org/docs#/metadata/list_from_collection_nmdcschema
 Or use the API programmatically! Note that some collections are large, so the responses are paged.
 
 You can learn about the other available collections at https://microbiomedata.github.io/nmdc-schema/Database/
+
+## Development
+
+This repository contains a `Dockerfile` you can use to run a container in which all the dependencies of `nmdc-schema` are present.
+
+### Usage
+
+You can build the container by issuing the following command in the root folder of the repo:
+
+```shell
+# Build a Docker image based upon the Dockerfile in the current folder.
+docker build -t nmdc-schema .
+```
+
+Once the container has been built, you can run it with:
+
+```shell
+# Instantiate the Docker image as a container, mount the current folder within it,
+# attach your terminal to the container's STDIN, STDOUT, and STDERR streams,
+# run `bash` within the container, and delete the container as soon as `bash` stops running.
+docker run --name nmdc-schema --rm -it -v "$(pwd):/src" nmdc-schema /bin/bash
+```
+
+Then, inside the Docker container, you can run whatever shell commands you want:
+
+```shell
+poetry install
+make squeaky-clean
+poetry shell
+# etc.
+```
+
+Alternatively, once the container has been built, you can run a specific shell command in it:
+
+```shell
+docker run --name nmdc-schema --rm -it -v "$(pwd):/src" nmdc-schema /bin/bash -c "hostname; whoami"
+```
+
+#### mkdocs
+
+In case you want to test the `mkdocs`, you can run the container with its port `8000` mapped to a localhost port (e.g. `18000`):
+
+```shell
+docker run --name nmdc-schema --rm -it -v "$(pwd):/src" -p "18000:8000" nmdc-schema /bin/bash
+```
+
+Then, inside the Docker container:
+
+```shell
+# Start the mkdocs server, binding the server to host "0.0.0.0" (i.e. allowing requests to come from any host) instead of "localhost" (default).
+$ poetry run mkdocs serve --dev-addr 0.0.0.0:8000
+```
+
+Finally, on your computer, visit the documentation website at http://localhost:18000/nmdc-schema/

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ This repository includes a Docker-based development environment. That environmen
 
 ```mermaid
 graph BT
-    host["Host"]
+    host["Host terminal"]
     host -- "$ curl http://localhost:8000" --> mkdocs
     host -- "$ docker compose exec app bash" --> bash
-    bash -- "# cd /nmdc-schema" --> dir["Repository<br>file tree"]
+    bash -- "# cd /nmdc-schema" --> dir(("Repository<br>root<br>directory"))
     host -- "$ cd ." --> dir
     subgraph Container["Container"]
         mkdocs["MkDocs dev-server"]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Here's how you can instantiate the development environment on your computer.
    > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then change the command to `DOCS_PORT=1234 docker compose up --detach` and re-run it (you can replace `1234` with any other port number between `1024`-`65535`, inclusive). You can try different port numbers until that error message stops appearing.
 2. Connect to a bash shell running within the container.
    ```shell
-   docker exec app bash
+   docker compose exec app bash
    ```
    > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container, and your computer is not using the SSH protocol, specifically.
 3. (Optional) Explore the container!

--- a/README.md
+++ b/README.md
@@ -72,54 +72,67 @@ You can learn about the other available collections at https://microbiomedata.gi
 
 ## Development
 
-This repository contains a `Dockerfile` you can use to run a container in which all the dependencies of `nmdc-schema` are present.
+This repository includes a Docker-based development environment. That environment consists of a single container running Linux. All the dependencies of this project (e.g. Apache Jena, yq) are present within that container.
 
 ### Usage
 
-You can build the container by issuing the following command in the root folder of the repo:
+Here's how you can instantiate the development environment on your computer.
 
-```shell
-# Build a Docker image based upon the Dockerfile in the current folder.
-docker build -t nmdc-schema .
-```
+#### Prerequisites
 
-Once the container has been built, you can run it with:
+- [Docker](https://www.docker.com/products/docker-desktop/) is installed on your computer.
+  - For example, version 24:
+    ```shell
+    $ docker --version
+    Docker version 24.0.6, build ed223bc
+    ```
 
-```shell
-# Instantiate the Docker image as a container, mount the current folder within it,
-# attach your terminal to the container's STDIN, STDOUT, and STDERR streams,
-# run `bash` within the container, and delete the container as soon as `bash` stops running.
-docker run --name nmdc-schema --rm -it -v "$(pwd):/src" nmdc-schema /bin/bash
-```
+#### Procedure
 
-Then, inside the Docker container, you can run whatever shell commands you want:
-
-```shell
-poetry install
-make squeaky-clean
-poetry shell
-# etc.
-```
-
-Alternatively, once the container has been built, you can run a specific shell command in it:
-
-```shell
-docker run --name nmdc-schema --rm -it -v "$(pwd):/src" nmdc-schema /bin/bash -c "hostname; whoami"
-```
-
-#### mkdocs
-
-In case you want to test the `mkdocs`, you can run the container with its port `8000` mapped to a localhost port (e.g. `18000`):
-
-```shell
-docker run --name nmdc-schema --rm -it -v "$(pwd):/src" -p "18000:8000" nmdc-schema /bin/bash
-```
-
-Then, inside the Docker container:
-
-```shell
-# Start the mkdocs server, binding the server to host "0.0.0.0" (i.e. allowing requests to come from any host) instead of "localhost" (default).
-$ poetry run mkdocs serve --dev-addr 0.0.0.0:8000
-```
-
-Finally, on your computer, visit the documentation website at http://localhost:18000/nmdc-schema/
+1. In the root folder of the repository, run the container (building it if it doesn't exist).
+   ```shell
+   docker compose up --detach
+   ```
+   > The first time you run that, it will take several **minutes** to finish. During that time, Docker will be _building_ a container image. When you run the command in the future, Docker will reuse that container image (unless you append `--build`).
+   >
+   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then append `--env DOCS_PORT=1234` to the command and re-run it (you can replace `1234` with any other port number available on your computer). Try different port numbers until that error message stops appearing.
+2. Connect to a bash shell running within the container.
+   ```shell
+   docker exec app bash
+   ```
+   > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container, and your computer is not using the SSH protocol, specifically.
+3. (Optional) Explore the container!
+   ```shell
+   $ whoami
+   $ hostname
+   $ uname -a
+   # ...
+   $ make --version
+   $ yq --version
+   $ python --version
+   $ poetry --version
+   $ ls /nmdc-schema
+   ```
+   > The root directory of the repository is mounted at `/nmdc-schema` within the container. Changes you make in that directory on your computer will show up within the container, and vice versa. 
+4. (Optional) Generate the MkDocs docs.
+   ```shell
+   $ make gendoc
+   ```
+5. (Optional) Visit the MkDocs server.
+   - In your web browser, visit http://localhost:8000
+     > Note: If you customized `DOCS_PORT` earlier, use that port number instead of `8000` here.
+6. Use the container as your `nmdc-schema` development environment.
+   ```shell
+   $ poetry install
+   $ make squeaky-clean
+   $ poetry shell
+   # etc.
+   ```
+7. (Optional) Done working on this project (e.g. for the day)? Stop the container.
+   ```shell
+   # (Optional) Disconnect from the container.
+   $ exit
+   
+   # Stop the container.
+   docker compose down
+   ```

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ graph BT
     dir["Repository<br>root directory"]
     host["Terminal<br>(You are here)"]
     
-    %% Nodes:
+    %% Links:
     host -- "$ curl http://localhost:8000" --> mkdocs
     host -- "$ docker compose exec app bash" --> bash
     bash -- "# cd /nmdc-schema" --> dir

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ title: Development environment
 graph BT
     %% Nodes:
     dir["Repository<br>root directory"]
-    host["Terminal<br><small>(You are here)</small>"]
+    host["Terminal<br>(You are here)"]
     
     %% Nodes:
     host -- "$ curl http://localhost:8000" --> mkdocs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       # the port on which the MkDocs dev-server listens by default.
       #
       # The environment variable can be specified either via an `.env` file,
-      # or via the `--env/-e` CLI option; an example usage of the latter being:
+      # or by defining it when invoking `docker compose`, like this:
       # ```
-      # $ docker compose up -e DOCS_PORT=1234
+      # DOCS_PORT=1234 docker compose up
       # ```
       #
       - "${DOCS_PORT:-8000}:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+  app:
+    # Use the container image built from the specified Dockerfile;
+    # as opposed to a container image available on DockerHub.
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      # Map a host port (by default, 8000, but it can be overridden via an
+      # environment variable) to port 8000 of the container; the latter being
+      # the port on which the MkDocs dev-server listens by default.
+      #
+      # The environment variable can be specified either via an `.env` file,
+      # or via the `--env/-e` CLI option; an example usage of the latter being:
+      # ```
+      # $ docker compose up -e DOCS_PORT=1234
+      # ```
+      #
+      - "${DOCS_PORT:-8000}:8000"
+    volumes:
+      # Mount the root directory of the repository, at `/nmdc-schema` within the container.
+      #
+      # Note: This will overwrite any `/nmdc-schema` directory that might have been created
+      #       while building the container (i.e. while processing the `Dockerfile`).
+      #
+      - "./:/nmdc-schema"


### PR DESCRIPTION
### Summary of changes

- Introduced* a `Dockerfile`, which...
    - Describes a Linux system that has all the dependencies of `nmdc-schema` installed 
        - (i.e. Python 3.9, Poetry, pandoc, OpenJDK, Apache Jena, and yq)
    - Runs the MkDocs dev-server as its main process 
- Introduced a `docker-compose.yml` file, which...
    - Maps the repo's root folder on the developer's computer, to `/nmdc-server` within the container
    - Maps localhost port `8000` (that port number can be customized via a `DOCS_PORT` environment variable) to port `8000` of the container (that's where the MkDocs dev-server listens)
- [Documented](https://github.com/microbiomedata/nmdc-schema/blob/1167-document-the-purpose-and-usage-of-the-dockerfile/README.md#development) the usage of the Docker-based development environment in the `README.md` file

### Footnotes

\* There was already a file named `Dockerfile` in the repo, but it didn't account for several dependencies. I think it was a remnant of an experiment.

When someone accesses the bash shell within the container, a welcome banner appears:

```
$ docker compose exec app bash

    Welcome to this nmdc-schema development container,
    which is running Debian GNU/Linux 12 (bookworm).

root@4ce4e7bb6c0d:/nmdc-schema#
```

I put that there to signify to users unfamiliar with containers that they have "entered" a new environment/context.