### PR TITLE
issue 598 add funding sources character limit

### DIFF
--- a/src/data/invalid/Study-has-missing_doi_provider.yaml
+++ b/src/data/invalid/Study-has-missing_doi_provider.yaml
@@ -54,5 +54,5 @@ relevant_protocols:
   - any string 1
   - any string 2
 funding_sources:
-  - This is an example of a funding source with too long of a description. Funding sources should be no more than 150 characters. Any longer is unnecessary and excessive. I't's very very very very very very very very very long.
+  - any string 1
   - any string 2

--- a/src/data/invalid/Study-has-publications.yaml
+++ b/src/data/invalid/Study-has-publications.yaml
@@ -53,5 +53,5 @@ relevant_protocols:
   - any string 1
   - any string 2
 funding_sources:
-  - This is an example of a funding source with too long of a description. Funding sources should be no more than 150 characters. Any longer is unnecessary and excessive. Its very very very very very very very very very long.
+  - any string 1
   - any string 2

--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -55,9 +55,7 @@ relevant_protocols:
   - any string 1
   - any string 2
 funding_sources:
-  - > 
-    This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. 
-    Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very 
-    very very very very very very very long"
+  - This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very very very very very very very very long"
   - any string 2
+
 

--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -55,7 +55,9 @@ relevant_protocols:
   - any string 1
   - any string 2
 funding_sources:
-  - This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very very very very very very very very long"
+  - > 
+    This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. 
+    Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very 
+    very very very very very very very long"
   - any string 2
-
 

--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -55,6 +55,9 @@ relevant_protocols:
   - any string 1
   - any string 2
 funding_sources:
-  - This is an example of a funding source with too long of a description. Funding sources should be no more than 150 characters. Any longer is unnecessary and excessive. Its very very very very very very very very very long.
+  - > 
+  This is an example of a funding source with too long of a description. Funding sources should be no more than 450 characters. 
+  Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very 
+  very very very very very very very long"
   - any string 2
 

--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -56,8 +56,8 @@ relevant_protocols:
   - any string 2
 funding_sources:
   - > 
-  This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. 
-  Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very 
-  very very very very very very very long"
+    This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. 
+    Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very 
+    very very very very very very very long"
   - any string 2
 

--- a/src/data/invalid/Study-illegal-funding_sources.yaml
+++ b/src/data/invalid/Study-illegal-funding_sources.yaml
@@ -56,7 +56,7 @@ relevant_protocols:
   - any string 2
 funding_sources:
   - > 
-  This is an example of a funding source with too long of a description. Funding sources should be no more than 450 characters. 
+  This is an example of a funding source with too long of a description. Funding sources should be no more than 250 characters. 
   Any longer is unnecessary and excessive. It's very very very very very very very very very very very very very very very very 
   very very very very very very very long"
   - any string 2

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2648,7 +2648,7 @@ slots:
   funding_sources:
     multivalued: true
     range: string
-    pattern: ^.{1,450}$
+    pattern: ^.{1,250}$
     description: >-
       A list of organizations, along with the award numbers, that underwrite financial support for projects of 
       a particular type. Typically, they process applications and award funds to the chosen qualified 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2648,6 +2648,7 @@ slots:
   funding_sources:
     multivalued: true
     range: string
+    pattern: ^.{1,450}$
     description: >-
       A list of organizations, along with the award numbers, that underwrite financial support for projects of 
       a particular type. Typically, they process applications and award funds to the chosen qualified 


### PR DESCRIPTION
https://github.com/orgs/microbiomedata/projects/106/views/1?pane=issue&itemId=51680292

This PR adds a character limit of 250 for the `funding_sources` slot so new studies submitted will adhere to the suggested `funding_sources` format and will not exceed the character limit.

Update for @lamccue and @mslarae13, we set character limit to 250 for a singling funding source (450 was for all the funding sources combined, but since `funding_sources` is multivalued, this number was updated.