### PR TITLE
re-add prefixmaps generation to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ gendoc: $(DOCDIR) prefixmaps
 	# Create directory for JavaScript files and copy them
 	mkdir -p $(DOCDIR)/javascripts
 	$(RUN) cp $(SRC)/scripts/*.js $(DOCDIR)/javascripts/
-	# Use `refgraph` to generate an interactive diagram
+	# Use `refgraph` to generate an interactive diagram within the compiled documentation website file tree.
 	mkdir -p $(DOCDIR)/visualizations
 	$(RUN) refgraph --schema nmdc_schema/nmdc_materialized_patterns.yaml --subject collection --graph $(DOCDIR)/visualizations/collection-graph.html
 testdoc: gendoc serve


### PR DESCRIPTION
see: https://github.com/microbiomedata/berkeley-schema-fy24/pull/223 (looks like this original change was merged into berkeley schema too late for it to be swept back up into the back merge to nmdc-schema)

