### PR TITLE
Invoke callback functions after manipulating collections

### DIFF
--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -161,9 +161,14 @@ def main(schema_path, input_path, output_path, salvage_prefix, migrator_name):
         total_dict[tdk] = curie_migrator.fix_curies_recursively_by_key(
             tdv, set(curie_slots))
 
-    # Instantiate an adapter that the migrator can use to manipulate
-    # a "database" that is represented as a Python dictionary.
-    dictionary_adapter = DictionaryAdapter(database=total_dict)
+    # Instantiate an adapter that the migrator can use to manipulate a "database" represented as a Python dictionary.
+    # Also, specify some callback functions, so we can react when certain events occur.
+    dictionary_adapter = DictionaryAdapter(
+        database=total_dict,
+        on_collection_created=lambda name: logger.info(f'Created collection "{name}"'),
+        on_collection_renamed=lambda old_name, name: logger.info(f'Renamed collection "{old_name}" to "{name}"'),
+        on_collection_deleted=lambda name: logger.info(f'Deleted collection "{name}"'),
+    )
 
     # Iterate over the specified Migrator classes:
     for current_migrator in migrators:

--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, Any
 
 
 class AdapterBase(ABC):
@@ -8,24 +8,49 @@ class AdapterBase(ABC):
     a Python data dictionary or a MongoDB database.
     """
 
+    def __init__(
+        self,
+        on_collection_created: Optional[Callable[[str], Any]] = None,
+        on_collection_renamed: Optional[Callable[[str, str], Any]] = None,
+        on_collection_deleted: Optional[Callable[[str], Any]] = None,
+    ):
+        r"""
+        Binds callback functions to the class instance.
+
+        Note: This is a "concrete" method within an "abstract" class.
+
+        :param on_collection_created: Callback function that will be invoked after a collection is created.
+                                      It will be passed the name of the collection.
+        :param on_collection_renamed: Callback function that will be invoked after a collection is renamed.
+                                      It will be passed the original name and new name of the collection.
+        :param on_collection_deleted: Callback function that will be invoked after a collection is deleted.
+                                      It will be passed the name of the collection.
+        """
+        self.on_collection_created = on_collection_created
+        self.on_collection_renamed = on_collection_renamed
+        self.on_collection_deleted = on_collection_deleted
+
     @abstractmethod
     def create_collection(self, collection_name: str) -> None:
         r"""
         Creates an empty collection having the specified name, if no collection by that name exists.
+        Also invokes `self.on_collection_created`, if defined, passing to it the name of the collection.
         """
         pass
 
     @abstractmethod
     def rename_collection(self, current_name: str, new_name: str) -> None:
         r"""
-        Renames the specified collection so that it has the specified name.
+        Renames the specified collection, if it exists, so that it has the specified new name.
+        Also invokes `self.on_collection_renamed`, if defined, passing to it the old and new names of the collection.
         """
         pass
 
     @abstractmethod
     def delete_collection(self, collection_name: str) -> None:
         r"""
-        Deletes the collection having the specified name.
+        Deletes the collection having the specified name, if such a collection exists.
+        Also invokes `self.on_collection_deleted`, if defined, passing to it the name of the collection.
         """
         pass
 

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -22,6 +22,9 @@ class DictionaryAdapter(AdapterBase):
         Creates an empty collection having the specified name, if no collection by that name exists.
         Also invokes `self.on_collection_created`, if defined, passing to it the name of the collection.
 
+        References:
+        - https://docs.python.org/3/library/functions.html#callable
+
         >>> database = {
         ...   "thing_set": [
         ...     {"id": "111", "foo": "bar"},
@@ -43,7 +46,10 @@ class DictionaryAdapter(AdapterBase):
         """
         if collection_name not in self._db:
             self._db[collection_name] = []
-            self.on_collection_created(collection_name)
+
+            # If the relevant callback function exists, invoke it.
+            if callable(self.on_collection_created):
+                self.on_collection_created(collection_name)
 
     def rename_collection(self, current_name: str, new_name: str) -> None:
         r"""
@@ -66,7 +72,10 @@ class DictionaryAdapter(AdapterBase):
         """
         if current_name in self._db:
             self._db[new_name] = self._db.pop(current_name)
-            self.on_collection_renamed(current_name, new_name)
+
+            # If the relevant callback function exists, invoke it.
+            if callable(self.on_collection_renamed):
+                self.on_collection_renamed(current_name, new_name)
 
     def delete_collection(self, collection_name: str) -> None:
         r"""
@@ -87,7 +96,10 @@ class DictionaryAdapter(AdapterBase):
         """
         if collection_name in self._db:
             del self._db[collection_name]
-            self.on_collection_deleted(collection_name)
+
+            # If the relevant callback function exists, invoke it.
+            if callable(self.on_collection_deleted):
+                self.on_collection_deleted(collection_name)
 
     def insert_document(self, collection_name: str, document: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -26,10 +26,14 @@ class MongoAdapter(AdapterBase):
 
         References:
         - https://pymongo.readthedocs.io/en/stable/api/pymongo/database.html#pymongo.database.Database.create_collection
+        - https://docs.python.org/3/library/functions.html#callable
         """
         if collection_name not in self._db.list_collection_names():
             self._db.create_collection(name=collection_name)
-            self.on_collection_created(collection_name)
+
+            # If the relevant callback function exists, invoke it.
+            if callable(self.on_collection_created):
+                self.on_collection_created(collection_name)
 
     def rename_collection(self, current_name: str, new_name: str) -> None:
         r"""
@@ -42,7 +46,10 @@ class MongoAdapter(AdapterBase):
         """
         if current_name in self._db.list_collection_names():
             self._db.get_collection(name=current_name).rename(new_name=new_name)
-            self.on_collection_renamed(current_name, new_name)
+
+            # If the relevant callback function exists, invoke it.
+            if callable(self.on_collection_renamed):
+                self.on_collection_renamed(current_name, new_name)
 
     def delete_collection(self, collection_name: str) -> None:
         r"""
@@ -54,7 +61,10 @@ class MongoAdapter(AdapterBase):
         """
         if collection_name in self._db.list_collection_names():
             self._db.drop_collection(name_or_collection=collection_name)
-            self.on_collection_deleted(collection_name)
+
+            # If the relevant callback function exists, invoke it.
+            if callable(self.on_collection_deleted):
+                self.on_collection_deleted(collection_name)
 
     def insert_document(self, collection_name: str, document: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -8,42 +8,53 @@ class MongoAdapter(AdapterBase):
     Class containing methods related to manipulating a MongoDB database.
     """
 
-    def __init__(self, database: Database) -> None:
+    def __init__(self, database: Database, **kwargs) -> None:
         r"""
-        Initializes the reference to the database this adapter instance will be used to manipulate.
+        Invokes the initialization method of the parent class, passing to it any specified keyword arguments.
+        Also initializes the reference to the database this adapter instance will be used to manipulate.
 
         References:
         - https://pymongo.readthedocs.io/en/stable/examples/type_hints.html#typed-database
         """
+        super().__init__(**kwargs)
         self._db = database
 
     def create_collection(self, collection_name: str) -> None:
         r"""
         Creates an empty collection having the specified name, if no collection by that name exists.
+        Also invokes `self.on_collection_created`, if defined, passing to it the name of the collection.
 
         References:
         - https://pymongo.readthedocs.io/en/stable/api/pymongo/database.html#pymongo.database.Database.create_collection
         """
-        self._db.create_collection(name=collection_name)
+        if collection_name not in self._db.list_collection_names():
+            self._db.create_collection(name=collection_name)
+            self.on_collection_created(collection_name)
 
     def rename_collection(self, current_name: str, new_name: str) -> None:
         r"""
-        Renames the specified collection so that it has the specified name.
+        Renames the specified collection, if it exists, so that it has the specified new name.
+        Also invokes `self.on_collection_renamed`, if defined, passing to it the old and new names of the collection.
 
         References:
         - https://pymongo.readthedocs.io/en/stable/api/pymongo/database.html#pymongo.database.Database.get_collection
         - https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.rename
         """
-        self._db.get_collection(name=current_name).rename(new_name=new_name)
+        if current_name in self._db.list_collection_names():
+            self._db.get_collection(name=current_name).rename(new_name=new_name)
+            self.on_collection_renamed(current_name, new_name)
 
     def delete_collection(self, collection_name: str) -> None:
         r"""
-        Deletes the collection having the specified name.
+        Deletes the collection having the specified name, if such a collection exists.
+        Also invokes `self.on_collection_deleted`, if defined, passing to it the name of the collection.
 
         References:
         - https://pymongo.readthedocs.io/en/stable/api/pymongo/database.html#pymongo.database.Database.drop_collection
         """
-        self._db.drop_collection(name_or_collection=collection_name)
+        if collection_name in self._db.list_collection_names():
+            self._db.drop_collection(name_or_collection=collection_name)
+            self.on_collection_deleted(collection_name)
 
     def insert_document(self, collection_name: str, document: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -151,9 +151,13 @@ class TestMongoAdapter(unittest.TestCase):
         )
 
         # Validate result:
-        # TODO: Confirm the correct documents were deleted, not just the correct quantity of documents.
+        collection = self.db[collection_name]
         assert num_documents_deleted == 2
         assert len(self.db[collection_name]) == 2
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "a"]) == 1
+        assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "b"]) == 0
+        assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "c"]) == 1
+        assert len([doc for doc in collection if doc["id"] == 4 and doc["x"] == "b"]) == 0
 
     def test_process_each_document(self):
         # Set up:

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -1,0 +1,200 @@
+import unittest
+from typing import Optional
+
+from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+
+
+class TestMongoAdapter(unittest.TestCase):
+    r"""
+    Tests targeting the `DictionaryAdapter` class.
+
+    You can run these tests like this:
+    $ poetry run python -m unittest -v nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+
+    References:
+    - https://docs.python.org/3/library/unittest.html#basic-example
+    - https://docs.python.org/3/library/unittest.html#unittest.TestCase.setUp
+    """
+
+    db: Optional[dict] = None
+
+    def setUp(self) -> None:
+        r"""
+        Gets a reference to the database.
+
+        Note: This function runs before each test starts.
+        """
+        self.db = dict()
+
+    def tearDown(self) -> None:
+        r"""
+        Relinquishes the reference to the database.
+
+        Note: This function runs after each test finishes.
+        """
+        self.db = None
+
+    def test_create_collection(self):
+        # Set up:
+        collection_name = "my_collection"
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.create_collection(collection_name)
+
+        # Validate result:
+        assert len(self.db.keys()) == 1
+        assert collection_name in self.db
+
+    def test_rename_collection(self):
+        # Set up:
+        collection_name_original = "my_collection"
+        collection_name_target = "your_collection"
+        self.db[collection_name_original] = []
+        assert len(self.db.keys()) == 1
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.rename_collection(collection_name_original, collection_name_target)
+
+        # Validate result:
+        assert len(self.db.keys()) == 1
+        assert collection_name_target in self.db
+
+    def test_delete_collection(self):
+        # Set up:
+        collection_name = "my_collection"
+        self.db[collection_name] = []
+        assert len(self.db.keys()) == 1
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.delete_collection(collection_name)
+
+        # Validate result:
+        assert len(self.db.keys()) == 0
+
+    def test_insert_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document = dict(id=123, foo="bar")
+        self.db[collection_name] = []
+        assert len(self.db[collection_name]) == 0
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.insert_document(collection_name, document)
+
+        # Validate result:
+        assert len(self.db[collection_name]) == 1
+        document_actual = self.db[collection_name][0]
+        for k, v in document.items():
+            assert v == document_actual[k]
+
+    def test_get_document_having_value_in_field(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(id=1, x="a")
+        document_2 = dict(id=2, x="b")
+        document_3 = dict(id=3, x="c")
+        self.db[collection_name] = []
+        self.db[collection_name].extend([document_1, document_2, document_3])
+        assert len(self.db[collection_name]) == 3
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        document_actual = adapter.get_document_having_value_in_field(
+            collection_name, "x", "b"
+        )
+
+        # Validate result:
+        for k, v in document_2.items():
+            assert v == document_actual[k]
+
+    def test_get_document_having_one_of_values_in_field(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(id=1, x="a")
+        document_2 = dict(id=2, x="b")
+        document_3 = dict(id=3, x="c")
+        self.db[collection_name] = []
+        self.db[collection_name].extend([document_1, document_2, document_3])
+        assert len(self.db[collection_name]) == 3
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        document_actual = adapter.get_document_having_one_of_values_in_field(
+            collection_name, "x", ["n", "b", "m"]
+        )
+
+        # Validate result:
+        for k, v in document_2.items():
+            assert v == document_actual[k]
+
+    def test_delete_documents_having_value_in_field(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(id=1, x="a")
+        document_2 = dict(id=2, x="b")
+        document_3 = dict(id=3, x="c")
+        document_4 = dict(id=4, x="b")  # note: x="b" here also
+        self.db[collection_name] = []
+        self.db[collection_name].extend(
+            [document_1, document_2, document_3, document_4]
+        )
+        assert len(self.db[collection_name]) == 4
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        num_documents_deleted = adapter.delete_documents_having_value_in_field(
+            collection_name, "x", "b"
+        )
+
+        # Validate result:
+        # TODO: Confirm the correct documents were deleted, not just the correct quantity of documents.
+        assert num_documents_deleted == 2
+        assert len(self.db[collection_name]) == 2
+
+    def test_process_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="a")
+        document_2 = dict(_id=2, id=2, x="b")
+        document_3 = dict(_id=3, id=3, x="c")
+        self.db[collection_name] = []
+        self.db[collection_name].extend(
+            [document_1, document_2, document_3]
+        )
+        assert len(self.db[collection_name]) == 3
+
+        def capitalize_x(doc: dict) -> dict:
+            r"""Example pipeline stage that capitalizes the first letter of the `x` value."""
+            doc["x"] = doc["x"].capitalize()
+            return doc
+
+        def append_z_to_x_value(doc: dict) -> dict:
+            r"""Example pipeline stage that appends "z" to the `x` value."""
+            doc["x"] = doc["x"] + "z"
+            return doc
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.process_each_document(
+            collection_name, [capitalize_x, append_z_to_x_value]
+        )
+
+        # Validate result:
+        collection = self.db[collection_name]
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "a"]) == 0  # pre-pipeline
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "b"]) == 0
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "c"]) == 0
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "A"]) == 0  # mid-pipeline
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "B"]) == 0
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "C"]) == 0
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "Az"]) == 1  # post-pipeline
+        assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "Bz"]) == 1
+        assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "Cz"]) == 1
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -195,6 +195,34 @@ class TestMongoAdapter(unittest.TestCase):
         assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "Bz"]) == 1
         assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "Cz"]) == 1
 
+    def test_callbacks(self):
+        # Set up:
+        collection_name = "my_collection"
+        new_collection_name = "my_new_collection"
+        event_log: list[str] = []
+        adapter = DictionaryAdapter(
+            database=self.db,
+            on_collection_created=lambda name: event_log.append(f"Created {name}"),
+            on_collection_renamed=lambda old_name, name: event_log.append(f"Renamed {old_name} to {name}"),
+            on_collection_deleted=lambda name: event_log.append(f"Deleted {name}"),
+        )
+        assert len(event_log) == 0
+
+        # Trigger callback and validate latest message in event log:
+        adapter.create_collection(collection_name)
+        assert len(event_log) == 1
+        assert event_log[0] == f"Created {collection_name}"
+
+        # Trigger callback and validate latest message in event log:
+        adapter.rename_collection(collection_name, new_collection_name)
+        assert len(event_log) == 2
+        assert event_log[1] == f"Renamed {collection_name} to {new_collection_name}"
+
+        # Trigger callback and validate latest message in event log:
+        adapter.delete_collection(new_collection_name)
+        assert len(event_log) == 3
+        assert event_log[2] == f"Deleted {new_collection_name}"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This branch introduces callback support into the migration framework. It also introduces additional unit tests.

### Summary of changes

- Consumers can now specify callback functions when instantiating an adapter. The adapter will invoke those callback functions—if defined—when corresponding events happen. That will allow the consumers to "react" to those events. Supported events are currently: creating a collection, renaming a collection, and deleting a collection.
- The adapters now also check whether a collection exists, before operating upon it.
- I added unit tests targeting the `DictionaryAdapter` (previously, there were none)
- I added unit tests targeting the callback functionality, specifically, of both adapters.
- I updated the `migration_recursion.py` script to use callback functions (as an example).
  > I used `lambda`s to keep the example concise. I could have defined functions and passed references to them instead; like this:
  > ```py
  > def my_func(name: str):
  >     pass
  >
  > dictionary_adapter = DictionaryAdapter(
  >     on_collection_created=my_func,
  >     # ...
  > )
  > ```