### PR TITLE
Allow `nmdc_data.py` consumer to specify which variant of schema they want to access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ test-schema:
 
 test-python:
 	$(RUN) python -m unittest discover
+	$(RUN) python -m doctest nmdc_schema/nmdc_data.py
 
 lint:
 	$(RUN) linkml-lint $(SOURCE_SCHEMA_PATH) > local/lint.log

--- a/nmdc_schema/nmdc_data.py
+++ b/nmdc_schema/nmdc_data.py
@@ -22,7 +22,11 @@ class SchemaVariantIdentifier(str, Enum):
 
     >>> type(SchemaVariantIdentifier.nmdc_materialized_patterns) is SchemaVariantIdentifier
     True
+    >>> "nmdc_materialized_patterns" == SchemaVariantIdentifier.nmdc_materialized_patterns
+    True
     >>> type(SchemaVariantIdentifier.nmdc_materialized_patterns.value) is str
+    True
+    >>> "nmdc_materialized_patterns" == SchemaVariantIdentifier.nmdc_materialized_patterns.value
     True
     """
 
@@ -92,7 +96,7 @@ def get_nmdc_jsonschema_bytesIO(variant: Optional[SchemaVariantIdentifier] = Non
 
     # Determine which file we will use.
     file_name = "nmdc.schema.json"
-    if variant == SchemaVariantIdentifier.nmdc_materialized_patterns.value:
+    if variant == SchemaVariantIdentifier.nmdc_materialized_patterns:
         file_name = "nmdc_materialized_patterns.schema.json"
 
     return io.BytesIO(pkgutil.get_data(__name__, file_name))

--- a/nmdc_schema/nmdc_data.py
+++ b/nmdc_schema/nmdc_data.py
@@ -112,6 +112,8 @@ def get_nmdc_jsonschema_bytes(variant: Optional[SchemaVariantIdentifier] = None)
     >>> bytes_b = get_nmdc_jsonschema_bytes(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)
     >>> type(bytes_b) is bytes and b"version" in bytes_b
     True
+    >>> len(bytes_b) > len(bytes_a)  # assumes that including structured patterns makes the file larger
+    True
     """
     nmdc_json = get_nmdc_jsonschema_bytesIO(variant=variant)
     return nmdc_json.getvalue()
@@ -130,6 +132,8 @@ def get_nmdc_jsonschema_string(variant: Optional[SchemaVariantIdentifier] = None
     True
     >>> str_b = get_nmdc_jsonschema_string(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)
     >>> type(str_b) is str and "version" in str_b
+    True
+    >>> len(str_b) > len(str_a)  # assumes that including structured patterns makes the file larger
     True
     """
     nmdc_json = get_nmdc_jsonschema_bytes(variant=variant)

--- a/nmdc_schema/nmdc_data.py
+++ b/nmdc_schema/nmdc_data.py
@@ -6,7 +6,7 @@ import io
 import json
 import pkgutil
 from os.path import getatime
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import click
 import yaml
@@ -59,7 +59,7 @@ def get_materialized_nmdc_yaml_string():
     return materialized_nmdc_yaml_string
 
 
-def get_nmdc_jsonschema_bytesIO() -> io.BytesIO:
+def get_nmdc_jsonschema_bytesIO(variant: Optional[str] = None) -> io.BytesIO:
     """Returns the nmdc.schema.json file as bytes steam.
     This function is not intended to be used directly, but it used by other functions
 
@@ -68,11 +68,16 @@ def get_nmdc_jsonschema_bytesIO() -> io.BytesIO:
     BytesIO
         A bytes stream of nmdc.schema.json file.
     """
-    # get nmdc.yaml file from the package data
-    return io.BytesIO(pkgutil.get_data(__name__, "nmdc.schema.json"))
+
+    # Determine which resource we will return.
+    resource = "nmdc.schema.json"
+    if variant == "materialized":
+        resource = "nmdc_materialized_patterns.schema.json"
+
+    return io.BytesIO(pkgutil.get_data(__name__, resource))
 
 
-def get_nmdc_jsonschema_bytes() -> bytes:
+def get_nmdc_jsonschema_bytes(variant: Optional[str] = None) -> bytes:
     """Reruns the nmdc.schema.json file as bytes.
 
     Returns
@@ -80,11 +85,11 @@ def get_nmdc_jsonschema_bytes() -> bytes:
     bytes
         The bytes of the nmdc.schema.json file.
     """
-    nmdc_json = get_nmdc_jsonschema_bytesIO()
+    nmdc_json = get_nmdc_jsonschema_bytesIO(variant=variant)
     return nmdc_json.getvalue()
 
 
-def get_nmdc_jsonschema_string() -> str:
+def get_nmdc_jsonschema_string(variant: Optional[str] = None) -> str:
     """Reruns the nmdc.schema.json file as a string.
 
     Returns
@@ -92,11 +97,11 @@ def get_nmdc_jsonschema_string() -> str:
     str
         A string containing the contents of nmdc.schema.json file.
     """
-    nmdc_json = get_nmdc_jsonschema_bytes()
+    nmdc_json = get_nmdc_jsonschema_bytes(variant=variant)
     return nmdc_json.decode("utf-8")
 
 
-def get_nmdc_jsonschema_dict() -> Dict:
+def get_nmdc_jsonschema_dict(variant: Optional[str] = None) -> Dict:
     """Parses the nmdc.schema.json file into a dict.
 
     Returns
@@ -104,11 +109,11 @@ def get_nmdc_jsonschema_dict() -> Dict:
     dict
         The dict of the keys and value in the nmdc.schema.json file.
     """
-    nmdc_json = get_nmdc_jsonschema_bytes()
+    nmdc_json = get_nmdc_jsonschema_bytes(variant=variant)
     return json.loads(nmdc_json)
 
 
-def get_nmdc_jsonschema() -> str:
+def get_nmdc_jsonschema(variant: Optional[str] = None) -> str:
     """
     Returns the NMDC jsonschema (nmdc.schema.json) as json.
 
@@ -117,7 +122,7 @@ def get_nmdc_jsonschema() -> str:
     str
         JSON string representation of the NMDC jsonschema (nmdc.schema.json).
     """
-    nmdc_schema = get_nmdc_jsonschema_dict()
+    nmdc_schema = get_nmdc_jsonschema_dict(variant=variant)
     return json.dumps(nmdc_schema, indent=2)
 
 

--- a/nmdc_schema/nmdc_data.py
+++ b/nmdc_schema/nmdc_data.py
@@ -92,7 +92,7 @@ def get_nmdc_jsonschema_bytesIO(variant: Optional[SchemaVariantIdentifier] = Non
 
     # Determine which file we will use.
     file_name = "nmdc.schema.json"
-    if variant == SchemaVariantIdentifier.nmdc_materialized_patterns:
+    if variant == SchemaVariantIdentifier.nmdc_materialized_patterns.value:
         file_name = "nmdc_materialized_patterns.schema.json"
 
     return io.BytesIO(pkgutil.get_data(__name__, file_name))

--- a/nmdc_schema/nmdc_data.py
+++ b/nmdc_schema/nmdc_data.py
@@ -7,12 +7,26 @@ import json
 import pkgutil
 from os.path import getatime
 from typing import Dict, List, Optional
+from enum import Enum
 
 import click
 import yaml
 from linkml.utils.rawloader import load_raw_schema
 from linkml_runtime.linkml_model.meta import SchemaDefinition
 from linkml_runtime.utils.schemaview import SchemaView
+
+
+class SchemaVariantIdentifier(str, Enum):
+    r"""
+    Identifiers of schema variants.
+
+    >>> type(SchemaVariantIdentifier.nmdc_materialized_patterns) is SchemaVariantIdentifier
+    True
+    >>> type(SchemaVariantIdentifier.nmdc_materialized_patterns.value) is str
+    True
+    """
+
+    nmdc_materialized_patterns = "nmdc_materialized_patterns"
 
 
 def get_nmdc_yaml_bytesIO() -> io.BytesIO:
@@ -59,7 +73,7 @@ def get_materialized_nmdc_yaml_string():
     return materialized_nmdc_yaml_string
 
 
-def get_nmdc_jsonschema_bytesIO(variant: Optional[str] = None) -> io.BytesIO:
+def get_nmdc_jsonschema_bytesIO(variant: Optional[SchemaVariantIdentifier] = None) -> io.BytesIO:
     """Returns the nmdc.schema.json file as bytes steam.
     This function is not intended to be used directly, but it used by other functions
 
@@ -67,53 +81,81 @@ def get_nmdc_jsonschema_bytesIO(variant: Optional[str] = None) -> io.BytesIO:
     -------
     BytesIO
         A bytes stream of nmdc.schema.json file.
+
+    >>> stream_a = get_nmdc_jsonschema_bytesIO()
+    >>> type(stream_a) is io.BytesIO
+    True
+    >>> stream_b = get_nmdc_jsonschema_bytesIO(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)
+    >>> type(stream_b) is io.BytesIO
+    True
     """
 
-    # Determine which resource we will return.
-    resource = "nmdc.schema.json"
-    if variant == "materialized":
-        resource = "nmdc_materialized_patterns.schema.json"
+    # Determine which file we will use.
+    file_name = "nmdc.schema.json"
+    if variant == SchemaVariantIdentifier.nmdc_materialized_patterns:
+        file_name = "nmdc_materialized_patterns.schema.json"
 
-    return io.BytesIO(pkgutil.get_data(__name__, resource))
+    return io.BytesIO(pkgutil.get_data(__name__, file_name))
 
 
-def get_nmdc_jsonschema_bytes(variant: Optional[str] = None) -> bytes:
+def get_nmdc_jsonschema_bytes(variant: Optional[SchemaVariantIdentifier] = None) -> bytes:
     """Reruns the nmdc.schema.json file as bytes.
 
     Returns
     -------
     bytes
         The bytes of the nmdc.schema.json file.
+
+    >>> bytes_a = get_nmdc_jsonschema_bytes()
+    >>> type(bytes_a) is bytes and b"version" in bytes_a
+    True
+    >>> bytes_b = get_nmdc_jsonschema_bytes(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)
+    >>> type(bytes_b) is bytes and b"version" in bytes_b
+    True
     """
     nmdc_json = get_nmdc_jsonschema_bytesIO(variant=variant)
     return nmdc_json.getvalue()
 
 
-def get_nmdc_jsonschema_string(variant: Optional[str] = None) -> str:
+def get_nmdc_jsonschema_string(variant: Optional[SchemaVariantIdentifier] = None) -> str:
     """Reruns the nmdc.schema.json file as a string.
 
     Returns
     -------
     str
         A string containing the contents of nmdc.schema.json file.
+
+    >>> str_a = get_nmdc_jsonschema_string()
+    >>> type(str_a) is str and "version" in str_a
+    True
+    >>> str_b = get_nmdc_jsonschema_string(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)
+    >>> type(str_b) is str and "version" in str_b
+    True
     """
     nmdc_json = get_nmdc_jsonschema_bytes(variant=variant)
     return nmdc_json.decode("utf-8")
 
 
-def get_nmdc_jsonschema_dict(variant: Optional[str] = None) -> Dict:
+def get_nmdc_jsonschema_dict(variant: Optional[SchemaVariantIdentifier] = None) -> Dict:
     """Parses the nmdc.schema.json file into a dict.
 
     Returns
     -------
     dict
         The dict of the keys and value in the nmdc.schema.json file.
+
+    >>> dict_a = get_nmdc_jsonschema_dict()
+    >>> type(dict_a) is dict and "version" in dict_a.keys()
+    True
+    >>> dict_b = get_nmdc_jsonschema_dict(variant=SchemaVariantIdentifier.nmdc_materialized_patterns)
+    >>> type(dict_b) is dict and "version" in dict_b.keys()
+    True
     """
     nmdc_json = get_nmdc_jsonschema_bytes(variant=variant)
     return json.loads(nmdc_json)
 
 
-def get_nmdc_jsonschema(variant: Optional[str] = None) -> str:
+def get_nmdc_jsonschema(variant: Optional[SchemaVariantIdentifier] = None) -> str:
     """
     Returns the NMDC jsonschema (nmdc.schema.json) as json.
 


### PR DESCRIPTION
### Summary of changes

> Note: This summary was copied from [here](https://github.com/microbiomedata/berkeley-schema-fy24/pull/204).

In this branch, I updated `nmdc_data.py` so that the fuctions that provide access to the JSON Schema version of the schema, allow the caller to specify which _variant_ of the schema they want (they currently only support the default variant and the `nmdc_materialized_patterns` variant).

That will allow callers (such as the Runtime and the migration notebooks) to access the `nmdc_materialized_patterns.schema.json` JSON Schema (which they can use to perform data validation).

I also added doctests to all modified functions to demonstrate that they return values of the types I expect. The doctests can be run via `$ poetry run python -m doctest nmdc_schema/nmdc_data.py` (or, now, `$ make test-python`).

---

### Note for reviewers

- This PR contains the same changes as https://github.com/microbiomedata/berkeley-schema-fy24/pull/204 (in fact, the commits on this branch were `git cherry-pick`-ed directly from the branch in that PR). This PR is the `nmdc-schema` equivalent of that `berkeley-schema-fy24` PR.
- I tagged the two people that reviewed the `berkeley-schema-fy24` PR, as reviewers of this PR. I also tagged someone else that has worked on the `nmdc_data.py` file in the past.

---

### Note regarding schema freeze

- This branch does not contain any schema changes.
- This branch _does_ add functionality that is available to downstream things that `import` the `nmdc_data.py` script (e.g. the Runtime), but it doesn't break any existing functionality. It is "opt in" functionality.