### PR TITLE
Resolve omics processing has output data object referential integrity exceptions

### DIFF
--- a/assets/mongodb_queries/data_qc/omics_processing_has_output_data_objects.js
+++ b/assets/mongodb_queries/data_qc/omics_processing_has_output_data_objects.js
@@ -12,7 +12,10 @@ db.omics_processing_set.aggregate([
   },
   {
     $match: {
-      output_docs: { $eq: [] }
+      $or: [
+        { output_docs: { $exists: false } },  // Check if output_docs doesn't exist
+        { output_docs: { $size: 0 } }         // Check if output_docs is an empty array
+      ]
     }
   }
 ])

--- a/assets/mongodb_queries/delete_omics_processing_has_output_ref_integrity_exceptions.js
+++ b/assets/mongodb_queries/delete_omics_processing_has_output_ref_integrity_exceptions.js
@@ -1,0 +1,26 @@
+// Description: Delete omics_processing_set documents that have invalid references in has_output field.
+// This script will delete the omics_processing_set documents that have invalid references in has_output field.
+
+db.omics_processing_set.aggregate([
+  {
+    $unwind: "$has_output"
+  },
+  {
+    $lookup: {
+      from: "data_object_set",
+      localField: "has_output",
+      foreignField: "id",
+      as: "output_docs"
+    }
+  },
+  {
+    $match: {
+      $or: [
+        { output_docs: { $exists: false } },  // Check if output_docs doesn't exist
+        { output_docs: { $size: 0 } }         // Check if output_docs is an empty array
+      ]
+    }
+  }
+]).forEach(function(doc) {
+    db.omics_processing_set.deleteMany({ _id: doc._id }); // Delete the matching documents
+});


### PR DESCRIPTION
The query`data_qc/omics_processing_has_output_data_objects.js` found 82 exceptions in the Napa database.

- 79 exceptions in nmdc:sty-11-dcqce727 
- #1897 

This PR provides a MongoDB query to find and delete these omics processing records