### PR TITLE
Add no-op migrators to versions 10.5.6 and 10.6.0

### DIFF
--- a/nmdc_schema/migrators/migrator_from_10_5_5_to_10_5_6.py
+++ b/nmdc_schema/migrators/migrator_from_10_5_5_to_10_5_6.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: This is a "no op" migrator. Its existence serves as documentation that no
+          database migration is necessary between the specified schema versions.
+    """
+
+    _from_version = "10.5.5"
+    _to_version = "10.5.6"
+
+    def upgrade(self) -> None:
+        r"""Do nothing."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_10_5_6_to_10_6_0.py
+++ b/nmdc_schema/migrators/migrator_from_10_5_6_to_10_6_0.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: This is a "no op" migrator. Its existence serves as documentation that no
+          database migration is necessary between the specified schema versions.
+    """
+
+    _from_version = "10.5.6"
+    _to_version = "10.6.0"
+
+    def upgrade(self) -> None:
+        r"""Do nothing."""
+        pass


### PR DESCRIPTION
# Guidelines

## _Soft_ Schema Freeze

The `nmdc-schema` and `berkeley-schema-fy24` schemas are under a soft freeze, which means changes **should not** be made that have any downstream implications. To ensure this, all PRs created creating during the freeze will be closely reviewed with **every** component of the NMDC system in mind.

## Reviewers

To ensure no changes are made unexpectedly, PR creators will request reviews from _all_ [Berkeley Schema Roll Out task coordinators](https://docs.google.com/document/d/1XXN1YuaBuSkxPXeiLKm5YxYzXTamBPQrzzeLhlh7PWs/edit#heading=h.u52g8v319adh).

We expect task coordinators to review PRs and provide feedback/approval within 1 week of when they are identified as reviewers. 

PRs will **NOT** be merged until all task coordinators (or one of their delegates) have approved. 

Expedition, questions, and discussion can happen at any meeting.

Delays in review & merging should be addressed in meetings or with NMDC leadership.

# PR Information

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation
- [ ] Schema change: Structure and content
  - created, updated, or deleted a `class`, `slot`, or `enum`
  - changed whether a `slot` is `multivalued`
  - changed the way a `slot` is assigned to a `class`
  - changed the `permissible_values` of an `enum`
  - _etc._
- [ ] Schema change: Cleanup and preparation
  - updated the description of a `class`, `slot`, or `enum`
  - updated the `mappings` of a `class`, `slot`, or `enum` to an ontology
  - added an `enum` for _future_ use (it is not in the `range` of any `slot`)
  - _etc._
- [x] Other: adding missing no-op migrator modules
     
## Description

> _PRs should be [small and concise](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/best-practices-for-pull-requests#write-small-prs)._
>
> Aim to create small, focused pull requests that fulfill a single purpose. Smaller pull requests are easier and faster to review and merge, leave less room to introduce bugs, and provide a clearer history of changes.

- In this branch, I am adding missing no-op migrator modules in preparation for making the 10.6.0 release.

## Related Issues

> All PRs should relate to or fix an issue(s). Please identify the issue(s) below.

- Related Issue(s): #
- Fixes: #

## Did you add/update any tests?

- [ ] Yes
- [x] No _(Add a justification below)_
- [ ] I need help with writing tests

Not applicable.

## Could this schema change make it so any valid data becomes invalid?

> This is a question about what the schema allows. It is not a question about what happens to exists in the NMDC database right now.
> 
> Example: If, in this PR branch, you renamed a `slot` from `foo` to `foo_bar`, the answer to this question would be "yes," **even if** nothing in the NMDC database _currently_ uses the `foo` `slot`.
>
> More examples: `slot` or `class` name changes, changes to a `slot`'s `multivalued` state, changes to a `slot`'s `range` (e.g. string to integer), changes to `slot` assignments to `class`es, changes to an `enum`'s `permissible_values`

- [ ] Yes _(A migrator is required)_
- [x] No
- [ ] I need help determining this

## If you answered "Yes", does this PR branch include that migrator?

- [ ] Yes
- [ ] No, this PR is incomplete and I need help writing the migrator

## Does this PR have any downstream implications?

> Examples: any change here that requires a change to workflows, workflow automation, the Mongo-to-Postgres ingest process, Jupyter notebooks, the Runtime, etc.

- [ ] Yes _(Explain below)_
- [x] No