### PR TITLE
Add Fuseki to standard development environment (Docker Compose stack)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,35 +2,50 @@
 
 ## Development environment
 
-This repository includes a container-based development environment. That environment consists of a single container—running Linux—in which all the dependencies of this project are present (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/)).
+This repository includes a container-based development environment. That environment consists of two containers:
+- A custom container—running Linux—in which all the dependencies of this project are present (e.g. [OpenJDK](https://openjdk.org/), [Apache Jena](https://jena.apache.org/), [GNU make](https://www.gnu.org/software/make/manual/make.html), [yq](https://mikefarah.gitbook.io/yq/))
+- A container based upon an "off-the-shelf" [container image](https://hub.docker.com/r/stain/jena-fuseki)—running [Fuseki](https://jena.apache.org/documentation/fuseki2/) (a SPARQL server)
 
-Here's a diagram showing how a developer can access various parts of the development environment from a terminal running in the host environment (i.e. the environment _hosting_ the container). 
+Here's a diagram showing how a developer can access various parts of the development environment from a terminal running in the host environment (i.e. the environment _hosting_ the containers). 
 
 ```mermaid
 ---
 title: Development environment
 ---
 graph BT
-    %% Nodes:
-    dir["Repository<br>root directory"]
-    host["Terminal<br>(You are here)"]
+    host_terminal["Terminal<br>(You are here)"]
+    
+    subgraph app_container["Container running `app` service"]
+        mkdocs_server["MkDocs dev-server"]
+        app_bash["bash shell"]
+    end
+    
+    subgraph fuseki_container["Container running `fuseki` service"]
+        fuseki_server["Fuseki web server"]
+        fuseki_bash["bash shell"]
+    end
+    
+    subgraph repo_file_tree["Repository file tree"]
+        repo_root_dir[".<br>(Root)"]
+        repo_fuseki_dir["./local/fuseki-data<br>(Fuseki data)"]
+    end
+    style repo_file_tree stroke-dasharray: 4
     
     %% Links:
-    host -- "$ curl http://localhost:8000" --> mkdocs
-    host -- "$ docker compose exec app bash" --> bash
-    bash -- "# cd /nmdc-schema" --> dir
-    host -- "$ cd ." --> dir
-    
-    subgraph Container["Container"]
-        %% Nodes:
-        mkdocs["MkDocs dev-server"]
-        bash["bash shell"]
-    end
+    host_terminal -- "$ curl http://localhost:8000" --> mkdocs_server
+    host_terminal -- "$ docker compose exec app bash" --> app_bash
+    app_bash -- "# cd /nmdc-schema" --> repo_root_dir
+    host_terminal -- "$ cd ." --> repo_root_dir
+    host_terminal -- "$ curl http://localhost:3030" --> fuseki_server
+    host_terminal -- "$ docker compose exec fuseki bash" --> fuseki_bash
+    fuseki_bash -- "# cd /fuseki" --> repo_fuseki_dir["Fuseki data<br>directory"]
+    repo_root_dir -. "cd local/fuseki-data" .-> repo_fuseki_dir
 ```
 
-> Note: The container can access the **host environment** using the [special hostname](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host), 
+> Note: The containers can access the **host environment** using the [special hostname](https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host), 
 > `host.docker.internal`. In other words, anything you can access via `localhost` from within the host environment—for
-> example, a MongoDB server or an SSH tunnel—you can access via `host.docker.internal` from within the container.
+> example, a MongoDB server or an SSH tunnel—you can access via `host.docker.internal` from within either of the
+> containers.
 
 ### Usage
 
@@ -51,15 +66,20 @@ Here's how you can instantiate the development environment on your computer.
    ```shell
    docker compose up --detach
    ```
-   > The first time you run that, it will take several **minutes** to finish. During that time, Docker will be _building_ a container image. When you run the command in the future, Docker will reuse that container image (unless you append `--build`).
+   > The first time you run that, it will take several **minutes** to finish. During that time, 
+   > Docker will be _building_ the container image for the custom container. 
+   > When you run the command in the future, Docker will reuse that container image (unless you append `--build`).
    >
-   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; then change the command to `DOCS_PORT=1234 docker compose up --detach` and re-run it (you can replace `1234` with any other port number between `1024`-`65535`, inclusive). You can try different port numbers until that error message stops appearing.
-2. Connect to a bash shell running within the container.
+   > **Troubleshooting tip:** If Docker shows an error message saying "port is already allocated"; 
+   > then change the command to `DOCS_PORT=1234 FUSEKI_PORT=5678 docker compose up --detach`
+   > and re-run it (you can replace `1234` and `5678` with any other port numbers between `1024`-`65535`, inclusive).
+   > You can try different port numbers until that error message stops appearing.
+2. Connect to a bash shell running within the container running the `app` service.
    ```shell
    docker compose exec app bash
    ```
    > You can think of this as "`ssh`-ing" into a Linux system. In this case, the Linux system is a Docker container running on your computer, and you are using something other than `ssh` to communicate with it.
-3. (Optional) Explore the container!
+3. (Optional) Explore that container!
    ```shell
    $ whoami
    $ hostname
@@ -72,7 +92,9 @@ Here's how you can instantiate the development environment on your computer.
    $ poetry --version
    $ ls /nmdc-schema
    ```
-   > The root directory of the repository is mounted at `/nmdc-schema` within the container. Changes you make in that directory on your computer will show up within the container, and vice versa. 
+   > The root directory of the repository is mounted at `/nmdc-schema` within that container.
+   > Changes you make in that directory on your computer will show up in `/nmdc-schema` within that container,
+   > and vice versa. 
 4. (Optional) Generate the MkDocs docs.
    ```shell
    $ make gendoc
@@ -80,18 +102,17 @@ Here's how you can instantiate the development environment on your computer.
 5. (Optional) Visit the MkDocs dev-server.
    - In your web browser, visit http://localhost:8000
      > Note: If you customized `DOCS_PORT` earlier, use that port number instead of `8000` here.
-6. Use the container as your `nmdc-schema` development environment.
+6. Use the container running the `app` service, as your `nmdc-schema` development environment.
    ```shell
    $ poetry install
    $ make squeaky-clean
    $ poetry shell
    # etc.
    ```
-7. (Optional) Done working on this project (e.g. for the day)? Stop the container.
+7. (Optional) Visit the Fuseki web server.
+   - In your web browser, visit http://localhost:3030
+     > Note: If you customized `FUSEKI_PORT` earlier, use that port number instead of `3030` here.
+8. (Optional) Done working on this project (e.g. for the day)? Stop the containers.
    ```shell
-   # (Optional) Disconnect from the container.
-   $ exit
-   
-   # Stop the container.
    docker compose down
    ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,3 +27,24 @@ services:
       #       while building the container (i.e. while processing the `Dockerfile`).
       #
       - "./:/nmdc-schema"
+
+  fuseki:
+    # Use the container image at: https://hub.docker.com/r/stain/jena-fuseki
+    image: stain/jena-fuseki
+    restart: unless-stopped
+    ports:
+      # Map a host port (by default, 3030, but it can be overridden via an
+      # environment variable) to port 3030 of the container; the latter being
+      # the port on which the Fuseki web server listens by default.
+      - "${FUSEKI_PORT:-3030}:3030"
+    volumes:
+      # Mount the `./local/fuseki-data` directory on the host, at `/fuseki` within the container.
+      #
+      # Note: Since `./local/fuseki-data` is within the repository file tree, and the entire
+      #       repository file tree is mounted within the `app` container, the `app` container
+      #       can share data with the `fuseki` container by putting files into this directory.
+      #
+      - "./local/fuseki-data:/fuseki"
+    environment:
+      # Administrator credentials: admin/password
+      - ADMIN_PASSWORD=password

--- a/project.Makefile
+++ b/project.Makefile
@@ -629,6 +629,19 @@ local/nmdc-sty-11-aygzgv51-tdb: local/nmdc-schema-v8.0.0.owl.ttl local/nmdc-sty-
 		--loc=$@ \
 		--query=assets/sparql/tdb-graph-list.rq
 
+# Populates a Jena TDB database that will be accessible to Fuseki.
+#
+# Note: Manually stop the `fuseki` container before running this target,
+#       in order to release a lock on a file that this target writes to.
+#
+# Note: We expect people to run this make target from within the `app` container.
+#
+nmdc-tdb2:
+	tdb2.tdbloader \
+		--loc=/nmdc-schema/local/fuseki-data/databases/$@ \
+		--graph=https://w3id.org/nmdc/nmdc \
+		/nmdc-schema/project/owl/nmdc.owl.ttl
+
 .PHONY: filtered-status
 filtered-status:
 	git status | grep -v 'project/' | grep -v 'nmdc_schema/.*yaml' | grep -v 'nmdc_schema/.*json' | \


### PR DESCRIPTION
### Summary of changes

- Adds Apache Jena Fuseki to the standard development environment

---

Here's a link to the rendered version of the updated developer docs: https://github.com/microbiomedata/nmdc-schema/blob/1664-add-fuseki-to-docker-stack/DEVELOPMENT.md