### PR TITLE
Range for slots in slots table on class documentation pages account ofor `any_of`/`exactly_one_of`

### DIFF
--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -8,6 +8,19 @@
     {%- endif -%}
 {%- endif -%}
 
+{% macro compute_range(slot) -%}
+    {%- if slot.any_of or slot.exactly_one_of -%}
+        {%- for subslot_range in schemaview.slot_range_as_union(slot) -%}
+            {{ gen.link(subslot_range) }}
+            {%- if not loop.last -%}
+                &nbsp;or&nbsp;<br />
+            {%- endif -%}
+        {%- endfor -%}
+    {%- else -%}
+        {{ gen.link(slot.range) }}
+    {%- endif -%}
+{% endmacro %}
+
 # Class: {{ title }}
 
 {%- if header -%}
@@ -34,6 +47,10 @@ URI: {{ gen.uri_link(element) }}
 ```{{ gen.mermaid_directive() }}
 {{ gen.mermaid_diagram([element.name]) }}
 ```
+{% elif diagram_type == "plantuml_class_diagram" %}
+```puml
+{{ gen.mermaid_diagram([element.name]) }}
+```
 {% else %}
 {% include "class_diagram.md.jinja2" %}
 {% endif %}
@@ -52,12 +69,12 @@ URI: {{ gen.uri_link(element) }}
 | ---  | --- | --- | --- |
 {% if gen.get_direct_slots(element)|length > 0 %}
 {%- for slot in gen.get_direct_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | direct |
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | direct |
 {% endfor -%}
 {% endif -%}
 {% if gen.get_indirect_slots(element)|length > 0 %}
 {%- for slot in gen.get_indirect_slots(element) -%}
-| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ gen.link(slot.range) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
+| {{ gen.link(slot) }} | {{ gen.cardinality(slot) }} <br/> {{ compute_range(slot) }} | {{ slot.description|enshorten }} | {{ gen.links(gen.get_slot_inherited_from(element.name, slot.name))|join(', ') }} |
 {% endfor -%}
 {% endif %}
 


### PR DESCRIPTION
In its current state, classes which have slots that get modified to have ranges as unions (using `any_of`) like https://microbiomedata.github.io/nmdc-schema/Extraction/ do not show the modified ranges correctly in the slots table.

Merging this PR in will start rendering the range, for say the `has_input` slot on the above class documentation page correctly. Similar pattern will be applied to all applicable classes.