### PR TITLE
Restore adapter method lost during PR #2009 merge: `do_for_each_document`

### DIFF
--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -116,3 +116,13 @@ class AdapterBase(ABC):
         This method is a specialized alternative to the `process_each_document` method.
         """
         pass
+
+    @abstractmethod
+    def do_for_each_document(
+        self, collection_name: str, action: Callable[[dict], None]
+    ) -> None:
+        r"""
+        Passes each document in the specified collection to the specified function. This method was designed
+        to facilitate iterating over all documents in a collection without actually modifying them.
+        """
+        pass

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -332,3 +332,35 @@ class DictionaryAdapter(AdapterBase):
         if collection_name in self._db:
             for document in self._db[collection_name]:
                 document[field_name] = value
+
+    def do_for_each_document(
+        self, collection_name: str, action: Callable[[dict], None]
+    ) -> None:
+        r"""
+        Passes each document in the specified collection to the specified function. This method was designed
+        to facilitate iterating over all documents in a collection without actually modifying them.
+
+        >>> total = 0
+        >>> def add_to_total(payment: dict) -> None:
+        ...     global total
+        ...     total += payment["amount"]
+        >>>
+        >>> database = {
+        ...   "payment_set": [
+        ...     {"id": "111", "amount": 100},
+        ...     {"id": "222", "amount": 200},
+        ...     {"id": "333", "amount": 300}
+        ...   ]
+        ... }
+        >>> da = DictionaryAdapter(database)
+        >>> total
+        0
+        >>> da.do_for_each_document("payment_set", add_to_total)
+        >>> total
+        600
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db:
+            for document in self._db[collection_name]:
+                action(document)

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -199,3 +199,16 @@ class MongoAdapter(AdapterBase):
             collection = self._db.get_collection(name=collection_name)
             collection.update_many({}, {"$set": {field_name: value}})
 
+    def do_for_each_document(
+        self, collection_name: str, action: Callable[[dict], None]
+    ) -> None:
+        r"""
+        Passes each document in the specified collection to the specified function. This method was designed
+        to facilitate iterating over all documents in a collection without actually modifying them.
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db.list_collection_names():
+            collection = self._db.get_collection(name=collection_name)
+            for document in collection.find():
+                action(document)

--- a/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_dictionary_adapter.py
@@ -226,6 +226,42 @@ class TestDictionaryAdapter(unittest.TestCase):
         assert len([doc for doc in collection if doc["_id"] == 2 and doc["id"] == 2 and doc["x"] == "new"]) == 1
         assert len([doc for doc in collection if doc["_id"] == 3 and doc["id"] == 3 and doc["x"] == "new"]) == 1
 
+    def test_do_for_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="a")
+        document_2 = dict(_id=2, id=2, x="b")
+        document_3 = dict(_id=3, id=3, x="c")
+        self.db[collection_name] = [document_1, document_2, document_3]
+        assert len(self.db[collection_name]) == 3
+        # Temporarily add an attribute to this class instance so that
+        # this test has something persistent it can modify and examine.
+        self._characters = []
+
+        def append_x_to_sequence(doc: dict) -> None:
+            r"""Example pipeline stage that appends the `x` value to some list."""
+            self._characters.append(doc["x"])
+
+        # Invoke function-under-test:
+        adapter = DictionaryAdapter(database=self.db)
+        adapter.do_for_each_document(
+            collection_name, append_x_to_sequence
+        )
+
+        # Validate result:
+        # - The list consists of the `x` values from the documents in the collection.
+        assert len(self._characters) == 3
+        assert self._characters[0] == "a"
+        assert self._characters[1] == "b"
+        assert self._characters[2] == "c"
+        # - The collection was not modified.
+        collection = self.db[collection_name]
+        assert len([doc for doc in collection if doc["_id"] == 1 and doc["id"] == 1 and doc["x"] == "a"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 2 and doc["id"] == 2 and doc["x"] == "b"]) == 1
+        assert len([doc for doc in collection if doc["_id"] == 3 and doc["id"] == 3 and doc["x"] == "c"]) == 1
+
+        # Clean up:
+        delattr(self, "_characters")
 
     def test_callbacks(self):
         # Set up:

--- a/nmdc_schema/migrators/adapters/test_mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_mongo_adapter.py
@@ -271,6 +271,44 @@ class TestMongoAdapter(unittest.TestCase):
         assert collection.count_documents({"_id": 2, "id": 2, "x": "new"}) == 1
         assert collection.count_documents({"_id": 3, "id": 3, "x": "new"}) == 1
 
+    def test_do_for_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="a")
+        document_2 = dict(_id=2, id=2, x="b")
+        document_3 = dict(_id=3, id=3, x="c")
+        self.db.create_collection(collection_name)
+        self.db.get_collection(collection_name).insert_many(
+            [document_1, document_2, document_3]
+        )
+        # Temporarily add an attribute to this class instance so that
+        # this test has something persistent it can modify and examine.
+        self._characters = []
+
+        def append_x_to_sequence(doc: dict) -> None:
+            r"""Example pipeline stage that appends the `x` value to some list."""
+            self._characters.append(doc["x"])
+
+        # Invoke function-under-test:
+        adapter = MongoAdapter(database=self.db)
+        adapter.do_for_each_document(
+            collection_name, append_x_to_sequence
+        )
+
+        # Validate result:
+        # - The list consists of the `x` values from the documents in the collection.
+        assert len(self._characters) == 3
+        assert self._characters[0] == "a"
+        assert self._characters[1] == "b"
+        assert self._characters[2] == "c"
+        # - The collection was not modified.
+        collection = self.db.get_collection(collection_name)
+        assert collection.count_documents({"_id": 1, "id": 1, "x": "a"}) == 1
+        assert collection.count_documents({"_id": 2, "id": 2, "x": "b"}) == 1
+        assert collection.count_documents({"_id": 3, "id": 3, "x": "c"}) == 1
+
+        # Clean up:
+        delattr(self, "_characters")
 
     def test_callbacks(self):
         # Set up:


### PR DESCRIPTION
While merging PR https://github.com/microbiomedata/nmdc-schema/pull/2009, the adapter method that had been merged in via PR https://github.com/microbiomedata/nmdc-schema/pull/2006 was accidentally deleted. Details are in Issue https://github.com/microbiomedata/nmdc-schema/issues/2031. 

In this branch, I have restored the deleted method and other deleted code related to the deleted method. All of this code was once in the `main` branch—specifically, from the time https://github.com/microbiomedata/nmdc-schema/pull/2006 was merged into `main` and the time https://github.com/microbiomedata/nmdc-schema/pull/2009 was merged into `main`.

I want this branch to be merged into `main` already despite a "schema freeze" being in effect.

Rationale:
1. This isn't a change to the schema
2. I think all migration squad members were under the impression both of these methods existed in `main` (I had been planning to make use of both of them in the `berkeley-schema-fy24` repo once the merge of `nmdc-schema/main` into `berkeley-schema-fy24` had taken place; in order to speed up the **Berkeley schema-related migrations**)