### PR TITLE
Indicate Apache Jena version number used by repo maintainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,10 @@ ipython_config.py
 .python-version
 
 # pipenv
+#
+#   Before the maintainers of this project began using Poetry, they used pipenv.
+#   This comment block is a remnant of that era.
+#
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,8 @@ To make new release of the schema, you must have the following installed on your
 - Some optional components use the Java-based [ROBOT](http://robot.obolibrary.org/), which might be replaced with Jena arq
 - [Jena riot]([url](https://www.bobdc.com/blog/jenagems/#rsparql)) is also a part of the MongoDB dumping, repairing and validation workflow, if the user wishes to generate and validate RDF/TTL.
 
+**Note**: The lead maintainer of this repository uses Apache Jena version `4.8.0`, specifically, which you can [download here](https://archive.apache.org/dist/jena/binaries/).
+
 ## Making changes to the NMDC Schema
 To track changes made to the NMDC Schema, it is best maintained by following these steps:
 1. Submit an [issue](https://github.com/microbiomedata/nmdc-schema/issues) detailing problem.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,13 +2,15 @@
 ## Dependencies
 To make new release of the schema, you must have the following installed on your system:
 - [poetry](https://python-poetry.org/docs/#installation/)
-  - this repo previously used pipenv and some documentation may make references to it.
 - [pandoc](https://pandoc.org/installing.html)
-- [Mike Farah's GO-based yq](https://github.com/mikefarah/yq)**
-- Some optional components use the Java-based [ROBOT](http://robot.obolibrary.org/), which might be replaced with Jena arq
-- [Jena riot]([url](https://www.bobdc.com/blog/jenagems/#rsparql)) is also a part of the MongoDB dumping, repairing and validation workflow, if the user wishes to generate and validate RDF/TTL.
+- [yq](https://github.com/mikefarah/yq)
+  - Specifically, [Mike Farah's Go-based yq](https://github.com/mikefarah/yq)
+- (Optional) [ROBOT](http://robot.obolibrary.org/)
+  - Editor's note: We may eventually switch to using [Apache Jena<sup>1</sup>  ARQ](https://jena.apache.org/documentation/query/) instead
+- (Optional) [Apache Jena<sup>1</sup> RIOT](https://jena.apache.org/documentation/io/)
+  - This is only necessary for dumping, repairing, and validating MongoDB data; which occurs when generating and validating RDF/TTL
 
-**Note**: The lead maintainer of this repository uses Apache Jena version `4.8.0`, specifically, which you can [download here](https://archive.apache.org/dist/jena/binaries/).
+<sup>1</sup> The lead maintainer of this repository uses Apache Jena version `4.8.0`, which you can [download here](https://archive.apache.org/dist/jena/binaries/).
 
 ## Making changes to the NMDC Schema
 To track changes made to the NMDC Schema, it is best maintained by following these steps:


### PR DESCRIPTION
### Summary of changes

- Indicate Apache Jena version number used by repo maintainer
- Make it easier to skim the list
- Move `pipenv` comment to the only occurrence of `pipenv` in the repo (it's in the `.gitignore` file)

### Screenshot

Here's a before-and-after (before on left, after on right) screenshot of the dependency list:

![image](https://github.com/microbiomedata/nmdc-schema/assets/134325062/7f731e2c-44c7-4cd3-9877-6081513dcb1c)

It isn't clear to me whether the "optional" programs are required in order to "make a new release of the schema," specifically, or they are required for other tasks (e.g. working on the project, in general) but not that specific one. The sentence before the list implies to me that the list pertains specifically to the task of making a new release of the schema.