### PR TITLE
Migrations: Update `create_migrator.py` to use template file and omit leading/trailing newlines

### DIFF
--- a/nmdc_schema/migrators/cli/README.md
+++ b/nmdc_schema/migrators/cli/README.md
@@ -1,0 +1,6 @@
+# CLI
+
+This directory contains a command-line tool — and supporting files — that can be used to create a migrator.
+
+- `create_migrator.py`: A click program that generates a migrator based upon a template and some user input 
+- `migrator.py.template`: The migrator template (containing variables prefixed with `$`)

--- a/nmdc_schema/migrators/cli/create_migrator.py
+++ b/nmdc_schema/migrators/cli/create_migrator.py
@@ -98,8 +98,7 @@ class Migrator(MigratorBase):
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
         pass
-
-'''
+'''.lstrip()  # remove leading whitespace
 
     # Create and populate the file (unless it already exists).
     file_path = Path(MIGRATOR_DIRECTORY) / Path(file_name)

--- a/nmdc_schema/migrators/cli/create_migrator.py
+++ b/nmdc_schema/migrators/cli/create_migrator.py
@@ -1,11 +1,34 @@
 import re
 from pathlib import Path
 from functools import wraps
+from string import Template
 
 import click
 
-# TODO: Determine directory path dynamically, instead of hard-coding it.
+# TODO: Determine directory paths dynamically, instead of hard-coding them.
 MIGRATOR_DIRECTORY = "nmdc_schema/migrators"
+TEMPLATE_DIRECTORY = "nmdc_schema/migrators/cli"
+
+
+def generate_migrator_contents(from_version: str, to_version: str) -> str:
+    r"""
+    Generates the code for a migrator, based upon a template and the specified version identifiers.
+
+    >>> contents = generate_migrator_contents("1.2.3", "4.5.6")
+    >>> "1.2.3" in contents and "4.5.6" in contents
+    True
+    >>> "MigratorBase" in contents
+    True
+    """
+
+    template_parameters = dict(from_version=from_version, to_version=to_version)
+
+    template_file_name = "migrator.py.template"
+    template_file_path = Path(TEMPLATE_DIRECTORY) / Path(template_file_name)
+    with template_file_path.open("r") as template_file:
+        template = Template(template_file.read())
+        file_contents = template.substitute(template_parameters)
+    return file_contents
 
 
 def click_option_validator(function_to_decorate):
@@ -83,22 +106,10 @@ def create_migrator(from_version: str, to_version: str) -> None:
     to_version_snake = to_version.replace(".", "_")
     file_name = f"migrator_from_{from_version_snake}_to_{to_version_snake}.py"
 
-    # Generate the migrator file contents.
-    # TODO: Move this to a dedicated template file to facilitate maintenance.
-    file_contents = f'''
-from nmdc_schema.migrators.migrator_base import MigratorBase
-
-
-class Migrator(MigratorBase):
-    r"""Migrates a database between two schemas."""
-
-    _from_version = "{from_version}"
-    _to_version = "{to_version}"    
-    
-    def upgrade(self) -> None:
-        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
-        pass
-'''.lstrip()  # remove leading whitespace
+    # Generate the migrator file contents from a template.
+    file_contents = generate_migrator_contents(
+        from_version=from_version, to_version=to_version
+    )
 
     # Create and populate the file (unless it already exists).
     file_path = Path(MIGRATOR_DIRECTORY) / Path(file_name)

--- a/nmdc_schema/migrators/cli/migrator.py.template
+++ b/nmdc_schema/migrators/cli/migrator.py.template
@@ -1,0 +1,12 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "$from_version"
+    _to_version = "$to_version"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        pass


### PR DESCRIPTION
In this branch, I made two changes:
- The `create_migrator.py` script no longer puts a leading newline and extra trailing newline into the migrator it creates
- The migrator template is now defined in a dedicated file, instead of in a string variable embedded within that script

I have tested the changes locally and am ready for them to be reviewed/merged.