### PR TITLE
1633 get study related records aka srcscripts nmdc_database_tools.py outputd path not working correctly

### DIFF
--- a/project.Makefile
+++ b/project.Makefile
@@ -582,10 +582,8 @@ migrator:
 	$(RUN) create-migrator
 
 .PHONY: extract-study
-extract-study:
+extract-study: local/nmdc-sty-11-aygzgv51
 	$(RUN) get-study-related-records \
-		--api_base NAPA \
-		--env_file local/.env \
+		--api-base-url https://api-napa.microbiomedata.org \
 		extract-study \
-		--study_id nmdc:sty-11-aygzgv51 \
-		--yaml_out
+		--output-dir $<

--- a/project.Makefile
+++ b/project.Makefile
@@ -581,9 +581,10 @@ migration-doctests:
 migrator:
 	$(RUN) create-migrator
 
-.PHONY: extract-study
-extract-study: local/nmdc-sty-11-aygzgv51
+local/nmdc-sty-11-aygzgv51.yaml:
 	$(RUN) get-study-related-records \
 		--api-base-url https://api-napa.microbiomedata.org \
 		extract-study \
-		--output-dir $^
+		--study-id nmdc:sty-11-aygzgv51 \
+		--quick-test \
+		--output-file $@

--- a/project.Makefile
+++ b/project.Makefile
@@ -586,4 +586,4 @@ extract-study: local/nmdc-sty-11-aygzgv51
 	$(RUN) get-study-related-records \
 		--api-base-url https://api-napa.microbiomedata.org \
 		extract-study \
-		--output-dir $<
+		--output-dir $^

--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -235,52 +235,52 @@ def extract_study(ctx, study_id, output_dir, json_out):
         else:
             raise e
 
-    # if len(omics_processing_records) > 0:
-    #     # downstream workflow activity records
-    #     (
-    #         read_qc_records,
-    #         read_based_analysis,
-    #         read_based_taxonomy,
-    #         metagenome_assembly_records,
-    #         metagenome_annotation_records,
-    #         mags_records,
-    #         metatranscriptome,
-    #         metabolomics_analysis,
-    #         metaproteomics_analysis,
-    #         nom_analysis,
-    #     ) = ([], [], [], [], [], [], [], [], [], [])
-    #     downstream_workflow_activity_sets = {
-    #         "read_qc_analysis_activity_set": read_qc_records,
-    #         "read_based_taxonomy_analysis_activity_set": read_based_taxonomy,
-    #         "metagenome_assembly_set": metagenome_assembly_records,
-    #         "metagenome_annotation_activity_set": metagenome_annotation_records,
-    #         "mags_activity_set": mags_records,
-    #         "metatranscriptome_activity_set": metatranscriptome,
-    #         "metabolomics_analysis_activity_set": metabolomics_analysis,
-    #         "metaproteomics_analysis_activity_set": metaproteomics_analysis,
-    #         "nom_analysis_activity_set": nom_analysis,
-    #     }
-    #     # Workflow Execution Activities and Data Objects for each OmicsProcessing record
-    #     for wf_set_name, wf_records in downstream_workflow_activity_sets.items():
-    #         logger.info(f"Getting {wf_set_name} records informed_by OmicsProcessing records.")
-    #         for omics_processing_record in omics_processing_records:
-    #             omics_processing_id = omics_processing_record["id"]
-    #             # Get the Workflow Execution Activity record for the OmicsProcessing record
-    #             workflow_activity_record = api_client.get_workflow_activity_informed_by(wf_set_name,
-    #                                                                                     omics_processing_id)
-    #             logger.info(f"Got {len(workflow_activity_record)} {wf_set_name} record informed_by "
-    #                         f"{omics_processing_id}.")
-    #             wf_records.extend(workflow_activity_record)
-    #             # Get the output data object(s) for the Workflow Execution Activity record
-    #             for record in workflow_activity_record:
-    #                 for data_object_id in record["has_output"]:
-    #                     data_object_response = requests.get(f"{api_client.base_url}data_objects/{data_object_id}")
-    #                     data_object_response.raise_for_status()
-    #                     data_object = data_object_response.json()
-    #                     logger.info(f"Got data object {data_object['id']} for "
-    #                                 f"{record['id']}.")
-    #                     db.data_object_set.append(data_object)
-    #         db.__setattr__(wf_set_name, wf_records)
+    if len(omics_processing_records) > 0:
+        # downstream workflow activity records
+        (
+            read_qc_records,
+            read_based_analysis,
+            read_based_taxonomy,
+            metagenome_assembly_records,
+            metagenome_annotation_records,
+            mags_records,
+            metatranscriptome,
+            metabolomics_analysis,
+            metaproteomics_analysis,
+            nom_analysis,
+        ) = ([], [], [], [], [], [], [], [], [], [])
+        downstream_workflow_activity_sets = {
+            "read_qc_analysis_activity_set": read_qc_records,
+            "read_based_taxonomy_analysis_activity_set": read_based_taxonomy,
+            "metagenome_assembly_set": metagenome_assembly_records,
+            "metagenome_annotation_activity_set": metagenome_annotation_records,
+            "mags_activity_set": mags_records,
+            "metatranscriptome_activity_set": metatranscriptome,
+            "metabolomics_analysis_activity_set": metabolomics_analysis,
+            "metaproteomics_analysis_activity_set": metaproteomics_analysis,
+            "nom_analysis_activity_set": nom_analysis,
+        }
+        # Workflow Execution Activities and Data Objects for each OmicsProcessing record
+        for wf_set_name, wf_records in downstream_workflow_activity_sets.items():
+            logger.info(f"Getting {wf_set_name} records informed_by OmicsProcessing records.")
+            for omics_processing_record in omics_processing_records:
+                omics_processing_id = omics_processing_record["id"]
+                # Get the Workflow Execution Activity record for the OmicsProcessing record
+                workflow_activity_record = api_client.get_workflow_activity_informed_by(wf_set_name,
+                                                                                        omics_processing_id)
+                logger.info(f"Got {len(workflow_activity_record)} {wf_set_name} record informed_by "
+                            f"{omics_processing_id}.")
+                wf_records.extend(workflow_activity_record)
+                # Get the output data object(s) for the Workflow Execution Activity record
+                for record in workflow_activity_record:
+                    for data_object_id in record["has_output"]:
+                        data_object_response = requests.get(f"{api_client.base_url}data_objects/{data_object_id}")
+                        data_object_response.raise_for_status()
+                        data_object = data_object_response.json()
+                        logger.info(f"Got data object {data_object['id']} for "
+                                    f"{record['id']}.")
+                        db.data_object_set.append(data_object)
+            db.__setattr__(wf_set_name, wf_records)
 
     # Write the results to a YAML or JSON file
     logger.info(f"Writing results to {output_file_name}.")

--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -115,6 +115,7 @@ def _write_db_to_file(db, output_file_name, yaml_out):
         with open(output_file_name, "w") as f:
             f.write(json.dumps(json_data, indent=4))
 
+
 @click.group()
 @click.option(
     "--api-base-url", help="API base URL to use.")
@@ -129,13 +130,17 @@ def cli(ctx, api_base_url):
 
 @cli.command()
 @click.option("--study-id",  help="Study ID to extract.")
-
 @click.option("--output-dir", help="Output directory, relative to project "
                                    "root.")
 @click.option("--json-out", is_flag=True, default=False, help=("Output in JSON "
                                                                "format."))
+@click.option("--quick-test", is_flag=True, default=False, help=("Quick test "
+                                                                 "mode - "
+                                                                 "biosamples "
+                                                                 "and omics "
+                                                                 "only "))
 @click.pass_context
-def extract_study(ctx, study_id, output_dir, json_out):
+def extract_study(ctx, study_id, output_dir, json_out, quick_test):
     """
     Extract a study and its associated records from the NMDC database
     via the API, and write the results to a YAML or JSON file.
@@ -235,7 +240,7 @@ def extract_study(ctx, study_id, output_dir, json_out):
         else:
             raise e
 
-    if len(omics_processing_records) > 0:
+    if len(omics_processing_records) > 0 and not quick_test:
         # downstream workflow activity records
         (
             read_qc_records,

--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -6,14 +6,18 @@ nmdc_database_tools.py:
 Command-line tools for extracting data from the NMDC database via the API.
 """
 import click
-from dotenv import load_dotenv
 import json
 from linkml_runtime.dumpers import yaml_dumper, json_dumper
 import logging
 import nmdc_schema.nmdc as nmdc
-import os
+
+from pathlib import Path
 import requests
 import yaml
+
+
+SCRIPTS_DIR = Path(__file__).parent
+PROJECT_ROOT = SCRIPTS_DIR.parent.parent
 
 # Studies with non-compliant IDs that have been re-IDed
 # Name:, study ID, legacy study ID
@@ -33,13 +37,12 @@ class NmdcApi:
     Basic API Client for GET requests.
     """
 
-    def __init__(self, api_base="NAPA"):
-        self.api_base = api_base
+    def __init__(self, api_base_url):
+        if not api_base_url.endswith("/"):
+            api_base_url += "/"
+        self.base_url = api_base_url
         self.headers = {'accept': 'application/json', 'Content-Type': 'application/json'}
-        if api_base == "NAPA":
-            self.base_url = os.getenv("NAPA_API_BASE_URL")
-        else:
-            raise NotImplementedError(f"API base {api_base} not implemented.")
+
 
     def get_biosamples_part_of_study(self, study_id):
         """
@@ -101,175 +104,87 @@ class NmdcApi:
             return workflow_activity_record
 
 
-
-
-
-
-# # TODO: Move API client to a common library that can be shared across projects.
-# def expiry_dt_from_now(days=0, hours=0, minutes=0, seconds=0):
-#     return datetime.now(timezone.utc) + timedelta(days=days, hours=hours,
-#                                                   minutes=minutes,
-#                                                   seconds=seconds)
-
-
-# class NmdcRuntimeUserApi:
-#     """
-#     Basic Runtime API Client with user/password authentication.
-#     """
-#
-#     def __init__(self, api_base="NAPA"):
-#         self.api_base = api_base
-#         if api_base == "NAPA":
-#             self.base_url = os.getenv("NAPA_BASE_URL")
-#             self.username = os.getenv("NAPA_USERNAME")
-#             self.password = os.getenv("NAPA_PASSWORD")
-#             self.headers = {}
-#             self.token_response = None
-#             self.refresh_token_after = None
-#         else:
-#             raise NotImplementedError(f"API base {api_base} not implemented.")
-#
-#     def ensure_token(self):
-#         if (self.refresh_token_after is None or datetime.now(timezone.utc) >
-#                 self.refresh_token_after):
-#             self.get_token()
-#
-#     def get_token(self):
-#         token_request_body = {
-#             "grant_type": "password",
-#             "username": self.username,
-#             "password": self.password,
-#             "scope": '',
-#             "client_id": "",
-#             "client_secret": "",
-#         }
-#         headers = {
-#             'accept': 'application/json',
-#             'Content-Type': 'application/x-www-form-urlencoded',
-#         }
-#         rv = requests.post(
-#             self.base_url + "token", data=token_request_body
-#         )
-#         self.token_response = rv.json()
-#         if "access_token" not in self.token_response:
-#             raise Exception(f"Getting token failed: {self.token_response}")
-#
-#         self.headers[
-#             "Authorization"] = f'Bearer {self.token_response["access_token"]}'
-#         self.refresh_token_after = expiry_dt_from_now(
-#             **self.token_response["expires"]
-#         ) - timedelta(seconds=5)
-#
-#     def request(self, method, url_path, params_or_json_data=None):
-#         self.ensure_token()
-#         kwargs = {"url": self.base_url + url_path, "headers": self.headers}
-#         if isinstance(params_or_json_data, BaseModel):
-#             params_or_json_data = params_or_json_data.dict(exclude_unset=True)
-#         if method.upper() == "GET":
-#             kwargs["params"] = params_or_json_data
-#         else:
-#             kwargs["json"] = params_or_json_data
-#         rv = requests.request(method, **kwargs)
-#         rv.raise_for_status()
-#         return rv
-#
-#     def get_biosamples_part_of_study(self, study_id):
-#         """
-#         Get the biosamples that are part of a study.
-#         """
-#         url = "nmdcschema/biosample_set"
-#         params = {"filter": {"part_of": {"$elemMatch": {"$eq": study_id}}}}
-#         response = self.request("POST", url, params)
-#         response.raise_for_status()
-#         biosample_records = response.json()["cursor"]["firstBatch"]
-#         return biosample_records
-#
-#     def get_omics_processing_records_part_of_study(self, study_id):
-#         """
-#         Get the OmicsProcessing records that are part of a study.
-#         """
-#         url = "queries:run"
-#         params = {"find": "omics_processing_set",
-#                   "filter": {"part_of": {"$elemMatch": {"$eq": study_id}}}}
-#         response = self.request("POST", url, params)
-#         response.raise_for_status()
-#         omics_processing_records = response.json()["cursor"]["firstBatch"]
-#         return omics_processing_records
-#
-#     def get_workflow_activity_informed_by(self, workflow_activity_set: str,
-#                                           informed_by_id: str):
-#         """
-#         Retrieve a workflow activity record for the given workflow activity set
-#         and informed by a given OmicsProcessing ID.
-#         """
-#         url = f"nmdcschema/{workflow_activity_set}"
-#         params = {"filter": {"was_informed_by": informed_by_id}}
-#         response = self.request("GET", url, params_or_json_data=params)
-#         if response.status_code != 200:
-#             raise Exception(
-#                 f"Error retrieving {workflow_activity_set} record informed by {informed_by_id}"
-#             )
-#         workflow_activity_record = response.json()["cursor"]["firstBatch"]
-#         return workflow_activity_record
-#
-
-def _write_db_to_file(db, output_dir, study_id, yaml_out):
+def _write_db_to_file(db, output_file_name, yaml_out):
     # Write the results to a YAML or JSON file
     if yaml_out:
-        output_file_name = f"{output_dir}{study_id.replace(':', '-')}.yaml"
         yaml_data = yaml.load(yaml_dumper.dumps(db), Loader=yaml.FullLoader)
         with open(output_file_name, "w") as f:
             f.write(yaml.dump(yaml_data, indent=4))
     else:
-        output_file_name = f"{output_dir}{study_id.replace(':', '-')}.json"
         json_data = json.loads(json_dumper.dumps(db, inject_type=False))
         with open(output_file_name, "w") as f:
             f.write(json.dumps(json_data, indent=4))
 
 @click.group()
-@click.option("--api_base", default="NAPA", help="API base to use.")
-@click.option("--env_file", default="../../local/.env", help="dotenv file for "
-                                                        "username, password, etc.")
-@click.option("--output_dir", default="../../local/", help="Output directory.")
+@click.option(
+    "--api-base-url", help="API base URL to use.")
 @click.pass_context
-def cli(ctx, api_base, env_file, output_dir):
+def cli(ctx, api_base_url):
     """
     NMDC database command-line tools.
     """
     ctx.ensure_object(dict)
-    load_dotenv(env_file)  # todo parameterize
-    ctx.obj["API_CLIENT"] = NmdcApi(api_base=api_base)
-    ctx.obj["OUTPUT_DIR"] = output_dir
+    ctx.obj["API_CLIENT"] = NmdcApi(api_base_url=api_base_url)
 
 
 @cli.command()
-@click.option(
-    "--study_id",
-    default=DEFAULT_STUDY_ID,
-    help=f"Optional updated study ID. Default: {DEFAULT_STUDY_ID}",
-)
-@click.option("--yaml_out", is_flag=True, default=False, help=("Output in YAML "
+@click.option("--study-id",  help="Study ID to extract.")
+
+@click.option("--output-dir", help="Output directory, relative to project "
+                                   "root.")
+@click.option("--json-out", is_flag=True, default=False, help=("Output in JSON "
                                                                "format."))
 @click.pass_context
-def extract_study(ctx, study_id, yaml_out):
+def extract_study(ctx, study_id, output_dir, json_out):
     """
     Extract a study and its associated records from the NMDC database
-    via the API, and write the results to a JSON or YAML file.
+    via the API, and write the results to a YAML or JSON file.
 
-    The study ID is optional, and defaults to the new (re-IDed) Stegen
-    study ID. If you want to extract a different study, you
-    can specify it here.
+    The study-id option is optional.  If not provided, will try to infer the
+    study ID from the output-dir option, provided that the output directory
+    uses the modified study ID format (nmdc-sty-<number>-<string>). e.g.,
+    nmdc-sty-1-1.
 
-    The output file is named after the study ID, with a .json/.yaml
-    extension. For example, the default output file name is
-    nmdc:sty-11-aygzgv51.json.
+    The output-dir option is optional. If not provided, will use
+    local/nmdc-sty-<number>-<string> as the output directory, provided that
+    the study ID follows NMDC format (nmdc:sty-<number>-<string>). e.g.,
+    nmdc:sty-1-1.
 
-    The output file is written to the current working directory.
+    If both study-id and output-dir are provided, the output-dir option will
+    be relative to the project root.
 
+    if neither study-id nor output-dir are provided, will raise an error.
+
+    The json option is optional. Default is to output in YAML format.
     """
-    output_dir = ctx.obj["OUTPUT_DIR"]
+    # Check that we have a study ID OR an output directory
+    if study_id is None and output_dir is None:
+        raise click.UsageError("Must provide either a study ID or an output "
+                               "directory.")
+    # If no study ID provided, try to infer it from the output directory
+    if study_id is None:
+        study_id = output_dir.split("/")[-1].replace("-", ":", 1)
+        output_dir = PROJECT_ROOT / output_dir
+    # If no output directory provided, make one based on the study ID
+    elif output_dir is None:
+        output_dir = PROJECT_ROOT / "local" / study_id.replace(':', '-')
+    # both study ID and output directory provided, make output directory relative to project root
+    else:
+        output_dir = PROJECT_ROOT / output_dir
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if json_out:
+        output_file_name = f"{output_dir}/{study_id.replace(':', '-')}.json"
+    else:
+        output_file_name = f"{output_dir}/{study_id.replace(':', '-')}.yaml"
+
+    logfile_name = f"{output_dir}/{study_id.replace(':', '-')}.log"
+
+
+
     logging.basicConfig(
-        filename=output_dir + study_id.replace(':', '-') + ".log",
+        filename=logfile_name,
         filemode='w',
         format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
         datefmt='%H:%M:%S',
@@ -320,55 +235,56 @@ def extract_study(ctx, study_id, yaml_out):
         else:
             raise e
 
-    if len(omics_processing_records) > 0:
-        # downstream workflow activity records
-        (
-            read_qc_records,
-            read_based_analysis,
-            read_based_taxonomy,
-            metagenome_assembly_records,
-            metagenome_annotation_records,
-            mags_records,
-            metatranscriptome,
-            metabolomics_analysis,
-            metaproteomics_analysis,
-            nom_analysis,
-        ) = ([], [], [], [], [], [], [], [], [], [])
-        downstream_workflow_activity_sets = {
-            "read_qc_analysis_activity_set": read_qc_records,
-            "read_based_taxonomy_analysis_activity_set": read_based_taxonomy,
-            "metagenome_assembly_set": metagenome_assembly_records,
-            "metagenome_annotation_activity_set": metagenome_annotation_records,
-            "mags_activity_set": mags_records,
-            "metatranscriptome_activity_set": metatranscriptome,
-            "metabolomics_analysis_activity_set": metabolomics_analysis,
-            "metaproteomics_analysis_activity_set": metaproteomics_analysis,
-            "nom_analysis_activity_set": nom_analysis,
-        }
-        # Workflow Execution Activities and Data Objects for each OmicsProcessing record
-        for wf_set_name, wf_records in downstream_workflow_activity_sets.items():
-            logger.info(f"Getting {wf_set_name} records informed_by OmicsProcessing records.")
-            for omics_processing_record in omics_processing_records:
-                omics_processing_id = omics_processing_record["id"]
-                # Get the Workflow Execution Activity record for the OmicsProcessing record
-                workflow_activity_record = api_client.get_workflow_activity_informed_by(wf_set_name,
-                                                                                        omics_processing_id)
-                logger.info(f"Got {len(workflow_activity_record)} {wf_set_name} record informed_by "
-                            f"{omics_processing_id}.")
-                wf_records.extend(workflow_activity_record)
-                # Get the output data object(s) for the Workflow Execution Activity record
-                for record in workflow_activity_record:
-                    for data_object_id in record["has_output"]:
-                        data_object_response = requests.get(f"{api_client.base_url}data_objects/{data_object_id}")
-                        data_object_response.raise_for_status()
-                        data_object = data_object_response.json()
-                        logger.info(f"Got data object {data_object['id']} for "
-                                    f"{record['id']}.")
-                        db.data_object_set.append(data_object)
-            db.__setattr__(wf_set_name, wf_records)
+    # if len(omics_processing_records) > 0:
+    #     # downstream workflow activity records
+    #     (
+    #         read_qc_records,
+    #         read_based_analysis,
+    #         read_based_taxonomy,
+    #         metagenome_assembly_records,
+    #         metagenome_annotation_records,
+    #         mags_records,
+    #         metatranscriptome,
+    #         metabolomics_analysis,
+    #         metaproteomics_analysis,
+    #         nom_analysis,
+    #     ) = ([], [], [], [], [], [], [], [], [], [])
+    #     downstream_workflow_activity_sets = {
+    #         "read_qc_analysis_activity_set": read_qc_records,
+    #         "read_based_taxonomy_analysis_activity_set": read_based_taxonomy,
+    #         "metagenome_assembly_set": metagenome_assembly_records,
+    #         "metagenome_annotation_activity_set": metagenome_annotation_records,
+    #         "mags_activity_set": mags_records,
+    #         "metatranscriptome_activity_set": metatranscriptome,
+    #         "metabolomics_analysis_activity_set": metabolomics_analysis,
+    #         "metaproteomics_analysis_activity_set": metaproteomics_analysis,
+    #         "nom_analysis_activity_set": nom_analysis,
+    #     }
+    #     # Workflow Execution Activities and Data Objects for each OmicsProcessing record
+    #     for wf_set_name, wf_records in downstream_workflow_activity_sets.items():
+    #         logger.info(f"Getting {wf_set_name} records informed_by OmicsProcessing records.")
+    #         for omics_processing_record in omics_processing_records:
+    #             omics_processing_id = omics_processing_record["id"]
+    #             # Get the Workflow Execution Activity record for the OmicsProcessing record
+    #             workflow_activity_record = api_client.get_workflow_activity_informed_by(wf_set_name,
+    #                                                                                     omics_processing_id)
+    #             logger.info(f"Got {len(workflow_activity_record)} {wf_set_name} record informed_by "
+    #                         f"{omics_processing_id}.")
+    #             wf_records.extend(workflow_activity_record)
+    #             # Get the output data object(s) for the Workflow Execution Activity record
+    #             for record in workflow_activity_record:
+    #                 for data_object_id in record["has_output"]:
+    #                     data_object_response = requests.get(f"{api_client.base_url}data_objects/{data_object_id}")
+    #                     data_object_response.raise_for_status()
+    #                     data_object = data_object_response.json()
+    #                     logger.info(f"Got data object {data_object['id']} for "
+    #                                 f"{record['id']}.")
+    #                     db.data_object_set.append(data_object)
+    #         db.__setattr__(wf_set_name, wf_records)
 
     # Write the results to a YAML or JSON file
-    _write_db_to_file(db, output_dir, study_id, yaml_out)
+    logger.info(f"Writing results to {output_file_name}.")
+    _write_db_to_file(db, output_file_name, json_out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes:
#1633 output-path argument not working correctly
#1634 should not require a .env file
#1635 click options should use hyphens not underscores

Additionally, this PR provides
- ability to provide study-id AND/OR output-dir.  If output-dir is provided as `{local_dir}/nmdc-sty-1-abcdef` with no study-id provided, the tool will infer a study ID `nmdc:sty-1-abcdef` for the last part of the output-dir arg.
- updated `project.Makefile` to run using a local output-dir target