### PR TITLE
Migrations: Implement `do_for_each_document` adapter method

### DIFF
--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -109,10 +109,10 @@ class AdapterBase(ABC):
 
     @abstractmethod
     def do_for_each_document(
-        self, collection_name: str, reader: Callable[[dict], None]
+        self, collection_name: str, action: Callable[[dict], None]
     ) -> None:
         r"""
-        Passes each document in the specified collection to the specified function. This function was designed to
-        facilitate iterating over all documents in a collection without actually modifying them.
+        Passes each document in the specified collection to the specified function. This method was designed
+        to facilitate iterating over all documents in a collection without actually modifying them.
         """
         pass

--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -108,7 +108,7 @@ class AdapterBase(ABC):
         pass
 
     @abstractmethod
-    def read_each_document(
+    def do_for_each_document(
         self, collection_name: str, reader: Callable[[dict], None]
     ) -> None:
         r"""

--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -106,3 +106,13 @@ class AdapterBase(ABC):
         back in the collection, replacing the original document.
         """
         pass
+
+    @abstractmethod
+    def read_each_document(
+        self, collection_name: str, reader: Callable[[dict], None]
+    ) -> None:
+        r"""
+        Passes each document in the specified collection to the specified function. This function was designed to
+        facilitate iterating over all documents in a collection without actually modifying them.
+        """
+        pass

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -304,7 +304,7 @@ class DictionaryAdapter(AdapterBase):
                 # Overwrite the original document with the processed one.
                 self._db[collection_name][index] = processed_document
 
-    def read_each_document(
+    def do_for_each_document(
         self, collection_name: str, reader: Callable[[dict], None]
     ) -> None:
         r"""
@@ -326,7 +326,7 @@ class DictionaryAdapter(AdapterBase):
         >>> da = DictionaryAdapter(database)
         >>> total
         0
-        >>> da.read_each_document("payment_set", add_to_total)
+        >>> da.do_for_each_document("payment_set", add_to_total)
         >>> total
         600
         """

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -265,9 +265,9 @@ class DictionaryAdapter(AdapterBase):
 
         Reference: https://docs.python.org/3/library/copy.html#copy.deepcopy
 
-        >>> def capitalize_foo_value(document: dict) -> dict:
-        ...     document["foo"] = document["foo"].upper()
-        ...     return document
+        >>> def capitalize_foo_value(thing: dict) -> dict:
+        ...     thing["foo"] = thing["foo"].upper()
+        ...     return thing
         >>>
         >>> database = {
         ...   "thing_set": [
@@ -305,16 +305,16 @@ class DictionaryAdapter(AdapterBase):
                 self._db[collection_name][index] = processed_document
 
     def do_for_each_document(
-        self, collection_name: str, reader: Callable[[dict], None]
+        self, collection_name: str, action: Callable[[dict], None]
     ) -> None:
         r"""
-        Passes each document in the specified collection to the specified function. This function was designed to
-        facilitate iterating over all documents in a collection without actually modifying them.
+        Passes each document in the specified collection to the specified function. This method was designed
+        to facilitate iterating over all documents in a collection without actually modifying them.
 
         >>> total = 0
-        >>> def add_to_total(document: dict) -> None:
+        >>> def add_to_total(payment: dict) -> None:
         ...     global total
-        ...     total += document["amount"]
+        ...     total += payment["amount"]
         >>>
         >>> database = {
         ...   "payment_set": [
@@ -334,4 +334,4 @@ class DictionaryAdapter(AdapterBase):
         # Iterate over every document in the collection, if the collection exists.
         if collection_name in self._db:
             for document in self._db[collection_name]:
-                reader(document)
+                action(document)

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -303,3 +303,35 @@ class DictionaryAdapter(AdapterBase):
 
                 # Overwrite the original document with the processed one.
                 self._db[collection_name][index] = processed_document
+
+    def read_each_document(
+        self, collection_name: str, reader: Callable[[dict], None]
+    ) -> None:
+        r"""
+        Passes each document in the specified collection to the specified function. This function was designed to
+        facilitate iterating over all documents in a collection without actually modifying them.
+
+        >>> total = 0
+        >>> def add_to_total(document: dict) -> None:
+        ...     global total
+        ...     total += document["amount"]
+        >>>
+        >>> database = {
+        ...   "payment_set": [
+        ...     {"id": "111", "amount": 100},
+        ...     {"id": "222", "amount": 200},
+        ...     {"id": "333", "amount": 300}
+        ...   ]
+        ... }
+        >>> da = DictionaryAdapter(database)
+        >>> total
+        0
+        >>> da.read_each_document("payment_set", add_to_total)
+        >>> total
+        600
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db:
+            for document in self._db[collection_name]:
+                reader(document)

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -187,15 +187,15 @@ class MongoAdapter(AdapterBase):
                 collection.replace_one(filter=filter_, replacement=document)
 
     def do_for_each_document(
-        self, collection_name: str, reader: Callable[[dict], None]
+        self, collection_name: str, action: Callable[[dict], None]
     ) -> None:
         r"""
-        Passes each document in the specified collection to the specified function. This function was designed to
-        facilitate iterating over all documents in a collection without actually modifying them.
+        Passes each document in the specified collection to the specified function. This method was designed
+        to facilitate iterating over all documents in a collection without actually modifying them.
         """
 
         # Iterate over every document in the collection, if the collection exists.
         if collection_name in self._db.list_collection_names():
             collection = self._db.get_collection(name=collection_name)
             for document in collection.find():
-                reader(document)
+                action(document)

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -186,7 +186,7 @@ class MongoAdapter(AdapterBase):
                 # Overwrite the original document with the processed one.
                 collection.replace_one(filter=filter_, replacement=document)
 
-    def read_each_document(
+    def do_for_each_document(
         self, collection_name: str, reader: Callable[[dict], None]
     ) -> None:
         r"""

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -185,3 +185,17 @@ class MongoAdapter(AdapterBase):
 
                 # Overwrite the original document with the processed one.
                 collection.replace_one(filter=filter_, replacement=document)
+
+    def read_each_document(
+        self, collection_name: str, reader: Callable[[dict], None]
+    ) -> None:
+        r"""
+        Passes each document in the specified collection to the specified function. This function was designed to
+        facilitate iterating over all documents in a collection without actually modifying them.
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db.list_collection_names():
+            collection = self._db.get_collection(name=collection_name)
+            for document in collection.find():
+                reader(document)

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -199,7 +199,6 @@ class TestDictionaryAdapter(unittest.TestCase):
         assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "Bz"]) == 1
         assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "Cz"]) == 1
 
-
     def test_do_for_each_document(self):
         # Set up:
         collection_name = "my_collection"
@@ -236,7 +235,6 @@ class TestDictionaryAdapter(unittest.TestCase):
 
         # Clean up:
         delattr(self, "_characters")
-
 
     def test_callbacks(self):
         # Set up:

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -199,6 +199,45 @@ class TestDictionaryAdapter(unittest.TestCase):
         assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "Bz"]) == 1
         assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "Cz"]) == 1
 
+
+    def test_do_for_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="a")
+        document_2 = dict(_id=2, id=2, x="b")
+        document_3 = dict(_id=3, id=3, x="c")
+        self.db[collection_name] = [document_1, document_2, document_3]
+        assert len(self.db[collection_name]) == 3
+        # Temporarily add an attribute to this class instance so that
+        # this test has something persistent it can modify and examine.
+        self._characters = []
+
+        def append_x_to_sequence(doc: dict) -> None:
+            r"""Example pipeline stage that appends the `x` value to some list."""
+            self._characters.append(doc["x"])
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.do_for_each_document(
+            collection_name, append_x_to_sequence
+        )
+
+        # Validate result:
+        # - The list consists of the `x` values from the documents in the collection.
+        assert len(self._characters) == 3
+        assert self._characters[0] == "a"
+        assert self._characters[1] == "b"
+        assert self._characters[2] == "c"
+        # - The collection was not modified.
+        collection = self.db[collection_name]
+        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "a"]) == 1
+        assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "b"]) == 1
+        assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "c"]) == 1
+
+        # Clean up:
+        delattr(self, "_characters")
+
+
     def test_callbacks(self):
         # Set up:
         collection_name = "my_collection"

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -4,7 +4,7 @@ from typing import Optional
 from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
 
 
-class TestMongoAdapter(unittest.TestCase):
+class TestDictionaryAdapter(unittest.TestCase):
     r"""
     Tests targeting the `DictionaryAdapter` class.
 

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -229,9 +229,9 @@ class TestDictionaryAdapter(unittest.TestCase):
         assert self._characters[2] == "c"
         # - The collection was not modified.
         collection = self.db[collection_name]
-        assert len([doc for doc in collection if doc["id"] == 1 and doc["x"] == "a"]) == 1
-        assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "b"]) == 1
-        assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "c"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 1 and doc["id"] == 1 and doc["x"] == "a"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 2 and doc["id"] == 2 and doc["x"] == "b"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 3 and doc["id"] == 3 and doc["x"] == "c"]) == 1
 
         # Clean up:
         delattr(self, "_characters")

--- a/nmdc_schema/migrators/migrator_from_1_0_0_to_EXAMPLE.py
+++ b/nmdc_schema/migrators/migrator_from_1_0_0_to_EXAMPLE.py
@@ -49,7 +49,7 @@ class Migrator(MigratorBase):
 
         # Advanced: Create and populate another new collection; based upon the documents in a _different_ collection.
         self.adapter.create_collection("report_set")
-        self.adapter.read_each_document("comment_set", self.create_report_based_upon_comment)
+        self.adapter.do_for_each_document("comment_set", self.create_report_based_upon_comment)
 
     def allow_multiple_names(self, study: dict) -> dict:
         """

--- a/nmdc_schema/migrators/migrator_from_1_0_0_to_EXAMPLE.py
+++ b/nmdc_schema/migrators/migrator_from_1_0_0_to_EXAMPLE.py
@@ -49,7 +49,7 @@ class Migrator(MigratorBase):
 
         # Advanced: Create and populate another new collection; based upon the documents in a _different_ collection.
         self.adapter.create_collection("report_set")
-        self.adapter.process_each_document("comment_set", [self.create_report_based_upon_comment])
+        self.adapter.read_each_document("comment_set", self.create_report_based_upon_comment)
 
     def allow_multiple_names(self, study: dict) -> dict:
         """
@@ -109,15 +109,12 @@ class Migrator(MigratorBase):
         # Return the transformed dictionary.
         return study
 
-    def create_report_based_upon_comment(self, comment: dict) -> dict:
+    def create_report_based_upon_comment(self, comment: dict) -> None:
         """
         Creates a report based upon the comment passed in.
 
-        Note: Although this function will be passed a document from the `comment_set` collection, it actually modifies
-              a _different_ (i.e. arbitrary) collection instead, and then returns the original `comment_set` document
-              unchanged. I consider this to be a "shoehorned" usage of the migration framework, but a necessary
-              usage since the migration framework doesn't provide a different way to do the same thing (yet).
+        Note: Although this function will be passed a document from the `comment_set` collection,
+              the function will actually modify a *different* collection instead.
         """
         report = {"body": f"Someone wrote {comment['text']}"}
         self.adapter.insert_document(collection_name="report_set", document=report)
-        return comment  # returns the original `comment_set` document, unmodified

--- a/project.Makefile
+++ b/project.Makefile
@@ -270,10 +270,16 @@ local/mongo_as_nmdc_database_cuire_repaired.ttl: local/mongo_as_nmdc_database.tt
 .PHONY: migration-doctests migrator
 
 # Runs all doctests defined within the migrator modules, adapters, and CLI scripts.
+#
+# To run in non-verbose mode:
+# ```
+# $ make migration-doctests DOCTEST_OPT=''
+# ```
+DOCTEST_OPT ?= -v
 migration-doctests:
-	$(RUN) python -m doctest -v nmdc_schema/migrators/*.py
-	$(RUN) python -m doctest -v nmdc_schema/migrators/adapters/*.py
-	$(RUN) python -m doctest -v nmdc_schema/migrators/cli/*.py
+	$(RUN) python -m doctest $(DOCTEST_OPT) nmdc_schema/migrators/*.py
+	$(RUN) python -m doctest $(DOCTEST_OPT) nmdc_schema/migrators/adapters/*.py
+	$(RUN) python -m doctest $(DOCTEST_OPT) nmdc_schema/migrators/cli/*.py
 
 # Generates a migrator skeleton for the specified schema versions.
 # Note: `create-migrator` is a Poetry script registered in `pyproject.toml`.


### PR DESCRIPTION
### Summary

In this branch, I implemented a new adapter method. Its name is `do_for_each_document`.

I also made the `make migration-doctests` command more flexible by allowing the user to specify whether they want its output to be verbose or not. In practice, verbose output from the `doctest` module can produce a "wall of text," making it difficult to notice failures. The non-verbose mode is more of a "just tell me if anything fails" mode, as opposed to "tell me everything you do."

#### About the `do_for_each_document` method

It differs from the existing `process_each_document` method in that — although both methods require the function passed in to accept a document as a parameter — this new method does not require the function passed in to _return_ a document (i.e. a document which would then be either passed to the next function in a processing pipeline or — if the function happened to be the final one in a pipeline — written back to the database).

This new method was designed to make the process of iterating over all documents in a collection — when not wanting to update those same documents — more intuitive for migrator authors. It also improves performance by eliminating an unnecessary "write" operation to the database for each document in the collection.

