### PR TITLE
Add accepting-legacy-ids-all prerequisite to site target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ create-data-harmonizer:
 	npm init data-harmonizer $(SOURCE_SCHEMA_PATH)
 
 all: site
-site: clean site-clean gen-project gendoc migration-doctests nmdc_schema/gold-to-mixs.sssom.tsv
+site: clean site-clean gen-project gendoc migration-doctests nmdc_schema/gold-to-mixs.sssom.tsv accepting-legacy-ids-all
 # may change files in nmdc_schema/ or project/. uncommitted changes are not tolerated by mkd-gh-deploy
 
 %.yaml: gen-project


### PR DESCRIPTION
Previously the `accepting-legacy-ids-all` target was only included as a prerequisite for the `test` and `only-test` targets. This meant that the artifacts generated by `accepting-legacy-ids-all` were not generated with simply running `make all`. Found this out the hard way when trying to bring v10.1.1 into `nmdc-runtime` which relies on the `nmdc_schema_accepting_legacy_ids` module.

cc @turbomam 