### PR TITLE
Automatic artifact regeneration and dynamic versioning in publish workflow

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -10,24 +10,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Install Poetry
       run: |
-        pip install poetry
-        poetry self add "poetry-dynamic-versioning[plugin]"
-      # uses: snok/install-poetry@v1.1.6
-      # with:
-      #   virtualenvs-create: true
-      #   virtualenvs-in-project: true
+        pipx install poetry
+        pipx inject poetry "poetry-dynamic-versioning[plugin]"
 
-    # - name: Install dependencies
-    #   run: poetry install --no-interaction
+    - name: Install project dependencies
+      run: poetry install --no-interaction
+
+    - name: Generate project files
+      run: |
+        poetry dynamic-versioning
+        make squeaky-clean all
 
     - name: Build source and wheel archives
       run: poetry build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nmdc_schema"
 readme = "README.md"
 repository = "https://github.com/microbiomedata/nmdc-schema"
-version = "10.1.0" # nmdc.yaml and GH say v10.0.0
+version = "0.0.0"
 authors = [
     "Bill Duncan <wdduncan@gmail.com>",
     "Chris Mungall <cjmungall@lbl.gov>",
@@ -70,22 +70,22 @@ sparql-burger = "^1.0.2"
 sparql-dataframe = "^0.4"
 
 [tool.poetry-dynamic-versioning]
+# We need poetry-dynamic-versioning to update the version in the src schema file,
+# then generate project artifacts from that schema with the real version populated,
+# and then perform any build or publish actions. Since this requires running
+# `poetry dynamic-versioning` manually before `poetry build`, we set enable = false.
 enable = false
 vcs = "git"
 style = "pep440"
 
-#[tool.poetry-dynamic-versioning.substitution]
-#files = [
-#    "*.py",
-#    "src/**/__init__.py",
-#    "src/**/__version__.py",
-#    "src/**/_version.py",
-#    "src/schema/nmdc.yaml"
-#]
-#patterns = [
-#    "(^\\s*__version__\\s*(?::.*?)?=\\s*['\\\"])[^'\\\"]*(['\\\"])",
-#    "(^version:\\s*['\\\"]?)[^'\\\"]*?(['\\\"]?)$"
-#]
+[tool.poetry-dynamic-versioning.substitution]
+files = [
+    "src/schema/nmdc.yaml"
+]
+patterns = [
+    "(^\\s*__version__\\s*(?::.*?)?=\\s*['\\\"])[^'\\\"]*(['\\\"])",
+    "(^version:\\s*['\\\"]?)[^'\\\"]*?(['\\\"]?)$"
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -15,7 +15,7 @@ description: >-
    * the NMDC schema itself, into which the other modules are imported
 
 license: https://creativecommons.org/publicdomain/zero/1.0/
-version: v10.1.0 # GH uses same version string # pyproject.toml says "9.3.2"
+version: 0.0.0
 
 imports:
   - annotation


### PR DESCRIPTION
Fixes #827 

### Summary
* Remove hardcoded version numbers in `pyproject.toml` and `src/schema/nmdc.yaml` (replaced with 0.0.0 placeholders)
* Update `poetry-dynamic-versioning` settings in `pyproject.toml` to do version replacement `src/schema/nmdc.yaml`
* Update `.github/workflows/pypi-publish.yaml` do manually invoke the `poetry-dynamic-versioning` plugin and then regenerate artifacts before running `poetry build`. We still have generated artifacts checked in, and it would be good practice to regenerate and check in changes before making a release. But those checked-in versions _will not_ be packaged directly into the distribution.
* Updated various actions in `.github/workflows/pypi-publish.yaml` to their latest versions