### PR TITLE
Migrations: Implement adapter method that deletes field from all documents in collection

### DIFF
--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -118,6 +118,17 @@ class AdapterBase(ABC):
         pass
 
     @abstractmethod
+    def remove_field_from_each_document(
+        self,
+        collection_name: str,
+        field_name: str,
+    ) -> None:
+        r"""
+        Removes the specified field from each document in the collection.
+        """
+        pass
+
+    @abstractmethod
     def do_for_each_document(
         self, collection_name: str, action: Callable[[dict], None]
     ) -> None:

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -333,6 +333,37 @@ class DictionaryAdapter(AdapterBase):
             for document in self._db[collection_name]:
                 document[field_name] = value
 
+    def remove_field_from_each_document(
+        self,
+        collection_name: str,
+        field_name: str,
+    ) -> None:
+        r"""
+        Removes the specified field from each document in the collection.
+
+        >>> database = {
+        ...   "thing_set": [
+        ...     {"id": "1", "x": "a"},
+        ...     {"id": "2"},
+        ...     {"id": "3", "x": None},
+        ...   ]
+        ... }
+        >>> da = DictionaryAdapter(database)
+        >>> da.remove_field_from_each_document("thing_set", "x")
+        >>> database["thing_set"][0]
+        {'id': '1'}
+        >>> database["thing_set"][1]
+        {'id': '2'}
+        >>> database["thing_set"][2]
+        {'id': '3'}
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db:
+            for document in self._db[collection_name]:
+                if field_name in document:
+                    del document[field_name]
+
     def do_for_each_document(
         self, collection_name: str, action: Callable[[dict], None]
     ) -> None:

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -199,6 +199,23 @@ class MongoAdapter(AdapterBase):
             collection = self._db.get_collection(name=collection_name)
             collection.update_many({}, {"$set": {field_name: value}})
 
+    def remove_field_from_each_document(
+        self,
+        collection_name: str,
+        field_name: str,
+    ) -> None:
+        r"""
+        Removes the specified field from each document in the collection.
+
+        References:
+        - https://www.mongodb.com/docs/manual/reference/operator/update/unset/
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db.list_collection_names():
+            collection = self._db.get_collection(name=collection_name)
+            collection.update_many({}, {"$unset": {field_name: 0}})  # value is arbitrary (e.g. 0)
+
     def do_for_each_document(
         self, collection_name: str, action: Callable[[dict], None]
     ) -> None:

--- a/nmdc_schema/migrators/adapters/test_mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_mongo_adapter.py
@@ -263,13 +263,35 @@ class TestMongoAdapter(unittest.TestCase):
         adapter.set_field_of_each_document(collection_name, "x", "new")
 
         # Validate result:
-        collection = self.db[collection_name]
+        collection = self.db.get_collection(collection_name)
         assert collection.count_documents({"x": "original"}) == 0
         assert collection.count_documents({"x": {"$exists": False}}) == 0
         assert collection.count_documents({"x": None}) == 0
         assert collection.count_documents({"_id": 1, "id": 1, "x": "new"}) == 1
         assert collection.count_documents({"_id": 2, "id": 2, "x": "new"}) == 1
         assert collection.count_documents({"_id": 3, "id": 3, "x": "new"}) == 1
+
+    def test_remove_field_of_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="original")
+        document_2 = dict(_id=2, id=2)
+        document_3 = dict(_id=3, id=3, x=None)
+        self.db.create_collection(collection_name)
+        self.db.get_collection(collection_name).insert_many(
+            [document_1, document_2, document_3]
+        )
+
+        # Invoke function-under-test:
+        adapter = MongoAdapter(database=self.db)
+        adapter.remove_field_from_each_document(collection_name, "x")
+
+        # Validate result:
+        collection = self.db.get_collection(collection_name)
+        assert collection.count_documents({"x": {"$exists": True}}) == 0
+        assert collection.count_documents({"_id": 1, "id": 1}) == 1
+        assert collection.count_documents({"_id": 2, "id": 2}) == 1
+        assert collection.count_documents({"_id": 3, "id": 3}) == 1
 
     def test_do_for_each_document(self):
         # Set up:


### PR DESCRIPTION
In this branch, I implemented an adapter method named `remove_field_from_each_document `, which migrator authors can use to delete a given field from every document in a given collection.

Previously, migrator authors could do this by iterating over documents in Python. This new adapter method delegates the iteration to MongoDB.

Fixes #2261 