### PR TITLE
mkdocs need to look for `javascripts/tablesort.js` in `docs/` directory

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,7 @@ markdown_extensions:
   - pymdownx.magiclink
 extra_javascript:
   - https://unpkg.com/tablesort@5.3.0/dist/tablesort.min.js
-  - tablesort.js
+  - javascripts/tablesort.js
 nav:
   - About: about.md
   - Identifiers in NMDC: identifiers.md


### PR DESCRIPTION
Fixes #1628 