### PR TITLE
Migrations: Implement `set_field_of_each_document` adapter method

### DIFF
--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Callable, List, Any
+from typing import Optional, Callable, List, Any, Union
 
 
 class AdapterBase(ABC):
@@ -104,5 +104,15 @@ class AdapterBase(ABC):
         Passes each document in the specified collection through the specified processing pipeline—in which
         the output of any given function is the input to the function after it—and stores the final output
         back in the collection, replacing the original document.
+        """
+        pass
+
+    @abstractmethod
+    def set_field_of_each_document(
+        self, collection_name: str, field_name: str, value: Union[None, str, int, float, bool],
+    ) -> None:
+        r"""
+        Assigns the specified value to the specified field of each document in the collection.
+        This method is a specialized alternative to the `process_each_document` method.
         """
         pass

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, Union
 from nmdc_schema.migrators.adapters.adapter_base import AdapterBase
 
 
@@ -303,3 +303,32 @@ class DictionaryAdapter(AdapterBase):
 
                 # Overwrite the original document with the processed one.
                 self._db[collection_name][index] = processed_document
+
+    def set_field_of_each_document(
+        self, collection_name: str, field_name: str, value: Union[None, str, int, float, bool],
+    ) -> None:
+        r"""
+        Assigns the specified value to the specified field of each document in the collection.
+        This method is a specialized alternative to the `process_each_document` method.
+
+        >>> database = {
+        ...   "thing_set": [
+        ...     {"id": "1", "name": "original"},
+        ...     {"id": "2"},
+        ...     {"id": "3", "name": None}
+        ...   ]
+        ... }
+        >>> da = DictionaryAdapter(database)
+        >>> da.set_field_of_each_document("thing_set", "name", "new")
+        >>> database["thing_set"][0]
+        {'id': '1', 'name': 'new'}
+        >>> database["thing_set"][1]
+        {'id': '2', 'name': 'new'}
+        >>> database["thing_set"][2]
+        {'id': '3', 'name': 'new'}
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db:
+            for document in self._db[collection_name]:
+                document[field_name] = value

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable, List
+from typing import Optional, Callable, List, Union
 from nmdc_schema.migrators.adapters.adapter_base import AdapterBase
 from pymongo.database import Database
 
@@ -185,3 +185,16 @@ class MongoAdapter(AdapterBase):
 
                 # Overwrite the original document with the processed one.
                 collection.replace_one(filter=filter_, replacement=document)
+
+    def set_field_of_each_document(
+        self, collection_name: str, field_name: str, value: Union[None, str, int, float, bool],
+    ) -> None:
+        r"""
+        Assigns the specified value to the specified field of each document in the collection.
+        This method is a specialized alternative to the `process_each_document` method.
+        """
+
+        # Update every document in the collection, if the collection exists.
+        if collection_name in self._db.list_collection_names():
+            collection = self._db.get_collection(name=collection_name)
+            collection.update_many({}, {"$set": {field_name: value}})

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -219,6 +219,9 @@ class TestMongoAdapter(unittest.TestCase):
 
         # Validate result:
         collection = self.db[collection_name]
+        assert len([doc for doc in collection if doc["x"] == "original"]) == 0
+        assert len([doc for doc in collection if "x" not in doc]) == 0
+        assert len([doc for doc in collection if doc["x"] is None]) == 0
         assert len([doc for doc in collection if doc["_id"] == 1 and doc["id"] == 1 and doc["x"] == "new"]) == 1
         assert len([doc for doc in collection if doc["_id"] == 2 and doc["id"] == 2 and doc["x"] == "new"]) == 1
         assert len([doc for doc in collection if doc["_id"] == 3 and doc["id"] == 3 and doc["x"] == "new"]) == 1

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -199,6 +199,30 @@ class TestMongoAdapter(unittest.TestCase):
         assert len([doc for doc in collection if doc["id"] == 2 and doc["x"] == "Bz"]) == 1
         assert len([doc for doc in collection if doc["id"] == 3 and doc["x"] == "Cz"]) == 1
 
+    def test_set_field_of_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="original")
+        document_2 = dict(_id=2, id=2)
+        document_3 = dict(_id=3, id=3, x=None)
+        self.db[collection_name] = []
+        self.db[collection_name].extend(
+            [document_1, document_2, document_3]
+        )
+        assert len(self.db[collection_name]) == 3
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.set_field_of_each_document(
+            collection_name, "x", "new"
+        )
+
+        # Validate result:
+        collection = self.db[collection_name]
+        assert len([doc for doc in collection if doc["_id"] == 1 and doc["id"] == 1 and doc["x"] == "new"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 2 and doc["id"] == 2 and doc["x"] == "new"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 3 and doc["id"] == 3 and doc["x"] == "new"]) == 1
+
     def test_callbacks(self):
         # Set up:
         collection_name = "my_collection"

--- a/nmdc_schema/migrators/adapters/test_mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_mongo_adapter.py
@@ -247,6 +247,30 @@ class TestMongoAdapter(unittest.TestCase):
         assert collection.count_documents({"id": 2, "x": "Bz"}) == 1
         assert collection.count_documents({"id": 3, "x": "Cz"}) == 1
 
+    def test_set_field_of_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="original")
+        document_2 = dict(_id=2, id=2)
+        document_3 = dict(_id=3, id=3, x=None)
+        self.db.create_collection(collection_name)
+        self.db.get_collection(collection_name).insert_many(
+            [document_1, document_2, document_3]
+        )
+
+        # Invoke function-under-test:
+        adapter = MongoAdapter(database=self.db)
+        adapter.set_field_of_each_document(collection_name, "x", "new")
+
+        # Validate result:
+        collection = self.db[collection_name]
+        assert collection.count_documents({"x": "original"}) == 0
+        assert collection.count_documents({"x": {"$exists": False}}) == 0
+        assert collection.count_documents({"x": None}) == 0
+        assert collection.count_documents({"_id": 1, "id": 1, "x": "new"}) == 1
+        assert collection.count_documents({"_id": 2, "id": 2, "x": "new"}) == 1
+        assert collection.count_documents({"_id": 3, "id": 3, "x": "new"}) == 1
+
     def test_callbacks(self):
         # Set up:
         collection_name = "my_collection"
@@ -255,7 +279,9 @@ class TestMongoAdapter(unittest.TestCase):
         adapter = MongoAdapter(
             database=self.db,
             on_collection_created=lambda name: event_log.append(f"Created {name}"),
-            on_collection_renamed=lambda old_name, name: event_log.append(f"Renamed {old_name} to {name}"),
+            on_collection_renamed=lambda old_name, name: event_log.append(
+                f"Renamed {old_name} to {name}"
+            ),
             on_collection_deleted=lambda name: event_log.append(f"Deleted {name}"),
         )
         assert len(event_log) == 0


### PR DESCRIPTION
### Summary

In this branch, I implemented a new adapter method. Its name is `set_field_of_each_document`.

I designed the method with the upcoming Berkeley schema migrations in mind. Specifically, one of the migrators assigns the same `type` value to every document in a collection. That migrator currently uses the `process_each_document` method, which does an ETL (extract, transform, load) process on each document. It's a relatively general-purpose method.

In contrast, with this new method — regardless of what the original document contains — this new method always sets the specified field to the specified value (so, instead of ETL, it's just "L" — the loading of the specified value into the existing document). Because this method's job responsibility is more narrow, it can use a more optimized query under the hood. I expect that this method will speed up the Berkeley schema migration.