### PR TITLE
Configure GHA to check docs for broken links

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,80 @@
+###############################################################################
+# Introduction, specific to nmdc-schema:
+# --------------------------------------
+# This workflow file is based upon the Baler 2.0.4 sample workflow file:
+# https://github.com/caltechlibrary/baler/blob/main/sample-workflow.yml
+# You can compare them in a text editor to see how they differ.
+#
+# In short, this workflow builds the schema documentation, then checks it for
+# broken links. If it finds any, it creates a GitHub Issue listing them.
+#
+# Once the maintainers of `nmdc-schema` feel comfortable with the way this link
+# checker works, they may consolidate it with the `deploy-docs.yaml` workflow.
+###############################################################################
+
+# GitHub Actions workflow for Baler (BAd Link reportER) version 2.0.4.
+# This is available as the file "sample-workflow.yml" from the source
+# code repository for Baler: https://github.com/caltechlibrary/baler
+
+name: Check links
+
+# Configure this section ─────────────────────────────────────────────
+
+env:
+  # Files to check. (Put patterns on separate lines, no leading dash.)
+  # Reference: https://github.com/marketplace/actions/baler-bad-link-reporter#files
+  files: |
+    docs/*.md
+    docs/**/*.md
+
+  # Label(s) assigned to issues created by this workflow. (Use commas to separate labels.)
+  # Reference: https://github.com/marketplace/actions/baler-bad-link-reporter#labels
+  labels: documentation,broken-link
+
+  # Number of previous issues to check for duplicate reports. (Max is 100.)
+  # Reference: https://github.com/marketplace/actions/baler-bad-link-reporter#lookback
+  lookback: 100
+
+  # Time (sec) to wait on an unresponsive URL before trying once more.
+  # Reference: https://github.com/marketplace/actions/baler-bad-link-reporter#timeout
+  timeout: 5
+
+  # Optional file containing a list of URLs to ignore, one per line.
+  # Reference: https://github.com/marketplace/actions/baler-bad-link-reporter#ignore
+  ignore: .github/workflows/check-links-ignore.txt
+
+on:
+  # Allow people to trigger the workflow manually.
+  # Reference: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
+  workflow_dispatch: {}
+
+# The rest of this file should be left as-is ─────────────────────────
+
+run-name: Check links in Markdown files
+jobs:
+  Baler:
+    name: Link checker and reporter
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check out commit
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with: { python-version: 3.9 }
+      - name: Install Poetry
+        uses: snok/install-poetry@v1.3
+      - name: Install Python dependencies (including "docs" extras)
+        # Reference: https://python-poetry.org/docs/pyproject/#extras
+        run: poetry install --extras docs
+      - name: Build docs
+        run: make gendoc
+      - name: Check links
+        uses: caltechlibrary/baler@v2
+        with:
+          files:    ${{github.event.inputs.files    || env.files}}
+          labels:   ${{github.event.inputs.labels   || env.labels}}
+          ignore:   ${{github.event.inputs.ignore   || env.ignore}}
+          timeout:  ${{github.event.inputs.timeout  || env.timeout}}
+          lookback: ${{github.event.inputs.lookback || env.lookback}}


### PR DESCRIPTION
This branch introduces a GitHub Actions workflow that (1) builds the docs and then (2) tests all the links within the docs and, if the [`caltechlibrary/baler@v2`](https://github.com/microbiomedata/nmdc-schema/issues/1465#issuecomment-1912595733) action determines any to be broken, creates a GitHub Issue listing them.

The workflow currently has a [manual trigger](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow). It can be updated to have additional triggers.

---

**Developer note:** I have not tested this action in the `nmdc-schema` repository, but I have tested the action in a demonstration repo: https://github.com/eecavanna/demo-gha-scan-md-broken-links

Fixes: https://github.com/microbiomedata/nmdc-schema/issues/1780

Related to: https://github.com/microbiomedata/nmdc-schema/issues/1465