### PR TITLE
Delete `quality_control_report` field from `Extraction` in more circumstances

### DIFF
--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -21,8 +21,12 @@ class Migrator(MigratorBase):
         >>> m = Migrator()
         >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'status': 'pass'}})
         {'id': 123, 'qc_status': 'pass'}
+        >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'status': 'fail'}})
+        {'id': 123, 'qc_status': 'fail'}
         >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'status': 'pass', 'name': 'n'}})
         {'id': 123, 'qc_status': 'pass'}
+        >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'status': 'fail', 'name': 'n'}})
+        {'id': 123, 'qc_status': 'fail'}
         >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'name': 'n'}})
         {'id': 123}
         >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {}})

--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -32,6 +32,7 @@ class Migrator(MigratorBase):
         if "quality_control_report" in extraction:
             if "status" in extraction["quality_control_report"]:
                 extraction["qc_status"] = extraction["quality_control_report"]["status"]
-                del extraction["quality_control_report"]["status"]
+
+            # Delete the field, even if it contains sub-fields other than "status".
             del extraction["quality_control_report"]
         return extraction

--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -28,7 +28,7 @@ class Migrator(MigratorBase):
         >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {}})
         {'id': 123}
         """
-        self.logger.info(f"Starting migration of {extraction['id']}")
+        self.logger.info(f"Migrating Extraction: {extraction['id']}")
         if "quality_control_report" in extraction:
             if "status" in extraction["quality_control_report"]:
                 extraction["qc_status"] = extraction["quality_control_report"]["status"]

--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -15,7 +15,7 @@ class Migrator(MigratorBase):
 
     def move_extraction_qc_status(self, extraction: dict) -> dict:
         r"""
-        Updates the `ExtractionSet` so that the value originally in its `quality_control_report.status` field, if any,
+        Updates the `Extraction` so that the value originally in its `quality_control_report.status` field, if any,
         is stored in a new field named `qc_status`; and the `quality_control_report` field no longer exists.
 
         >>> m = Migrator()

--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -1,4 +1,3 @@
-
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
@@ -7,7 +6,7 @@ class Migrator(MigratorBase):
 
     _from_version = "9.3"
     _to_version = "9.4"
-    
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._agenda = dict(
@@ -30,9 +29,9 @@ class Migrator(MigratorBase):
         {'id': 123}
         """
         self.logger.info(f"Starting migration of {extraction['id']}")
-        if 'quality_control_report' in extraction:
-            if 'status' in extraction['quality_control_report']:
-                extraction['qc_status'] = extraction['quality_control_report']['status']
-                del extraction['quality_control_report']['status']
-            del extraction['quality_control_report']
+        if "quality_control_report" in extraction:
+            if "status" in extraction["quality_control_report"]:
+                extraction["qc_status"] = extraction["quality_control_report"]["status"]
+                del extraction["quality_control_report"]["status"]
+            del extraction["quality_control_report"]
         return extraction

--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -16,16 +16,23 @@ class Migrator(MigratorBase):
 
     def move_extraction_qc_status(self, extraction: dict) -> dict:
         r"""
-        Move quality_control_report.status to qc_status
+        Updates the `ExtractionSet` so that the value originally in its `quality_control_report.status` field, if any,
+        is stored in a new field named `qc_status`; and the `quality_control_report` field no longer exists.
 
         >>> m = Migrator()
         >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'status': 'pass'}})
         {'id': 123, 'qc_status': 'pass'}
+        >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'status': 'pass', 'name': 'n'}})
+        {'id': 123, 'qc_status': 'pass'}
+        >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {'name': 'n'}})
+        {'id': 123}
+        >>> m.move_extraction_qc_status({'id': 123, 'quality_control_report': {}})
+        {'id': 123}
         """
         self.logger.info(f"Starting migration of {extraction['id']}")
         if 'quality_control_report' in extraction:
             if 'status' in extraction['quality_control_report']:
                 extraction['qc_status'] = extraction['quality_control_report']['status']
                 del extraction['quality_control_report']['status']
-                del extraction['quality_control_report']
+            del extraction['quality_control_report']
         return extraction

--- a/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
+++ b/nmdc_schema/migrators/migrator_from_9_3_to_9_4.py
@@ -33,6 +33,6 @@ class Migrator(MigratorBase):
             if "status" in extraction["quality_control_report"]:
                 extraction["qc_status"] = extraction["quality_control_report"]["status"]
 
-            # Delete the field, even if it contains sub-fields other than "status".
+            # Delete the key, even if it contains sub-keys other than "status".
             del extraction["quality_control_report"]
         return extraction


### PR DESCRIPTION
### Summary of changes

- Updated `migrator_from_9_3_to_9_4.py` to delete the `quality_control_report` field regardless of whether the `status` sub-field existed
- Formatted code using `black`
- Added more doctests to illustrate more input variations