### PR TITLE
`napa_compliance` branch: Update script to generate request bodies for `/queries:run` endpoint

### DIFF
--- a/nmdc_schema/connect_napa_mongo.py
+++ b/nmdc_schema/connect_napa_mongo.py
@@ -443,6 +443,10 @@ for doc in omics_coll.find(omics_with_gold_projects):
 ###############
 # track down records WorkflowExecutionActivity (WEA) records that need to be deleted and their associated data objects
 
+# Flag you can use to control whether you want this script to also delete the documents it finds, or to only
+# generate the `/queries:run` HTTP request bodies that can be used to delete them later via the Runtime API.
+DELETE_DOCUMENTS_NOW: bool = False
+
 seq_based_collection_list = [
     "read_qc_analysis_activity_set",
     "read_based_taxonomy_analysis_activity_set",
@@ -474,7 +478,8 @@ for gp in target_gp_for_del:
                 print("found " + doc["id"] + " in collection " + collection)
                 deleted_record_identifiers.append((collection, doc["id"]))
                 # wea_to_delete.append(doc)
-                wea_coll.delete_one({"was_informed_by": gold_proj_curie})
+                if DELETE_DOCUMENTS_NOW:
+                    wea_coll.delete_one({"was_informed_by": gold_proj_curie})
             # this method should not be used as there are data objects that need to be removed that are not listed in has_output for the WEA records
             # if "has_input" in doc.keys():
             #  for input in doc["has_input"]:
@@ -494,7 +499,8 @@ for gp in target_gp_for_del:
         # Delete each matching document
         for doc in matching_docs:
             deleted_record_identifiers.append(("data_object_set", doc["id"]))
-            data_object_coll.delete_one({"_id": doc["_id"]})
+            if DELETE_DOCUMENTS_NOW:
+                data_object_coll.delete_one({"_id": doc["_id"]})
 
 # Print the list of deleted record identifiers to a tsv file
 with open("deleted_record_identifiers.tsv", "w") as f:

--- a/nmdc_schema/connect_napa_mongo.py
+++ b/nmdc_schema/connect_napa_mongo.py
@@ -513,7 +513,7 @@ def make_deletion_descriptors(collection_names_and_document_ids: list) -> dict:
     be used within the body of a request to the `/queries:run` endpoint of the
     Runtime API. The deletion descriptors are grouped by collection, since the
     `/queries:run` endpoint only processes documents in a single collection
-    per each HTTP request.
+    per HTTP request.
     """
 
     deletion_descriptors = dict()
@@ -526,7 +526,7 @@ def make_deletion_descriptors(collection_names_and_document_ids: list) -> dict:
         if collection_name not in deletion_descriptors:
             deletion_descriptors[collection_name] = []
 
-        # Create and append a deletion descriptor for this item.
+        # Create and append a deletion descriptor for this document.
         deletion_descriptor = dict(q=dict(id=document_id), limit=1)
         deletion_descriptors[collection_name].append(deletion_descriptor)
 
@@ -536,7 +536,7 @@ def make_deletion_descriptors(collection_names_and_document_ids: list) -> dict:
 def dump_request_body(collection_name: str, its_deletion_descriptors: list) -> str:
     r"""
     Creates a request body into which the specified deletion descriptors are
-    incorporated, and writes them to a JSON file. That request body can be
+    incorporated, and writes them to a JSON file. That request body can then be
     submitted to the `/queries:run` endpoint of the Runtime API.
     """
 

--- a/nmdc_schema/connect_napa_mongo.py
+++ b/nmdc_schema/connect_napa_mongo.py
@@ -514,6 +514,18 @@ def make_deletion_descriptors(collection_names_and_document_ids: list) -> dict:
     Runtime API. The deletion descriptors are grouped by collection, since the
     `/queries:run` endpoint only processes documents in a single collection
     per HTTP request.
+
+    Note: The remainder of this docstring consists of doctests.
+          Reference: https://docs.python.org/3/library/doctest.html
+
+    >>> make_deletion_descriptors([])
+    {}
+    >>> make_deletion_descriptors([("my_collection", "my_id")])
+    {'my_collection': [{'q': {'id': 'my_id'}, 'limit': 1}]}
+    >>> make_deletion_descriptors([("my_collection", "my_id"), ("my_collection", "other_id")])
+    {'my_collection': [{'q': {'id': 'my_id'}, 'limit': 1}, {'q': {'id': 'other_id'}, 'limit': 1}]}
+    >>> make_deletion_descriptors([("my_collection", "my_id"), ("other_collection", "other_id")])
+    {'my_collection': [{'q': {'id': 'my_id'}, 'limit': 1}], 'other_collection': [{'q': {'id': 'other_id'}, 'limit': 1}]}
     """
 
     deletion_descriptors = dict()

--- a/nmdc_schema/connect_napa_mongo.py
+++ b/nmdc_schema/connect_napa_mongo.py
@@ -530,7 +530,6 @@ def make_deletion_descriptors(collection_names_and_document_ids: list) -> dict:
 
     deletion_descriptors = dict()
     for collection_name_and_document_id in collection_names_and_document_ids:
-
         # Extract the elements of the tuple.
         (collection_name, document_id) = collection_name_and_document_id
 
@@ -569,9 +568,9 @@ def make_request_body(collection_name: str, its_deletion_descriptors: list) -> d
 deletion_descriptors = make_deletion_descriptors(deleted_record_identifiers)
 for collection_name in deletion_descriptors.keys():
     its_deletion_descriptors = deletion_descriptors[collection_name]
+    request_body = make_request_body(collection_name, its_deletion_descriptors)
     file_path = f"./{collection_name}.deletion_api_request_body.json"
     with open(file_path, "w") as json_file:
-        request_body = make_request_body(collection_name, its_deletion_descriptors)
         json.dump(request_body, json_file)
         print(f"Created file: {file_path}")
 


### PR DESCRIPTION
In this branch, I added code that will generate bodies (each one in its own JSON file) for HTTP requests that can be made to the `/queries:run` endpoint of the Runtime API.

I tested the added code (by running it in a Jupyter notebook that contained only the added code and a contrived `deleted_record_identifiers` list, shown below).

Here's a screenshot showing what the request bodies would look like for an example (contrived) `deleted_record_identifiers` list:

![image](https://github.com/microbiomedata/nmdc-schema/assets/134325062/49ab7268-2807-42aa-b7d5-3691293c6982)

Note: I did not remove the preexisting `some_collection.delete_one(...)` statements from this Python script. I will leave that to my teammate to do when she is ready.

Note: The target branch for this PR is the `napa_compliance` branch, not the `main` branch.