### PR TITLE
2084 tighter pattern constraint on was_generated_by

### DIFF
--- a/src/data/invalid/DataObject-invalid_was_generated_by.yaml
+++ b/src/data/invalid/DataObject-invalid_was_generated_by.yaml
@@ -1,0 +1,7 @@
+#invalid b/c the was_generated_by value has an ID version
+id: nmdc:dobj-99-izwYW6
+name: 1232.4.481.ATCGATC.fastq.gz
+description: Sequencing from project ABDC description  
+file_size_bytes: 32787380
+type: nmdc:DataObject
+was_generated_by: nmdc:omprc-11-abd4sg.1

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -399,7 +399,7 @@ classes:
           interpolated: true
       was_generated_by:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc|wf|omprc)-{id_shoulder}-{id_blade}{id_version}$"
+          syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:omprc-{id_shoulder}-{id_blade}$"
           interpolated: true
 
   Biosample:

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -78,7 +78,7 @@ slots:
     mappings:
       - prov:wasGeneratedBy
     structured_pattern:
-      syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc|wf|omprc)-{id_shoulder}-{id_blade}{id_version}$"
+      syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:omprc-{id_shoulder}-{id_blade}$"
       interpolated: true
 
   used:


### PR DESCRIPTION
This PR modifies the pattern constraint for was_generated_by to be stricter, specifically it prevents OmicsProcessing from being allowed to have a ID version.