### PR TITLE
1747 improve logging for database tools `extract-study` warn for missing data objects

### DIFF
--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -21,17 +21,6 @@ SCRIPTS_DIR = Path(__file__).parent
 PROJECT_ROOT = SCRIPTS_DIR.parent.parent
 LOCAL_DIR = PROJECT_ROOT / "local"
 
-# Studies with non-compliant IDs that have been re-IDed
-# Name:, study ID, legacy study ID
-STUDIES = {
-    "Stegen": ("nmdc:sty-11-aygzgv51", "gold:Gs0114663"),
-    "SPRUCE": ("nmdc:sty-11-33fbta56", "gold:Gs0110138"),
-    "EMP": (None, "gold:Gs0154244"),
-    "Luquillo": (None, "gold:Gs0128850"),
-    "CrestedButte": ("nmdc:sty-11-dcqce727", "gold:Gs0135149"),
-}
-# Update study IDs after re-IDing
-DEFAULT_STUDY_ID = STUDIES["Stegen"][0]
 
 # TODO: Move NmdcApi class to the nacent nmdc-common/client package
 # TODO: Add unit tests for NmdcApi class

--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -132,18 +132,25 @@ def cli(ctx, api_base_url):
 
 
 @cli.command()
-@click.argument("study_id", required=True,)
-@click.option("--output-file", help="Path to output file, relative to project "
-                                   "root.")
-@click.option("--quick-test", is_flag=True, default=False, help=("Quick test "
-                                                                 "mode - "
-                                                                 "biosamples "
-                                                                 "and omics "
-                                                                 "only "))
-@click.option("--search-orphaned-data-objects", is_flag=True, default=False,
-              help=("Search for orphaned data objects by description."))
-@click.option("--search-legacy-identifiers", is_flag=True, default=False,
-              help=("Search for legacy IDs for Study and OmicsProcessing."))
+@click.option("--study-id", required=True, )
+@click.option(
+    "--output-file",
+    help="Path to output file, relative to project root."
+)
+@click.option(
+    "--quick-test",
+    is_flag=True,
+    default=False,
+    help=("Quick test mode, Biosamples and OmicsProcessing records only")
+)
+@click.option(
+    "--search-orphaned-data-objects", is_flag=True, default=False,
+    help=("Search for orphaned data objects by description.")
+)
+@click.option(
+    "--search-legacy-identifiers", is_flag=True, default=False,
+    help=("Search for legacy IDs for Study and OmicsProcessing.")
+    )
 @click.pass_context
 def extract_study(ctx, study_id, output_file, quick_test, search_orphaned_data_objects, search_legacy_identifiers):
     """


### PR DESCRIPTION
This PR provides minor updates to the `extract-study` tool:

- make study_id an argument rather than option
- remove filename normalization swapping ':' for '-' in study_id.  Colons appear to work fine in filenames
- update logging ERROR for orphan data objects or study-id not found