### PR TITLE
values in the `sample_link` slot may not always follow a formal syntax, like CURIe or GUID

### DIFF
--- a/src/data/invalid/Biosample-invalid-linkage.yaml
+++ b/src/data/invalid/Biosample-invalid-linkage.yaml
@@ -17,3 +17,4 @@ sample_link:
   - 'this sample is pooled from three other samples'
   - 'but I am not even listing which samples'
   - 'because of how bad and invalid this example is'
+  - 23456

--- a/src/data/invalid/Biosample-invalid-linkage.yaml
+++ b/src/data/invalid/Biosample-invalid-linkage.yaml
@@ -1,0 +1,19 @@
+id: nmdc:bsm-99-dtTMNb
+part_of:
+  - nmdc:sty-00-abc123
+env_broad_scale:
+  has_raw_value: ENVO:00002030
+  term:
+    id: ENVO:00002030
+env_local_scale:
+  has_raw_value: ENVO:00002169
+  term:
+    id: ENVO:00002169
+env_medium:
+  has_raw_value: ENVO:00005792
+  term:
+    id: ENVO:00005792
+sample_link: 
+  - 'this sample is pooled from three other samples'
+  - 'but I am not even listing which samples'
+  - 'because of how bad and invalid this example is'

--- a/src/data/valid/Biosample-exhasutive.yaml
+++ b/src/data/valid/Biosample-exhasutive.yaml
@@ -455,8 +455,7 @@ exp_duct:
 exp_pipe:
   has_raw_value: xxx
 
-experimental_factor_other: unconstrained text, but presumably expects 'term label
-  [term id]'
+experimental_factor_other: unconstrained text, but presumably expects 'term label [term id]'
 ext_door:
   has_raw_value: xxx
 ext_wall_orient: north

--- a/src/data/valid/Biosample-exhasutive.yaml
+++ b/src/data/valid/Biosample-exhasutive.yaml
@@ -876,8 +876,7 @@ samp_well_name:
   has_raw_value: xxx
 
 sample_link:
-  - IGSN:DSJ0284
-  - any:curie
+  - 'core: soil_core_O'
 sample_shipped: 15 g
 sample_type: water_extract_soil
 saturates_pc:

--- a/src/data/valid/Biosample-exhaustive-issue-796-bye-yq-for-7-4-10.yaml
+++ b/src/data/valid/Biosample-exhaustive-issue-796-bye-yq-for-7-4-10.yaml
@@ -357,8 +357,7 @@ rna_volume: 25
 collection_date_inc: "2023-01-29"
 collection_time: 05:42+0000
 collection_time_inc: 13:42+0000
-experimental_factor_other: unconstrained text, but presumably expects 'term label
-  [term id]'
+experimental_factor_other: unconstrained text, but presumably expects 'term label [term id]'
 filter_method: Basix PES, 13-100-106 FisherSci is an example value, but unconstrained
   text is accepted at this point
 isotope_exposure: 13C glucose
@@ -380,6 +379,7 @@ technical_reps: "2"
 analysis_type:
   - metabolomics
   - metagenomics
+
 sample_link:
   - 'parent: example_samp_45'
 zinc:

--- a/src/data/valid/Biosample-exhaustive-issue-796-bye-yq-for-7-4-10.yaml
+++ b/src/data/valid/Biosample-exhaustive-issue-796-bye-yq-for-7-4-10.yaml
@@ -381,8 +381,7 @@ analysis_type:
   - metabolomics
   - metagenomics
 sample_link:
-  - IGSN:DSJ0284
-  - any:curie
+  - 'parent: example_samp_45'
 zinc:
   has_raw_value: 2.5 mg/kg
 manganese:

--- a/src/data/valid/Database-biosample-exhasutive.yaml
+++ b/src/data/valid/Database-biosample-exhasutive.yaml
@@ -876,8 +876,7 @@ biosample_set:
       has_raw_value: xxx
 
     sample_link:
-      - IGSN:DSJ0284
-      - any:curie
+      - 'parent: example_samp_24'
     sample_shipped: 15 g
     sample_type: water_extract_soil
     saturates_pc:

--- a/src/schema/portal/sample_id.yaml
+++ b/src/schema/portal/sample_id.yaml
@@ -46,16 +46,19 @@ slots:
     recommended: true
 
   sample_link:
-    description: A unique identifier to assign parent-child, subsample, or sibling
-      samples. This is relevant when a sample or other material was used to generate
-      the new sample.
+    description: The name(s) of sample(s) to be linked to this sample. This should 
+    match a sample name provided to NMDC & should identify the sample relationship 
+    that is being provided. This is relevant when a sample or other material was used 
+    to generate the new sample.
     comments:
       - 'This field allows multiple entries separated by ; (Examples: Soil collected
       from the field will link with the soil used in an incubation. The soil a plant
       was grown in links to the plant sample. An original culture sample was transferred
       to a new vial and generated a new sample)'
     examples:
-      - value: IGSN:DSJ0284
+      - value: core: soil core 1
+      - value: parent: sample A
+      - value: pooling: sample 1, sample 2, sample 3
     from_schema: https://example.com/nmdc_dh
     multivalued: true
     range: string

--- a/src/schema/portal/sample_id.yaml
+++ b/src/schema/portal/sample_id.yaml
@@ -46,19 +46,19 @@ slots:
     recommended: true
 
   sample_link:
-    description: The name(s) of sample(s) to be linked to this sample. This should 
-    match a sample name provided to NMDC & should identify the sample relationship 
+    description: 'The name(s) of sample(s) to be linked to this sample. This should 
+    match a sample name provided to NMDC and should identify the sample relationship 
     that is being provided. This is relevant when a sample or other material was used 
-    to generate the new sample.
+    to generate the new sample.'
     comments:
       - 'This field allows multiple entries separated by ; (Examples: Soil collected
       from the field will link with the soil used in an incubation. The soil a plant
       was grown in links to the plant sample. An original culture sample was transferred
       to a new vial and generated a new sample)'
     examples:
-      - value: core: soil core 1
-      - value: parent: sample A
-      - value: pooling: sample 1, sample 2, sample 3
+      - value: 'core: soil core 1'
+      - value: 'parent: sample A'
+      - value: 'pooling: sample 1, sample 2, sample 3'
     from_schema: https://example.com/nmdc_dh
     multivalued: true
     range: string


### PR DESCRIPTION
From 
- https://github.com/microbiomedata/nmdc-schema/issues/1669

I updated the slot definition as described in the original issue, then updated the valid example files that already contained `sample_link` and created an invalid example file.