### PR TITLE
Update pypi-publish.yaml for trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -8,6 +8,10 @@ jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      # this permission is mandatory for trusted publishing
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -34,7 +38,5 @@ jobs:
       run: poetry build
 
     - name: Publish distribution 📦 to PyPI
+      # No username or password because we're using trusted publishing
       uses: pypa/gh-action-pypi-publish@v1.2.2
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Fixes #1930 

The necessary settings have already been updated in PyPI. These changes to the PyPI publishing workflow finish the job. For more information see https://docs.pypi.org/trusted-publishers/.