### PR TITLE
Add tooltip annotation for gold_path_field

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2968,10 +2968,11 @@ slots:
     abstract: true
     description: >-
       This is a grouping for any of the gold path fields
+    
     annotations:
-      tool_tip: 
-        GOLD Ecosystem Classification paths describe the surroundings from which an environmental 
-        sample or an organism is collected.
+      tool_tip: GOLD Ecosystem Classification paths describe the surroundings from which an environmental sample or an organism is collected.
+    comments:
+      - Tool tip pull from https://gold.jgi.doe.gov/ecosystem_classification
   ecosystem:
     is_a: gold_path_field
     description:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2968,6 +2968,10 @@ slots:
     abstract: true
     description: >-
       This is a grouping for any of the gold path fields
+    annotations:
+      tool_tip: 
+        GOLD Ecosystem Classification paths describe the surroundings from which an environmental 
+        sample or an organism is collected.
   ecosystem:
     is_a: gold_path_field
     description:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -2968,11 +2968,12 @@ slots:
     abstract: true
     description: >-
       This is a grouping for any of the gold path fields
-    
     annotations:
-      tool_tip: GOLD Ecosystem Classification paths describe the surroundings from which an environmental sample or an organism is collected.
-    comments:
-      - Tool tip pull from https://gold.jgi.doe.gov/ecosystem_classification
+      tool_tip:
+        tag: tool_tip
+        value: GOLD Ecosystem Classification paths describe the surroundings from which an environmental sample or an organism is collected.
+        annotations:
+          source: https://gold.jgi.doe.gov/ecosystem_classification
   ecosystem:
     is_a: gold_path_field
     description:


### PR DESCRIPTION
This PR adds a tool tip for slot gold_path_field. Description change only, no changes to example data. No migration needed.