### PR TITLE
Implement a "no op" migrator from `v10.4.0` to `v10.5.4`

### DIFF
--- a/nmdc_schema/migrators/migrator_from_10_4_0_to_10_5_4.py
+++ b/nmdc_schema/migrators/migrator_from_10_4_0_to_10_5_4.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: This is a "no op" migrator. Its existence serves as documentation that no
+          database migration is necessary between the specified schema versions.
+    """
+
+    _from_version = "10.4.0"
+    _to_version = "10.5.4"
+
+    def upgrade(self) -> None:
+        r"""Do nothing."""
+        pass


### PR DESCRIPTION
In this branch, I created a "no op" migrator to indicate that no database migration is necessary between schema versions `v10.4.0` and `v10.5.4`.