### PR TITLE
Migrations: Update migrator to run faster by delegating document iteration to MongoDB

### DIFF
--- a/nmdc_schema/migrators/adapters/adapter_base.py
+++ b/nmdc_schema/migrators/adapters/adapter_base.py
@@ -126,3 +126,16 @@ class AdapterBase(ABC):
         to facilitate iterating over all documents in a collection without actually modifying them.
         """
         pass
+
+    @abstractmethod
+    def copy_value_from_field_to_field_in_each_document(
+        self,
+        collection_name: str,
+        source_field_name: str,
+        destination_field_name: str,
+    ) -> None:
+        r"""
+        For each document in the collection that has the source field, copy the value of the source field
+        into the destination field, creating the destination field if it doesn't already exist.
+        """
+        pass

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -364,3 +364,42 @@ class DictionaryAdapter(AdapterBase):
         if collection_name in self._db:
             for document in self._db[collection_name]:
                 action(document)
+
+    def copy_value_from_field_to_field_in_each_document(
+        self,
+        collection_name: str,
+        source_field_name: str,
+        destination_field_name: str,
+    ) -> None:
+        r"""
+        For each document in the collection that has the source field, copy the value of the source field
+        into the destination field, creating the destination field if it doesn't already exist.
+
+        >>> database = {
+        ...   "thing_set": [
+        ...     {"id": "1", "color": "blue"},
+        ...     {"id": "2"},
+        ...     {"id": "3", "color": None},
+        ...     {"id": "4", "color": "blue", "hue": "yellow"},
+        ...     {"id": "5", "color": "blue", "hue": None},
+        ...   ]
+        ... }
+        >>> da = DictionaryAdapter(database)
+        >>> da.copy_value_from_field_to_field_in_each_document("thing_set", "color", "hue")
+        >>> database["thing_set"][0]  # source field exists and is not empty
+        {'id': '1', 'color': 'blue', 'hue': 'blue'}
+        >>> database["thing_set"][1]  # source field does not exist
+        {'id': '2'}
+        >>> database["thing_set"][2]  # source field is empty
+        {'id': '3', 'color': None, 'hue': None}
+        >>> database["thing_set"][3]  # destination field exists and is not empty
+        {'id': '4', 'color': 'blue', 'hue': 'blue'}
+        >>> database["thing_set"][4]  # destination field exists and is empty
+        {'id': '5', 'color': 'blue', 'hue': 'blue'}
+        """
+
+        # Iterate over every document in the collection, if the collection exists.
+        if collection_name in self._db:
+            for document in self._db[collection_name]:
+                if source_field_name in document:
+                    document[destination_field_name] = document[source_field_name]

--- a/nmdc_schema/migrators/adapters/dictionary_adapter.py
+++ b/nmdc_schema/migrators/adapters/dictionary_adapter.py
@@ -378,8 +378,8 @@ class DictionaryAdapter(AdapterBase):
         >>> database = {
         ...   "thing_set": [
         ...     {"id": "1", "color": "blue"},
-        ...     {"id": "2"},
-        ...     {"id": "3", "color": None},
+        ...     {"id": "2", "color": None},
+        ...     {"id": "3"},
         ...     {"id": "4", "color": "blue", "hue": "yellow"},
         ...     {"id": "5", "color": "blue", "hue": None},
         ...   ]
@@ -388,10 +388,10 @@ class DictionaryAdapter(AdapterBase):
         >>> da.copy_value_from_field_to_field_in_each_document("thing_set", "color", "hue")
         >>> database["thing_set"][0]  # source field exists and is not empty
         {'id': '1', 'color': 'blue', 'hue': 'blue'}
-        >>> database["thing_set"][1]  # source field does not exist
-        {'id': '2'}
-        >>> database["thing_set"][2]  # source field is empty
-        {'id': '3', 'color': None, 'hue': None}
+        >>> database["thing_set"][1]  # source field is empty
+        {'id': '2', 'color': None, 'hue': None}
+        >>> database["thing_set"][2]  # source field does not exist
+        {'id': '3'}
         >>> database["thing_set"][3]  # destination field exists and is not empty
         {'id': '4', 'color': 'blue', 'hue': 'blue'}
         >>> database["thing_set"][4]  # destination field exists and is empty

--- a/nmdc_schema/migrators/adapters/mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/mongo_adapter.py
@@ -212,3 +212,27 @@ class MongoAdapter(AdapterBase):
             collection = self._db.get_collection(name=collection_name)
             for document in collection.find():
                 action(document)
+
+    def copy_value_from_field_to_field_in_each_document(
+        self,
+        collection_name: str,
+        source_field_name: str,
+        destination_field_name: str,
+    ) -> None:
+        r"""
+        For each document in the collection that has the source field, copy the value of the source field
+        into the destination field, creating the destination field if it doesn't already exist.
+
+        References:
+        - https://www.mongodb.com/docs/manual/reference/method/db.collection.updateMany
+        - https://www.mongodb.com/docs/manual/reference/operator/update/set/
+        - https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html#pymongo.collection.Collection.update_many
+        """
+
+        # Update every document in the collection, if the collection exists.
+        if collection_name in self._db.list_collection_names():
+            collection = self._db.get_collection(name=collection_name)
+            collection.update_many(
+                {source_field_name: {"$exists": True}},
+                [{"$set": {destination_field_name: f"${source_field_name}"}}]
+            )

--- a/nmdc_schema/migrators/adapters/test_mongo_adapter.py
+++ b/nmdc_schema/migrators/adapters/test_mongo_adapter.py
@@ -25,7 +25,7 @@ class TestMongoAdapter(unittest.TestCase):
     You can start up a containerized MongoDB server like this:
     $ docker run --rm --detach --name mongo-test-nmdc-schema -p 27017:27017 mongo
 
-    One that's running, other containers will be able to access it via:
+    Once that's running, other containers will be able to access it via:
     - host.docker.internal:27017
 
     You can run these tests like this:
@@ -263,7 +263,7 @@ class TestMongoAdapter(unittest.TestCase):
         adapter.set_field_of_each_document(collection_name, "x", "new")
 
         # Validate result:
-        collection = self.db[collection_name]
+        collection = self.db.get_collection(collection_name)
         assert collection.count_documents({"x": "original"}) == 0
         assert collection.count_documents({"x": {"$exists": False}}) == 0
         assert collection.count_documents({"x": None}) == 0
@@ -309,6 +309,34 @@ class TestMongoAdapter(unittest.TestCase):
 
         # Clean up:
         delattr(self, "_characters")
+
+    def test_copy_value_from_field_to_field_in_each_document(self):
+        # Set up:
+        collection_name = "my_collection"
+        document_1 = dict(_id=1, id=1, x="a")
+        document_2 = dict(_id=2, id=2, x=None)
+        document_3 = dict(_id=3, id=3)
+        document_4 = dict(_id=4, id=4, x="a", y="b")
+        document_5 = dict(_id=5, id=5, x="a", y=None)
+        self.db.create_collection(collection_name)
+        self.db.get_collection(collection_name).insert_many(
+            [document_1, document_2, document_3, document_4, document_5]
+        )
+
+        # Invoke function-under-test:
+        adapter = MongoAdapter(database=self.db)
+        adapter.copy_value_from_field_to_field_in_each_document(
+            collection_name, "x", "y"
+        )
+
+        # Validate result:
+        collection = self.db.get_collection(collection_name)
+        assert collection.count_documents({}) == 5
+        assert collection.count_documents({"_id": 1, "id": 1, "x": "a", "y": "a"}) == 1
+        assert collection.count_documents({"_id": 2, "id": 2, "x": None, "y": None}) == 1
+        assert collection.count_documents({"_id": 3, "id": 3}) == 1
+        assert collection.count_documents({"_id": 4, "id": 4, "x": "a", "y": "a"}) == 1
+        assert collection.count_documents({"_id": 5, "id": 5, "x": "a", "y": "a"}) == 1
 
     def test_callbacks(self):
         # Set up:


### PR DESCRIPTION
In this branch, I did one new thing, plus I merged in two other branches that haven't yet been merged into `main` (so, if this PR branch gets merged into `main`, I'll close the PRs associated with those other two branches).

The new thing I did in this branch is: I updated the [`migrator_from_11_0_3_to_11_1_0_part_2`](nmdc_schema/migrators/partials/migrator_from_11_0_3_to_11_1_0/migrator_from_11_0_3_to_11_1_0_part_2.py) so it would run faster. Specifically, I updated it to delegate an intensive task to MongoDB (which is optimized for that task), instead of doing it "manually" in Python.

In order to accomplish that, I merged (into _this_ branch) a couple branches, each of which introduced some necessary adapter method upon which the above migrator change depends. That's why this PR branch "includes" two other branches.

This PR supersedes #2262 and #2263.

I hope it works.