### PR TITLE
Refactor to simplify API client and to use the nmdcschema GET endpoint

### DIFF
--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -6,16 +6,13 @@ nmdc_database_tools.py:
 Command-line tools for extracting data from the NMDC database via the API.
 """
 import click
-from datetime import datetime, timedelta, timezone
 from dotenv import load_dotenv
 import json
 from linkml_runtime.dumpers import yaml_dumper, json_dumper
 import logging
 import nmdc_schema.nmdc as nmdc
 import os
-from pydantic import BaseModel
 import requests
-import time
 import yaml
 
 # Studies with non-compliant IDs that have been re-IDed
@@ -31,115 +28,190 @@ STUDIES = {
 DEFAULT_STUDY_ID = STUDIES["Stegen"][0]
 
 
-# TODO: Move API client to a common library that can be shared across projects.
-def expiry_dt_from_now(days=0, hours=0, minutes=0, seconds=0):
-    return datetime.now(timezone.utc) + timedelta(days=days, hours=hours,
-                                                  minutes=minutes,
-                                                  seconds=seconds)
-
-
-class NmdcRuntimeUserApi:
+class NmdcApi:
     """
-    Basic Runtime API Client with user/password authentication.
+    Basic API Client for GET requests.
     """
 
     def __init__(self, api_base="NAPA"):
         self.api_base = api_base
+        self.headers = {'accept': 'application/json', 'Content-Type': 'application/json'}
         if api_base == "NAPA":
-            self.base_url = os.getenv("NAPA_BASE_URL")
-            self.username = os.getenv("NAPA_USERNAME")
-            self.password = os.getenv("NAPA_PASSWORD")
-            self.headers = {}
-            self.token_response = None
-            self.refresh_token_after = None
+            self.base_url = os.getenv("NAPA_API_BASE_URL")
         else:
             raise NotImplementedError(f"API base {api_base} not implemented.")
-
-    def ensure_token(self):
-        if (self.refresh_token_after is None or datetime.now(timezone.utc) >
-                self.refresh_token_after):
-            self.get_token()
-
-    def get_token(self):
-        token_request_body = {
-            "grant_type": "password",
-            "username": self.username,
-            "password": self.password,
-            "scope": '',
-            "client_id": "",
-            "client_secret": "",
-        }
-        headers = {
-            'accept': 'application/json',
-            'Content-Type': 'application/x-www-form-urlencoded',
-        }
-        rv = requests.post(
-            self.base_url + "token", data=token_request_body
-        )
-        self.token_response = rv.json()
-        if "access_token" not in self.token_response:
-            raise Exception(f"Getting token failed: {self.token_response}")
-
-        self.headers[
-            "Authorization"] = f'Bearer {self.token_response["access_token"]}'
-        self.refresh_token_after = expiry_dt_from_now(
-            **self.token_response["expires"]
-        ) - timedelta(seconds=5)
-
-    def request(self, method, url_path, params_or_json_data=None):
-        self.ensure_token()
-        kwargs = {"url": self.base_url + url_path, "headers": self.headers}
-        if isinstance(params_or_json_data, BaseModel):
-            params_or_json_data = params_or_json_data.dict(exclude_unset=True)
-        if method.upper() == "GET":
-            kwargs["params"] = params_or_json_data
-        else:
-            kwargs["json"] = params_or_json_data
-        rv = requests.request(method, **kwargs)
-        rv.raise_for_status()
-        return rv
 
     def get_biosamples_part_of_study(self, study_id):
         """
         Get the biosamples that are part of a study.
         """
-        url = "queries:run"
-        params = {"find": "biosample_set",
-                  "filter": {"part_of": {"$elemMatch": {"$eq": study_id}}}}
-        response = self.request("POST", url, params)
+        biosample_records = []
+        params = {
+            'filter': '{"part_of": "'+study_id+'"}',
+            'max_page_size': '1000',
+        }
+        url = self.base_url + "nmdcschema/biosample_set"
+        response = requests.get(url, params=params, headers=self.headers)
         response.raise_for_status()
-        biosample_records = response.json()["cursor"]["firstBatch"]
+        biosample_records.extend(response.json()["resources"])
+        # Get the next page of results, if any
+        while response.json().get("next_page_token") is not None:
+            params['page_token'] = response.json()["next_page_token"]
+            response = requests.get(url, params=params, headers=self.headers)
+            response.raise_for_status()
+            biosample_records.extend(response.json()["resources"])
+
+
         return biosample_records
 
     def get_omics_processing_records_part_of_study(self, study_id):
         """
         Get the OmicsProcessing records that are part of a study.
         """
-        url = "queries:run"
-        params = {"find": "omics_processing_set",
-                  "filter": {"part_of": {"$elemMatch": {"$eq": study_id}}}}
-        response = self.request("POST", url, params)
+        omics_processing_records = []
+        params = {
+            'filter': '{"part_of": "'+study_id+'"}',
+            'max_page_size': '1000',
+        }
+        url = self.base_url + "nmdcschema/omics_processing_set"
+        response = requests.get(url, params=params, headers=self.headers)
         response.raise_for_status()
-        omics_processing_records = response.json()["cursor"]["firstBatch"]
+        omics_processing_records.extend(response.json()["resources"])
+        # Get the next page of results, if any
+        while response.json().get("next_page_token") is not None:
+            params['page_token'] = response.json()["next_page_token"]
+            response = requests.get(url, params=params, headers=self.headers)
+            response.raise_for_status()
+            omics_processing_records.extend(response.json()["resources"])
         return omics_processing_records
 
     def get_workflow_activity_informed_by(self, workflow_activity_set: str,
-                                          informed_by_id: str):
-        """
-        Retrieve a workflow activity record for the given workflow activity set
-        and informed by a given OmicsProcessing ID.
-        """
-        url = "queries:run"
-        params = {"find": workflow_activity_set,
-                  "filter": {"was_informed_by": informed_by_id}}
-        response = self.request("POST", url, params_or_json_data=params)
-        if response.status_code != 200:
-            raise Exception(
-                f"Error retrieving {workflow_activity_set} record informed by {informed_by_id}"
-            )
-        workflow_activity_record = response.json()["cursor"]["firstBatch"]
-        return workflow_activity_record
+                                            informed_by_id: str):
+            """
+            Retrieve a workflow activity record for the given workflow activity set
+            and informed by a given OmicsProcessing ID.
+            """
+            params = {
+                'filter': '{"was_informed_by": "'+informed_by_id+'"}',
+            }
+            url = self.base_url + "nmdcschema/" + workflow_activity_set
+            response = requests.get(url, params=params, headers=self.headers)
+            response.raise_for_status()
+            workflow_activity_record = response.json()["resources"]
+            return workflow_activity_record
 
+
+
+
+
+
+# # TODO: Move API client to a common library that can be shared across projects.
+# def expiry_dt_from_now(days=0, hours=0, minutes=0, seconds=0):
+#     return datetime.now(timezone.utc) + timedelta(days=days, hours=hours,
+#                                                   minutes=minutes,
+#                                                   seconds=seconds)
+
+
+# class NmdcRuntimeUserApi:
+#     """
+#     Basic Runtime API Client with user/password authentication.
+#     """
+#
+#     def __init__(self, api_base="NAPA"):
+#         self.api_base = api_base
+#         if api_base == "NAPA":
+#             self.base_url = os.getenv("NAPA_BASE_URL")
+#             self.username = os.getenv("NAPA_USERNAME")
+#             self.password = os.getenv("NAPA_PASSWORD")
+#             self.headers = {}
+#             self.token_response = None
+#             self.refresh_token_after = None
+#         else:
+#             raise NotImplementedError(f"API base {api_base} not implemented.")
+#
+#     def ensure_token(self):
+#         if (self.refresh_token_after is None or datetime.now(timezone.utc) >
+#                 self.refresh_token_after):
+#             self.get_token()
+#
+#     def get_token(self):
+#         token_request_body = {
+#             "grant_type": "password",
+#             "username": self.username,
+#             "password": self.password,
+#             "scope": '',
+#             "client_id": "",
+#             "client_secret": "",
+#         }
+#         headers = {
+#             'accept': 'application/json',
+#             'Content-Type': 'application/x-www-form-urlencoded',
+#         }
+#         rv = requests.post(
+#             self.base_url + "token", data=token_request_body
+#         )
+#         self.token_response = rv.json()
+#         if "access_token" not in self.token_response:
+#             raise Exception(f"Getting token failed: {self.token_response}")
+#
+#         self.headers[
+#             "Authorization"] = f'Bearer {self.token_response["access_token"]}'
+#         self.refresh_token_after = expiry_dt_from_now(
+#             **self.token_response["expires"]
+#         ) - timedelta(seconds=5)
+#
+#     def request(self, method, url_path, params_or_json_data=None):
+#         self.ensure_token()
+#         kwargs = {"url": self.base_url + url_path, "headers": self.headers}
+#         if isinstance(params_or_json_data, BaseModel):
+#             params_or_json_data = params_or_json_data.dict(exclude_unset=True)
+#         if method.upper() == "GET":
+#             kwargs["params"] = params_or_json_data
+#         else:
+#             kwargs["json"] = params_or_json_data
+#         rv = requests.request(method, **kwargs)
+#         rv.raise_for_status()
+#         return rv
+#
+#     def get_biosamples_part_of_study(self, study_id):
+#         """
+#         Get the biosamples that are part of a study.
+#         """
+#         url = "nmdcschema/biosample_set"
+#         params = {"filter": {"part_of": {"$elemMatch": {"$eq": study_id}}}}
+#         response = self.request("POST", url, params)
+#         response.raise_for_status()
+#         biosample_records = response.json()["cursor"]["firstBatch"]
+#         return biosample_records
+#
+#     def get_omics_processing_records_part_of_study(self, study_id):
+#         """
+#         Get the OmicsProcessing records that are part of a study.
+#         """
+#         url = "queries:run"
+#         params = {"find": "omics_processing_set",
+#                   "filter": {"part_of": {"$elemMatch": {"$eq": study_id}}}}
+#         response = self.request("POST", url, params)
+#         response.raise_for_status()
+#         omics_processing_records = response.json()["cursor"]["firstBatch"]
+#         return omics_processing_records
+#
+#     def get_workflow_activity_informed_by(self, workflow_activity_set: str,
+#                                           informed_by_id: str):
+#         """
+#         Retrieve a workflow activity record for the given workflow activity set
+#         and informed by a given OmicsProcessing ID.
+#         """
+#         url = f"nmdcschema/{workflow_activity_set}"
+#         params = {"filter": {"was_informed_by": informed_by_id}}
+#         response = self.request("GET", url, params_or_json_data=params)
+#         if response.status_code != 200:
+#             raise Exception(
+#                 f"Error retrieving {workflow_activity_set} record informed by {informed_by_id}"
+#             )
+#         workflow_activity_record = response.json()["cursor"]["firstBatch"]
+#         return workflow_activity_record
+#
 
 def _write_db_to_file(db, output_dir, study_id, yaml_out):
     # Write the results to a YAML or JSON file
@@ -156,8 +228,9 @@ def _write_db_to_file(db, output_dir, study_id, yaml_out):
 
 @click.group()
 @click.option("--api_base", default="NAPA", help="API base to use.")
-@click.option("--env_file", default="local/.env", help="dotenv file for username, password, etc.")
-@click.option("--output_dir", default="local/", help="Output directory.")
+@click.option("--env_file", default="../../local/.env", help="dotenv file for "
+                                                        "username, password, etc.")
+@click.option("--output_dir", default="../../local/", help="Output directory.")
 @click.pass_context
 def cli(ctx, api_base, env_file, output_dir):
     """
@@ -165,7 +238,7 @@ def cli(ctx, api_base, env_file, output_dir):
     """
     ctx.ensure_object(dict)
     load_dotenv(env_file)  # todo parameterize
-    ctx.obj["API_CLIENT"] = NmdcRuntimeUserApi(api_base=api_base)
+    ctx.obj["API_CLIENT"] = NmdcApi(api_base=api_base)
     ctx.obj["OUTPUT_DIR"] = output_dir
 
 
@@ -211,7 +284,8 @@ def extract_study(ctx, study_id, yaml_out):
 
     # Get the study, if it exists
     try:
-        study_response = api_client.request("GET", f"studies/{study_id}")
+        study_url = f"{api_client.base_url}studies/{study_id}"
+        study_response = requests.get(study_url)
         study = study_response.json()
         logger.info(f"Got study {study['id']} from the NMDC database.")
     except requests.exceptions.HTTPError as e:
@@ -262,7 +336,6 @@ def extract_study(ctx, study_id, yaml_out):
         ) = ([], [], [], [], [], [], [], [], [], [])
         downstream_workflow_activity_sets = {
             "read_qc_analysis_activity_set": read_qc_records,
-            "read_based_analysis_activity_set": read_based_analysis,
             "read_based_taxonomy_analysis_activity_set": read_based_taxonomy,
             "metagenome_assembly_set": metagenome_assembly_records,
             "metagenome_annotation_activity_set": metagenome_annotation_records,
@@ -286,7 +359,7 @@ def extract_study(ctx, study_id, yaml_out):
                 # Get the output data object(s) for the Workflow Execution Activity record
                 for record in workflow_activity_record:
                     for data_object_id in record["has_output"]:
-                        data_object_response = api_client.request("GET", f"data_objects/{data_object_id}")
+                        data_object_response = requests.get(f"{api_client.base_url}data_objects/{data_object_id}")
                         data_object_response.raise_for_status()
                         data_object = data_object_response.json()
                         logger.info(f"Got data object {data_object['id']} for "


### PR DESCRIPTION
#1629 
PR provides an update to the nmdc database tools script:
- Simplify API client to GET only / no authentication
- Update the client's `get_*` methods to use GET and handle paginated results

Improved search performance for `was_informed_by` search using the `nmdcschema/` GET endpoint


Re-extracted the Stegen study - Counts of extracted results:
- biosample_set: 85
- data_object_set: 846
- metagenome_annotation_activity_set: 2
- metagenome_assembly_set: 50
- omics_processing_set: 479
- read_based_taxonomy_analysis_activity_set: 50
- read_qc_analysis_activity_set: 50
- study_set: 1

Extracted YAML data and logfile are here:
https://drive.google.com/drive/folders/1-02CcMgcVQ2SSLceSwOeYgkfKzvujh_i?usp=sharing

