### PR TITLE
Convert `insert_many_pymongo.py` into `click` CLI command

### DIFF
--- a/nmdc_schema/insert_many_pymongo.py
+++ b/nmdc_schema/insert_many_pymongo.py
@@ -16,10 +16,10 @@ click_log.basic_config(logger)
 @click_log.simple_verbosity_option(logger)
 @click.option(
     "--input-file",
-    "--in",
     type=click.File(),
     required=True,
-    help=r"Path to JSON file containing input data",
+    help=r"Path to a JSON file containing the data you want to insert. "
+         r"The JSON file must conform to the NMDC Schema.",
     prompt=r"Path to JSON file",
 )
 @click.option(
@@ -27,7 +27,9 @@ click_log.basic_config(logger)
     type=str,
     required=True,
     envvar="TEMP_MONGO_URI",
-    help=r"MongoDB connection string (can be specified via an environment variable named `TEMP_MONGO_URI`)",
+    help=r"MongoDB connection string. Note: Some connection strings include a password. "
+         r"To avoid putting your password on the command line, you can specify the connection string "
+         r"via an environment variable named `TEMP_MONGO_URI`.",
     prompt=r"MongoDB connection string",
 )
 @click.option(
@@ -35,24 +37,25 @@ click_log.basic_config(logger)
     type=bool,
     required=False,
     default=True,
-    help=f"Whether to use the `directConnection` parameter for the MongoDB connection",
-    prompt=f"Whether to use the `directConnection` parameter for the MongoDB connection",
+    show_default=True,
+    help=f"Whether you want the script to set the `directConnection` flag when connecting to the MongoDB server. "
+         f"That is required by some MongoDB servers that belong to a replica set. ",
 )
 @click.option(
     "--database-name",
     type=str,
     required=False,
     default="nmdc",
+    show_default=True,
     help=f"MongoDB database name",
-    prompt=f"MongoDB database name",
 )
 @click.option(
     "--validator-uri",
     type=str,
     required=False,
     default="https://api.microbiomedata.org/metadata/json:validate",
+    show_default=True,
     help=f"URI of NMDC Schema-based validator",
-    prompt=f"URI of NMDC Schema-based validator",
 )
 def insert_many_pymongo(
     input_file,

--- a/nmdc_schema/insert_many_pymongo.py
+++ b/nmdc_schema/insert_many_pymongo.py
@@ -102,7 +102,7 @@ def insert_many_pymongo(
     logger.info(f'Processing the {len(json_data.keys())} collection(s) provided.')
     for collection_name, documents in json_data.items():
         if len(documents) > 0:
-            logger.debug(f'Inserting {len(documents)} documents into the "{collection_name}" collection.')
+            logger.info(f'Inserting {len(documents)} documents into the "{collection_name}" collection.')
             result = db[collection_name].insert_many(documents)
             num_documents_inserted = len(result.inserted_ids)
             num_documents_provided = len(documents)

--- a/nmdc_schema/insert_many_pymongo.py
+++ b/nmdc_schema/insert_many_pymongo.py
@@ -62,9 +62,7 @@ def insert_many_pymongo(
     validator_uri: str,
 ) -> None:
     r"""
-    Reads data from a JSON file and inserts that data into a MongoDB database.
-
-    The contents of the JSON file conform to the NMDC Schema.
+    Reads data from an NMDC Schema-conformant JSON file and inserts that data into a MongoDB database.
     """
     r"""
     References:

--- a/nmdc_schema/insert_many_pymongo.py
+++ b/nmdc_schema/insert_many_pymongo.py
@@ -1,29 +1,121 @@
-import os
-from pprint import pprint
-import secrets
-import time
-import pymongo
-from pymongo import MongoClient
+import json
+import logging
 
-#connect to napa mongo
-#set value of napa_mongo_pw manually interactively
-napa_mongo = (
-     "mongodb://root:"
-     + napa_mongo_pw
-     + "@mongo-loadbalancer.nmdc-napa.production.svc.spin.nersc.org:27017/?authSource=admin")
-client = MongoClient(napa_mongo)
-mydb = client["nmdc"]
+import click_log
+import click  # not currently a top-level dependency of `nmdc-schema`
+import pymongo  # not currently a top-level dependency of `nmdc-schema`
+import requests  # not currently a top-level dependency of `nmdc-schema`
 
 
-#workaround example for json:submit endpoint
-#modified from https://stackoverflow.com/questions/49510049/how-to-import-json-file-to-mongodb-using-python
-#read in json file which has target collections and documents to insert
-with open('20240118.stegen.metap.SOP01.json') as f:
-  file_data = json.load(f)
-
-#loop through target collections and insert documents for each 
-for collection,documents in file_data.items():
-   target_coll=mydb[collection]
-   target_coll.insert_many(documents)
+logger = logging.getLogger(__name__)
+click_log.basic_config(logger)
 
 
+
+@click.command()
+@click_log.simple_verbosity_option(logger)
+@click.option(
+    "--input-file",
+    "--in",
+    type=click.File(),
+    required=True,
+    help=r"Path to JSON file containing input data",
+    prompt=r"Path to JSON file",
+)
+@click.option(
+    "--mongo-uri",
+    type=str,
+    required=True,
+    envvar="TEMP_MONGO_URI",
+    help=r"MongoDB connection string (can be specified via an environment variable named `TEMP_MONGO_URI`)",
+    prompt=r"MongoDB connection string",
+)
+@click.option(
+    "--is-direct-connection",
+    type=bool,
+    required=False,
+    default=True,
+    help=f"Whether to use the `directConnection` parameter for the MongoDB connection",
+    prompt=f"Whether to use the `directConnection` parameter for the MongoDB connection",
+)
+@click.option(
+    "--database-name",
+    type=str,
+    required=False,
+    default="nmdc",
+    help=f"MongoDB database name",
+    prompt=f"MongoDB database name",
+)
+@click.option(
+    "--validator-uri",
+    type=str,
+    required=False,
+    default="https://api.microbiomedata.org/metadata/json:validate",
+    help=f"URI of NMDC Schema-based validator",
+    prompt=f"URI of NMDC Schema-based validator",
+)
+def insert_many_pymongo(
+    input_file,
+    mongo_uri: str,
+    is_direct_connection: bool,
+    database_name: str,
+    validator_uri: str,
+) -> None:
+    r"""
+    Reads data from a JSON file and inserts that data into a MongoDB database.
+
+    The JSON file consists of a top-level object whose property names corresponding to MongoDB collection names.
+    The value of each of those properties is an array of objects. Each object corresponding to a document you want
+    to insert into that collection.
+    """
+    r"""
+    References:
+    - Topic: Specifying a file path via a CLI option (and `click` providing a file handle to the function).
+      https://click.palletsprojects.com/en/8.1.x/api/#click.File
+    - Topic: `click` populating function parameters from environment variables.
+      https://click.palletsprojects.com/en/8.1.x/options/#values-from-environment-variables
+    - Topic: `click_log`.
+      https://click-log.readthedocs.io/en/stable/
+    """
+
+    # Validate the JSON data with respect to the NMDC schema.
+    #
+    # Note: The validation endpoint currently returns `{"result": "All Okay!"}`
+    #       when data is valid.
+    #
+    logger.debug(f"Validating the JSON data.")
+    json_data = json.load(input_file)
+    response = requests.post(validator_uri, json=json_data)
+    assert response.status_code == 200, f"Failed to access validator at {validator_uri}"
+    validation_result = response.json()
+    if validation_result.get("result") == "All Okay!":
+        logger.debug(f"The JSON data is valid.")
+    else:
+        logger.error(f"Validation result: {validation_result}")
+        raise ValueError(f"The JSON data is not valid.")
+
+    # Validate the MongoDB connection string and database name.
+    mongo_client = pymongo.MongoClient(host=mongo_uri, directConnection=is_direct_connection)
+    with pymongo.timeout(5):  # stop trying after 5 seconds
+        assert (database_name in mongo_client.list_database_names()), f'The database named "{database_name}" does not exist.'
+
+    # Insert the JSON data into the MongoDB database.
+    db = mongo_client[database_name]
+    logger.info(f'Processing the {len(json_data.keys())} collection(s) provided.')
+    for collection_name, documents in json_data.items():
+        if len(documents) > 0:
+            logger.debug(f'Inserting {len(documents)} documents into the "{collection_name}" collection.')
+            result = db[collection_name].insert_many(documents)
+            num_documents_inserted = len(result.inserted_ids)
+            num_documents_provided = len(documents)
+            logger.info(f"Inserted {num_documents_inserted} of {num_documents_provided} documents.")
+            if num_documents_inserted < num_documents_provided:
+                logger.warning(f"Not all of the provided documents were inserted.")
+        else:
+            logger.warning(f'Skipping collection "{collection_name}" because no documents were provided for it.')
+
+    return None
+
+
+if __name__ == "__main__":
+    insert_many_pymongo()  # `click` will prompt the user for options

--- a/nmdc_schema/insert_many_pymongo.py
+++ b/nmdc_schema/insert_many_pymongo.py
@@ -64,9 +64,7 @@ def insert_many_pymongo(
     r"""
     Reads data from a JSON file and inserts that data into a MongoDB database.
 
-    The JSON file consists of a top-level object whose property names corresponding to MongoDB collection names.
-    The value of each of those properties is an array of objects. Each object corresponding to a document you want
-    to insert into that collection.
+    The contents of the JSON file conform to the NMDC Schema.
     """
     r"""
     References:


### PR DESCRIPTION
### Summary of changes

- Overhauled the previous script
- It is now a CLI command built upon the `click` CLI framework (this is used elsewhere in `nmdc-schema`)
- It now validates the submitted JSON data against the NMDC Schema before inserting it into the database
- It now accepts CLI options for its customizable parameters (e.g. JSON file path, MongoDB URI)
- It now prompts the user for parameters that were missing when it was invoked

Its `--help` output is:

```shell
# poetry run python nmdc_schema/insert_many_pymongo.py --help
Usage: insert_many_pymongo.py [OPTIONS]

  Reads data from a JSON file and inserts that data into a MongoDB database.

  The contents of the JSON file conform to the NMDC Schema.

Options:
  -v, --verbosity LVL             Either CRITICAL, ERROR, WARNING, INFO or
                                  DEBUG
  --input-file, --in FILENAME     Path to JSON file containing input data
                                  [required]
  --mongo-uri TEXT                MongoDB connection string (can be specified
                                  via an environment variable named
                                  `TEMP_MONGO_URI`)  [required]
  --is-direct-connection BOOLEAN  Whether to use the `directConnection`
                                  parameter for the MongoDB connection
  --database-name TEXT            MongoDB database name
  --validator-uri TEXT            URI of NMDC Schema-based validator
  --help                          Show this message and exit.
```

Here's an example invocation:

```shell
TEMP_MONGO_URI='mongodb://localhost:27017/?authSource=admin' poetry run python nmdc_schema/insert_many_pymongo.py --input-file ./path/to/my/data.json --is-direct-connection False --database-name nmdc
```