### PR TITLE
wipe all traces of "has unit" etc

### DIFF
--- a/assets/yq-for-mixs_subset_modified.txt
+++ b/assets/yq-for-mixs_subset_modified.txt
@@ -147,8 +147,12 @@
 '.slots.host_taxid.comments |= ["Homo sapiens [NCBITaxon:9606] would be a reasonable has_raw_value"]' 
 '.slots.host_taxid.range = "ControlledIdentifiedTermValue"' 
 '.slots.samp_taxon_id.comments |= ["coal metagenome [NCBITaxon:1260732] would be a reasonable has_raw_value"]' 
-'.slots.samp_taxon_id.range = "ControlledIdentifiedTermValue"' 
+'.slots.samp_taxon_id.range = "ControlledIdentifiedTermValue"'
 
+# these slots, by their old names, are not used anywhere in mixs.yaml and seem to confuse the mkdocs search when looking for has_unit etc.
+'del(.slots.["has numeric value"])'
+'del(.slots.["has raw value"])'
+'del(.slots.["has unit"])'
 
 # add "M horizon" to soil_horizon_enum
 '.enums.soil_horizon_enum.permissible_values.["M horizon"] = {}'

--- a/project.Makefile
+++ b/project.Makefile
@@ -57,7 +57,6 @@ local/mixs_regen/mixs_subset_modified.yaml: local/mixs_regen/mixs_subset.yaml as
 	sed -i.bak 's/range: text value/range: TextValue/' $@
 
 	grep "^'" $(word 2, $^) | while IFS= read -r line ; do echo $$line ; eval yq -i $$line $@ ; done
-	# eval yq -i $$line $@
 	rm -rf local/mixs_regen/mixs_subset_modified.yaml.bak
 
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -645,9 +645,6 @@ classes:
       - growth_hormone_regm
       - hall_count
       - handidness
-      - has numeric value
-      - has raw value
-      - has unit
       - hc_produced
       - hcr
       - hcr_fw_salinity


### PR DESCRIPTION
thanks for you help brainstorming and debugging @sujaypatil96 

@pkalita-lbl I am tempted to merge this and make a 10.0.1 release, but you had written a [slack message](https://nmdc-group.slack.com/archives/CFVF3G3H7/p1706128772003919) suggesting that we refrain from doing that kind of thing before the next scheduled nmdc ecosystem release.

This PR removes `has unit` and some other slots whose names begin with 'has' and a whitespace. They were never used anywhere.