### PR TITLE
Limit regex-anchoring carets (`^`) to LinkML `settings`, not `structured_pattern`s

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -399,7 +399,7 @@ classes:
           interpolated: true
       was_generated_by:
         structured_pattern:
-          syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:omprc-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:omprc-{id_shoulder}-{id_blade}$"
           interpolated: true
 
   Biosample:

--- a/src/schema/prov.yaml
+++ b/src/schema/prov.yaml
@@ -78,7 +78,7 @@ slots:
     mappings:
       - prov:wasGeneratedBy
     structured_pattern:
-      syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:omprc-{id_shoulder}-{id_blade}$"
+      syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:omprc-{id_shoulder}-{id_blade}$"
       interpolated: true
 
   used:


### PR DESCRIPTION
Regular expression patterns can be left anchored with `^` and/or right anchored with `$`. Anything that comes before or after one of those anchors invalidates otherwise acceptable strings.

LinkML validates strings with the `pattern` metaslot on `SlotDefinitions`. Because some patterns are a pain to write, LinkML also offers `structured_pattern`s which can be composed from  LinkML `settings`. At this point in time, `structured_pattern`s can be converted into `pattern`s with the `gen-linkml` command in `--materialize-patterns` mode.

Thew LinkML language doesn't take any stance on whether anchors should go inside of `settings` as below, or whether they should go in the `structured_pattern.syntax`

**This PR does take a stand: anchors should go in `settings`**, not in `structured_pattern.syntax`, and it **fixes existing `structured_pattern.syntax`** to follow that rule.

