### PR TITLE
Add metagenomics_long_read PV to AnalysisTypeEnum

### DIFF
--- a/src/schema/portal/sample_id.yaml
+++ b/src/schema/portal/sample_id.yaml
@@ -25,7 +25,12 @@ enums:
     from_schema: https://example.com/nmdc_dh
     permissible_values:
       metabolomics: { }
-      metagenomics: { }
+      metagenomics:
+        title: Metagenomics
+        description: Standard short-read metagenomic sequencing
+      metagenomics_long_read:
+        title: Metagenomics (long read)
+        description: Long-read metagenomic sequencing
       metaproteomics: { }
       metatranscriptomics: { }
       natural organic matter: { }


### PR DESCRIPTION
Related to https://github.com/microbiomedata/submission-schema/issues/168

The decision in the latest UFO squad meeting was to keep the existing `metagenomics` PV, which was always _implicitly_ referring to short-read sequencing, and add a new PV for long-read metagenomic sequencing. 