### PR TITLE
Add `Manifest` class

### DIFF
--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -25,8 +25,6 @@ data_generation_set:
     analyte_category: metabolome
     associated_studies:
       - nmdc:sty-00-555xxx
-    in_manifest:
-      - nmdc:manif-99-krhtest                                   #defined below
 manifest_set:
   - id: nmdc:manif-99-krhtest
     type: nmdc:Manifest

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -12,8 +12,6 @@ data_generation_set:
     analyte_category: metabolome
     associated_studies:
       - nmdc:sty-00-555xxx
-    in_manifest:
-      - nmdc:manif-99-krhtest                                   #defined below
   - id: nmdc:dgms-99-oW43DzG2
     type: nmdc:MassSpectrometry
     has_input:
@@ -67,6 +65,8 @@ data_object_set:
     name: emsl_calibration_run.raw                        #example name
     description: GCMS data file
     file_size_bytes: 9208349052
+    in_manifest:
+      - nmdc:manif-99-krhtest                                   #defined below
   - id: nmdc:dobj-11-9n9n9n
     type: nmdc:DataObject
     data_category: instrument_data
@@ -74,3 +74,5 @@ data_object_set:
     name: example_gcms_emsl_run.raw                      #example name
     description: GCMS data file
     file_size_bytes: 9208349052
+    in_manifest:
+      - nmdc:manif-99-krhtest                                   #defined below

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -28,7 +28,7 @@ data_generation_set:
 manifest_set:
   - id: nmdc:manif-99-krhtest
     type: nmdc:Manifest
-    manifest_collection: instrument_run
+    manifest_category: instrument_run
 calibration_set:
   - id: nmdc:calib-99-zUCd5Q
     type: nmdc:CalibrationInformation

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -12,6 +12,27 @@ data_generation_set:
     analyte_category: metabolome
     associated_studies:
       - nmdc:sty-00-555xxx
+    in_manifest:
+      - nmdc:manif-99-krhtest                                   #defined below
+  - id: nmdc:dgms-99-oW43DzG2
+    type: nmdc:MassSpectrometry
+    has_input:
+      - nmdc:procsm-11-9gjxns62                                 #random example process sample
+    has_output:
+      - nmdc:dobj-11-9n9n91                                     #randome example data object
+    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG0 #defined below
+    has_chromatography_configuration: nmdc:chrcon-99-oW43DzG1   #defined below
+    eluent_introduction_category: gas_chromatography
+    has_calibration: nmdc:calib-99-zUCd5Q                       #defined below
+    analyte_category: metabolome
+    associated_studies:
+      - nmdc:sty-00-555xxx
+    in_manifest:
+      - nmdc:manif-99-krhtest                                   #defined below
+manifest_set:
+  - id: nmdc:manif-99-krhtest
+    type: nmdc:Manifest
+    collection_type: instrument_run
 
 calibration_set:
   - id: nmdc:calib-99-zUCd5Q
@@ -54,3 +75,7 @@ data_object_set:
     name: example_gcms_emsl_run.raw                      #example name
     description: GCMS data file
     file_size_bytes: 9208349052
+#manifest_set:
+#  - id: nmdc:manif-99-krhtest
+#    type: nmdc:Manifest
+#    collection_type: instrument_run

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -32,8 +32,7 @@ data_generation_set:
 manifest_set:
   - id: nmdc:manif-99-krhtest
     type: nmdc:Manifest
-    collection_type: instrument_run
-
+    manifest_collection: instrument_run
 calibration_set:
   - id: nmdc:calib-99-zUCd5Q
     type: nmdc:CalibrationInformation
@@ -75,7 +74,3 @@ data_object_set:
     name: example_gcms_emsl_run.raw                      #example name
     description: GCMS data file
     file_size_bytes: 9208349052
-#manifest_set:
-#  - id: nmdc:manif-99-krhtest
-#    type: nmdc:Manifest
-#    collection_type: instrument_run

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -528,7 +528,9 @@ slots:
   in_manifest:
     range: Manifest
     multivalued: true
-    #TODO KRH: add description and structured_pattern constraints
+    description: one or more combinations of other DataObjects that can be analyzed together
+    comments:
+      - A DataObject can be part of multiple manifests, for example, a DataObject could be part of a manifest for a single run of an instrument and a manifest for technical replicates of a single sample.
 
   manifest_category:
     range: ManifestCategoryEnum

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -621,9 +621,9 @@ enums:
       instrument_run:
         description: >-
           A collection of data objects from a single run of an instrument.
-      technical_replicates:
+      poolable_replicates:
         description: >-
-          A collection of data objects that represent technical replicates of a single sample.
+          A collection of data objects that can be pooled for downstream analyses.
       fractions:
         description: >-
           A collection of data objects that represent fractions of a single sample.

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -533,7 +533,7 @@ slots:
   manifest_category:
     range: ManifestCategoryEnum
     description: >-
-      The type of collection that describes the data in the collection.
+      The type of collection that describes the data in the manifest.
     required: true
 
   model:
@@ -618,13 +618,13 @@ enums:
     #TODO KRH: add more collection types, mappings, and descriptions
       instrument_run:
         description: >-
-          A collection of data generation records from a single run of an instrument.
+          A collection of data objects from a single run of an instrument.
       technical_replicates:
         description: >-
-          A collection of data generation records that represent technical replicates of a single sample.
+          A collection of data objects that represent technical replicates of a single sample.
       fractions:
         description: >-
-          A collection of data generation records that represent fractions of a single sample.
+          A collection of data objects that represent fractions of a single sample.
 
   InstrumentModelEnum:
     permissible_values:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -535,7 +535,7 @@ slots:
   manifest_category:
     range: ManifestCategoryEnum
     description: >-
-      The type of collection that describes the data in the manifest.
+      The type of context in which the constituent DataObjects can be analyzed together.
     required: true
 
   model:
@@ -616,8 +616,8 @@ enums:
           - NCIT:C61538
   
   ManifestCategoryEnum:
+    description: A list of contexts in which some DataObjects can be analyzed together.
     permissible_values:
-    #TODO KRH: add more collection types, mappings, and descriptions
       instrument_run:
         description: >-
           A collection of data objects from a single run of an instrument.

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -330,6 +330,7 @@ classes:
       - instrument_used
       - mod_date
       - principal_investigator
+      - in_manifest
     slot_usage:
       has_input:
         required: true
@@ -524,6 +525,16 @@ slots:
     multivalued: true
     description: What instrument was used during DataGeneration or MaterialProcessing.
 
+  in_manifest:
+    range: Manifest
+    multivalued: true
+    #TODO KRH: add description and structured_pattern constraints
+
+  collection_type:
+    range: CollectionTypeEnum
+    description: >-
+      The type of collection that describes the data in the collection.
+
   model:
     range: InstrumentModelEnum
   vendor:
@@ -600,6 +611,14 @@ enums:
         comments: A consortium has collections of data, those data do not come from a hypothesis-driven experiment.
         exact_mappings:
           - NCIT:C61538
+  
+  CollectionTypeEnum:
+    permissible_values:
+    #TODO KRH: add more collection types, mappings, and descriptions
+      instrument_run:
+        description: >-
+          A collection of data generated from a single run of an instrument.
+
   InstrumentModelEnum:
     permissible_values:
       exploris_21T:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -290,6 +290,7 @@ classes:
       - md5_checksum
       - url
       - was_generated_by
+      - in_manifest
     slot_usage:
       name:
         required: true
@@ -330,7 +331,6 @@ classes:
       - instrument_used
       - mod_date
       - principal_investigator
-      - in_manifest
     slot_usage:
       has_input:
         required: true

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -534,6 +534,7 @@ slots:
     range: CollectionTypeEnum
     description: >-
       The type of collection that describes the data in the collection.
+    required: true
 
   model:
     range: InstrumentModelEnum
@@ -617,7 +618,13 @@ enums:
     #TODO KRH: add more collection types, mappings, and descriptions
       instrument_run:
         description: >-
-          A collection of data generated from a single run of an instrument.
+          A collection of data generation records from a single run of an instrument.
+      technical_replicates:
+        description: >-
+          A collection of data generation records that represent technical replicates of a single sample.
+      fractions:
+        description: >-
+          A collection of data generation records that represent fractions of a single sample.
 
   InstrumentModelEnum:
     permissible_values:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -530,8 +530,8 @@ slots:
     multivalued: true
     #TODO KRH: add description and structured_pattern constraints
 
-  collection_type:
-    range: CollectionTypeEnum
+  manifest_category:
+    range: ManifestCategoryEnum
     description: >-
       The type of collection that describes the data in the collection.
     required: true
@@ -613,7 +613,7 @@ enums:
         exact_mappings:
           - NCIT:C61538
   
-  CollectionTypeEnum:
+  ManifestCategoryEnum:
     permissible_values:
     #TODO KRH: add more collection types, mappings, and descriptions
       instrument_run:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -258,7 +258,7 @@ classes:
   Manifest:
     is_a: InformationObject
     class_uri: nmdc:Manifest
-    #TODO KRH: add description
+    description: A representation of a collection of data objects and a description of why these data objects are grouped together.
     slots:
       - manifest_category
     slot_usage:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -303,6 +303,7 @@ classes:
       - functional_annotation_set
       - genome_feature_set
       - instrument_set
+      - manifest_set
       - material_processing_set
       - processed_sample_set
       - protocol_execution_set
@@ -1135,6 +1136,12 @@ slots:
     mixins: object_set
     range: Configuration
     description: This property links a database object to the set of configurations within it.
+
+  manifest_set:
+    #TODO KRH: Do I need a mix in here?
+    mixins: object_set
+    range: Manifest
+    description: This property links a database object to the set of manifests within it.
 
   protocol_execution_set:
     mixins: object_set

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -260,7 +260,7 @@ classes:
     class_uri: nmdc:Manifest
     #TODO KRH: add description
     slots:
-      - manifest_collection
+      - manifest_category
     slot_usage:
       id:
         structured_pattern:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1138,7 +1138,6 @@ slots:
     description: This property links a database object to the set of configurations within it.
 
   manifest_set:
-    #TODO KRH: Do I need a mix in here?
     mixins: object_set
     range: Manifest
     description: This property links a database object to the set of manifests within it.

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -260,7 +260,7 @@ classes:
     class_uri: nmdc:Manifest
     #TODO KRH: add description
     slots:
-      - collection_type
+      - manifest_collection
     slot_usage:
       id:
         structured_pattern:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -254,6 +254,17 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"
           interpolated: true
+  
+  Manifest:
+    is_a: InformationObject
+    class_uri: nmdc:Manifest
+    #TODO KRH: add description
+    slots:
+      - collection_type
+    slot_usage:
+      id:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:manif-{id_shoulder}-{id_blade}$" 
 
   FunctionalAnnotationAggMember:
     class_uri: nmdc:FunctionalAnnotationAggMember

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -258,7 +258,9 @@ classes:
   Manifest:
     is_a: InformationObject
     class_uri: nmdc:Manifest
-    description: A representation of a collection of data objects and a description of why these data objects are grouped together.
+    description: A qualified collection of DataObjects that can be analyzed together in the same experimental context.
+    comments:
+      - Manifest are currently uncoupled from other modelling. For example, there is no schema requirement that DataObjects in a fractions Manifest were all obtained by analyzing the same ProcessedSample.
     slots:
       - manifest_category
     slot_usage:


### PR DESCRIPTION
This PR

1) Adds a `Manifest` class (inherits from `Information` class) to model collections of `DataObjects` records for workflows. `Manifest` class has slot `manifest_category` with range of `ManifestCategoryEnum`
2) Adds `in_manifest` slot to `DataObject` to connect `DataObject`s to a `Manifest` or to multiple `Manifests`s
3) Adds `manifest_set` to `Database` class
4) Expands existing examples the use of the `in_manifest` slot, `Manifest` class, and `manifest_set` slot

No migration necessary, this only adds slots and classes and does not refactor existing classes or slots.

Addresses https://github.com/microbiomedata/nmdc-schema/issues/766; should unblock https://github.com/microbiomedata/nmdc-server/issues/1365
