### PR TITLE
Add `bulk chemistry` back to `AnalysisTypeEnum`

### DIFF
--- a/src/data/valid/Biosample-possibly-exhaustive.yaml
+++ b/src/data/valid/Biosample-possibly-exhaustive.yaml
@@ -1357,6 +1357,11 @@ technical_reps: '2'
 analysis_type:
   - metabolomics
   - metagenomics
+  - metagenomics_long_read
+  - metaproteomics
+  - metatranscriptomics
+  - natural organic matter
+  - bulk chemistry
 sample_link:
   - IGSN:DSJ0284
   - any:curie

--- a/src/schema/portal_enums.yaml
+++ b/src/schema/portal_enums.yaml
@@ -77,3 +77,4 @@ enums:
       metaproteomics:
       metatranscriptomics:
       natural organic matter:
+      bulk chemistry:


### PR DESCRIPTION
These changes add back `bulk chemistry` as a permissible value of `AnalysisTypeEnum`. This was originally added in https://github.com/microbiomedata/nmdc-schema/pull/1858, but I believe it got lost in the Berkeley shuffle (not totally unsurprising given that the definition of `AnalysisTypeEnum` moved from one file to another). 

These changes also add all of the current `AnalysisTypeEnum` permissible values to the `Biosample-possibly-exhaustive.yaml` example.

Since this is entirely additive, no migration is needed.