### PR TITLE
Document the `make mkd-gh-deploy` command

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -23,7 +23,17 @@ jobs:
       - name: Install dependencies.
         run: poetry install -E docs
 
-      - name: Build documentation.
+      - name: Build and deploy documentation.
+        # Build the docs and deploy them to GitHub Pages.
+        #
+        # Note: The `make mkd-gh-deploy` command below uses the `mkd-%` target
+        #       defined in `Makefile`. That target's action (i.e. recipe)
+        #       strips off the `mkd-` prefix and passes the rest of the command
+        #       to `$ poetry run mkdocs`, effectively translating the command
+        #       below into `$ poetry run mkdocs gh-deploy`.
+        #
+        # Reference: https://www.mkdocs.org/user-guide/deploying-your-docs/
+        #
         run: |
           mkdir -p docs
           touch docs/.nojekyll


### PR DESCRIPTION
In this branch, I documented a command that I failed to find documentation about. I originally didn't know there was a sort of "wildcard" `mkd-*` target defined somewhere, which this command relies on; and so I found this command mysterious.