### PR TITLE
Migrator: Update `_from_version` and `_to_version` to reflect role of migrator

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_11_0_3_to_11_1_0/migrator_from_11_0_3_to_11_1_0_part_2.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_0_3_to_11_1_0/migrator_from_11_0_3_to_11_1_0_part_2.py
@@ -4,9 +4,9 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 class Migrator(MigratorBase):
     r"""Migrates a database between two schemas."""
 
-    _from_version = "11_0_3"
-    _to_version = "11_1_0" 
-    # See PR2203
+    # Note: This migrator was introduced via PR 2203 (i.e. https://github.com/microbiomedata/nmdc-schema/pull/2203).
+    _from_version = "11.1.0.part_1"
+    _to_version = "11.1.0.part_2" 
 
     def upgrade(self):
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""


### PR DESCRIPTION
In this branch, I updated the `_from_version` and `_to_version` values in a partial migrator to reflect the partial migrator's position among other partial migrators belonging to the same top-level migrator. I also elaborated on an existing comment in the code.

---

_Obligatory reiteration that the overall `_from_version` and `_to_version`-based procedure is [broken](https://github.com/microbiomedata/nmdc-schema/issues/2205)._ 🐔 🥚 🙈 