### PR TITLE
Remove `direct_infusion_category` and `DirectInfusionEnum`

### DIFF
--- a/src/docs/v10-vs-v11-retrospective.md
+++ b/src/docs/v10-vs-v11-retrospective.md
@@ -355,7 +355,6 @@ slot names other than `type`):
 - `chemical_conversion_category`
 - `chromatographic_category` _applicable to `ChromatographyConfiguration` and `ChromatographicSeparationProcess` ?_
 - `data_category`
-- `direct_infusion_category`
 - `eluent_introduction_category`
 - `feature_category`
 - `protocol_execution_category`
@@ -393,7 +392,6 @@ And the following **enumerations** were added:
 - `ChemicalConversionCategoryEnum`
 - `ChromatographicCategoryEnum`
 - `DataCategoryEnum`
-- `DirectInfusionEnum`
 - `EluentIntroductionCategoryEnum`
 - `ExecutionResourceEnum`
 - `IonizationSourceEnum`

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -422,10 +422,6 @@ slots:
         in the Workflow Chain
     range: AnalyteCategoryEnum
 
-  direct_infusion_category:
-    range: DirectInfusionEnum
-    description: used when a processed sample is introduced into a mass spectrometer without chromatographic separation
-
   type:
     required: true
     range: uriorcurie
@@ -1111,13 +1107,6 @@ enums:
       nom:
         aliases:
           - natural organic matter
-
-  DirectInfusionEnum:
-    permissible_values:
-      direct_infusion:
-        aliases:
-          - DI
-      autosampler: { }
 
   ExtractionTargetEnum:
     permissible_values:


### PR DESCRIPTION
Removed `direct_infusion_category` (now incorporated into `eluent_introduction_category`) and `DirectInfusionEnum` (now part of `EluentIntroductionCategoryEnum`) from v10-vsv11-retrospective.md and basic_slots.yaml. 

Fixes #2234.
These slots were never part of the schema (they were iterations within the berkeley fork that should have been removed pre-v11 release). No deprecation or migration needed; no released version of the schema ever used this slot or Enum on any classes.