### PR TITLE
Fix invalid or confusing examples

### DIFF
--- a/assets/yq-for-mixs_subset_modified.txt
+++ b/assets/yq-for-mixs_subset_modified.txt
@@ -183,7 +183,8 @@
 'del(.classes)'
 'del(.enums.[].name)' 
 'del(.enums.[].permissible_values.[].text)' 
-'del(.slots.[].name)' 
+'del(.slots.[].name)'
+'del(.slots.[].domain_of)'
 'del(.slots.add_recov_method.pattern)' 
 'del(.subsets.[].name)' 
 
@@ -207,6 +208,19 @@
 
 # add "M horizon" to soil_horizon_enum
 '.enums.soil_horizon_enum.permissible_values.["M horizon"] = {}'
+
+# Fix a few examples so that they are validatable
+'del(.slots.env_broad_scale.examples)'
+'.slots.env_broad_scale.examples.[0].value = "oceanic epipelagic zone biome [ENVO:01000035]"'
+
+'del(.slots.env_local_scale.examples)'
+'.slots.env_local_scale.examples.[0].value = "litter layer [ENVO:01000338]"'
+
+'del(.slots.env_medium.examples)'
+'.slots.env_medium.examples.[0].value = "soil [ENVO:00001998]"'
+
+'del(.slots.host_body_product.examples)'
+'.slots.host_body_product.examples.[0].value = "mucus [UBERON:0000912]"'
 
 # as of 2024-01-30:
 # ValueError: Conflicting URIs (https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/mixs.yaml, https://w3id.org/linkml/types) for item: date

--- a/assets/yq-for-mixs_subset_modified.txt
+++ b/assets/yq-for-mixs_subset_modified.txt
@@ -209,6 +209,17 @@
 # add "M horizon" to soil_horizon_enum
 '.enums.soil_horizon_enum.permissible_values.["M horizon"] = {}'
 
+# replace host_sex_enum permissible values
+'del(.enums.host_sex_enum.permissible_values)'
+'.enums.host_sex_enum.permissible_values.["female"] = {}'
+'.enums.host_sex_enum.permissible_values.["hermaphrodite"] = {}'
+'.enums.host_sex_enum.permissible_values.["non-binary"] = {}'
+'.enums.host_sex_enum.permissible_values.["male"] = {}'
+'.enums.host_sex_enum.permissible_values.["transgender"] = {}'
+'.enums.host_sex_enum.permissible_values.["transgender (female to male)"] = {}'
+'.enums.host_sex_enum.permissible_values.["transgender (male to female)"] = {}'
+'.enums.host_sex_enum.permissible_values.["undeclared"] = {}'
+
 # Fix a few examples so that they are validatable
 'del(.slots.env_broad_scale.examples)'
 '.slots.env_broad_scale.examples.[0].value = "oceanic epipelagic zone biome [ENVO:01000035]"'

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -3731,7 +3731,7 @@ slots:
     description: 'Report the environmental material(s) immediately surrounding the sample or specimen at the time of sampling. We recommend using subclasses of ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. a tree, a leaf, a table top).'
     title: environmental medium
     examples:
-      - value: 'soil [ENVO:00001998]; Annotating a fish swimming in the upper 100 m of the Atlantic Ocean, consider: ocean water [ENVO:00002151]. Example: Annotating a duck on a pond consider: pond water [ENVO:00002228]|air [ENVO_00002005]'
+      - value: soil [ENVO:00001998]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - environmental medium

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -598,8 +598,12 @@ enums:
     permissible_values:
       female: {}
       hermaphrodite: {}
+      non-binary: {}
       male: {}
-      neuter: {}
+      transgender: {}
+      transgender (female to male): {}
+      transgender (male to female): {}
+      undeclared: {}
   indoor_space_enum:
     from_schema: http://w3id.org/mixs/terms
     permissible_values:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -3713,7 +3713,7 @@ slots:
     description: 'Report the entity or entities which are in the sample or specimen’s local vicinity and which you believe have significant causal influences on your sample or specimen. We recommend using EnvO terms which are of smaller spatial grain than your entry for env_broad_scale. Terms, such as anatomical sites, from other OBO Library ontologies which interoperate with EnvO (e.g. UBERON) are accepted in this field. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS.'
     title: local environmental context
     examples:
-      - value: 'litter layer [ENVO:01000338]; Annotating a pooled sample taken from various vegetation layers in a forest consider: canopy [ENVO:00000047]|herb and fern layer [ENVO:01000337]|litter layer [ENVO:01000338]|understory [01000335]|shrub layer [ENVO:01000336].'
+      - value: litter layer [ENVO:01000338]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - local environmental context

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -3695,7 +3695,7 @@ slots:
     description: 'Report the major environmental system the sample or specimen came from. The system(s) identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. in the desert or a rainforest). We recommend using subclasses of EnvO’s biome class:  http://purl.obolibrary.org/obo/ENVO_00000428. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: broad-scale environmental context
     examples:
-      - value: oceanic epipelagic zone biome [ENVO:01000033] for annotating a water sample from the photic zone in middle of the Atlantic Ocean
+      - value: oceanic epipelagic zone biome [ENVO:01000035]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - broad-scale environmental context

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1530,31 +1530,6 @@ slots:
       - altitude
     is_a: environment field
     slot_uri: MIXS:0000094
-    domain_of:
-      - agriculture
-      - air
-      - built environment
-      - core
-      - food-animal and animal feed
-      - food-farm environment
-      - food-food production facility
-      - food-human foods
-      - host-associated
-      - human-associated
-      - human-gut
-      - human-oral
-      - human-skin
-      - human-vaginal
-      - hydrocarbon resources-cores
-      - hydrocarbon resources-fluids_swabs
-      - microbial mat_biofilm
-      - miscellaneous natural or artificial environment
-      - plant-associated
-      - sediment
-      - soil
-      - symbiont-associated
-      - wastewater_sludge
-      - water
     range: QuantityValue
     multivalued: false
   aminopept_act:
@@ -3698,8 +3673,6 @@ slots:
       tooltip: The biome or major environmental system where the sample or specimen originated. Choose values from subclasses of the 'biome' class [ENVO:00000428] in the Environment Ontology (ENVO). For host-associated or plant-associated samples, use terms from the UBERON or Plant Ontology to describe the broad anatomical or morphological context
     description: 'Report the major environmental system the sample or specimen came from. The system(s) identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. in the desert or a rainforest). We recommend using subclasses of EnvO’s biome class:  http://purl.obolibrary.org/obo/ENVO_00000428. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: broad-scale environmental context
-    examples:
-      - value: oceanic epipelagic zone biome [ENVO:01000035]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - broad-scale environmental context
@@ -3708,6 +3681,8 @@ slots:
     slot_uri: MIXS:0000012
     range: ControlledIdentifiedTermValue
     multivalued: false
+    examples:
+      - value: oceanic epipelagic zone biome [ENVO:01000035]
   env_local_scale:
     annotations:
       expected_value:
@@ -3716,8 +3691,6 @@ slots:
       tooltip: The specific environmental entities or features near the sample or specimen that significantly influence its characteristics or composition. These entities are typically smaller in scale than the broad environmental context. Values for this field should be countable, material nouns and must be chosen from subclasses of BFO:0000040 (material entity) that appear in the Environment Ontology (ENVO). For host-associated or plant-associated samples, use terms from the UBERON or Plant Ontology to describe specific anatomical structures or plant parts.
     description: 'Report the entity or entities which are in the sample or specimen’s local vicinity and which you believe have significant causal influences on your sample or specimen. We recommend using EnvO terms which are of smaller spatial grain than your entry for env_broad_scale. Terms, such as anatomical sites, from other OBO Library ontologies which interoperate with EnvO (e.g. UBERON) are accepted in this field. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS.'
     title: local environmental context
-    examples:
-      - value: litter layer [ENVO:01000338]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - local environmental context
@@ -3726,6 +3699,8 @@ slots:
     slot_uri: MIXS:0000013
     range: ControlledIdentifiedTermValue
     multivalued: false
+    examples:
+      - value: litter layer [ENVO:01000338]
   env_medium:
     annotations:
       expected_value:
@@ -3734,8 +3709,6 @@ slots:
       tooltip: The predominant environmental material or substrate that directly surrounds or hosts the sample or specimen at the time of sampling. Choose values from subclasses of the 'environmental material' class [ENVO:00010483] in the Environment Ontology (ENVO). Values for this field should be measurable or mass material nouns, representing continuous environmental materials. For host-associated or plant-associated samples, use terms from the UBERON or Plant Ontology to indicate a tissue, organ, or plant structure
     description: 'Report the environmental material(s) immediately surrounding the sample or specimen at the time of sampling. We recommend using subclasses of ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. a tree, a leaf, a table top).'
     title: environmental medium
-    examples:
-      - value: soil [ENVO:00001998]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - environmental medium
@@ -3744,6 +3717,8 @@ slots:
     slot_uri: MIXS:0000014
     range: ControlledIdentifiedTermValue
     multivalued: false
+    examples:
+      - value: soil [ENVO:00001998]
   escalator:
     annotations:
       expected_value:
@@ -4959,8 +4934,6 @@ slots:
         value: '1'
     description: Substance produced by the body, e.g. Stool, mucus, where the sample was obtained from. For foundational model of anatomy ontology (fma) or Uber-anatomy ontology (UBERON) terms, please see https://www.ebi.ac.uk/ols/ontologies/fma or https://www.ebi.ac.uk/ols/ontologies/uberon
     title: host body product
-    examples:
-      - value: mucus [UBERON:0000912]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - host body product
@@ -4969,6 +4942,8 @@ slots:
     slot_uri: MIXS:0000888
     range: ControlledTermValue
     multivalued: false
+    examples:
+      - value: mucus [UBERON:0000912]
   host_body_site:
     annotations:
       expected_value:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -4956,7 +4956,7 @@ slots:
     description: Substance produced by the body, e.g. Stool, mucus, where the sample was obtained from. For foundational model of anatomy ontology (fma) or Uber-anatomy ontology (UBERON) terms, please see https://www.ebi.ac.uk/ols/ontologies/fma or https://www.ebi.ac.uk/ols/ontologies/uberon
     title: host body product
     examples:
-      - value: Portion of mucus [fma66938]
+      - value: mucus [UBERON:0000912]
     from_schema: http://w3id.org/mixs/terms
     aliases:
       - host body product

--- a/src/schema/portal_mixs_inspired.yaml
+++ b/src/schema/portal_mixs_inspired.yaml
@@ -61,7 +61,8 @@ slots:
     comments:
       - 'Time should be entered as HH:MM(:SS) in GMT. See here for a converter: https://www.worldtimebuddy.com/pst-to-gmt-converter'
     examples:
-      - value: 13:33 or 13:33:55
+      - value: 13:33
+      - value: 13:33:55
     see_also:
       - MIXS:0000011
     rank: 3

--- a/src/schema/portal_mixs_inspired.yaml
+++ b/src/schema/portal_mixs_inspired.yaml
@@ -25,7 +25,9 @@ slots:
       - Date should be formatted as YYYY(-MM(-DD)). Ie, 2021-04-15, 2021-04 and 2021
         are all acceptable.
     examples:
-      - value: 2021-04-15, 2021-04 and 2021 are all acceptable.
+      - value: 2021-04-15
+      - value: 2021-04
+      - value: 2021
     see_also:
       - MIXS:0000011
     rank: 2

--- a/src/schema/portal_mixs_inspired.yaml
+++ b/src/schema/portal_mixs_inspired.yaml
@@ -237,7 +237,9 @@ slots:
       - Date should be formatted as YYYY(-MM(-DD)). Ie, 2021-04-15, 2021-04 and 2021
         are all acceptable.
     examples:
-      - value: 2021-04-15, 2021-04 and 2021 are all acceptable.
+      - value: 2021-04-15
+      - value: 2021-04
+      - value: '2021'
     see_also:
       - MIXS:0000011
     rank: 4
@@ -253,7 +255,8 @@ slots:
     comments:
       - 'Time should be entered as HH:MM(:SS) in GMT. See here for a converter: https://www.worldtimebuddy.com/pst-to-gmt-converter'
     examples:
-      - value: 13:33 or 13:33:55
+      - value: 13:33
+      - value: 13:33:55
     see_also:
       - MIXS:0000011
     rank: 5

--- a/src/schema/portal_mixs_inspired.yaml
+++ b/src/schema/portal_mixs_inspired.yaml
@@ -43,7 +43,8 @@ slots:
     comments:
       - 'Time should be entered as HH:MM(:SS) in GMT. See here for a converter: https://www.worldtimebuddy.com/pst-to-gmt-converter'
     examples:
-      - value: 13:33 or 13:33:55
+      - value: 13:33
+      - value: 13:33:55
     see_also:
       - MIXS:0000011
     rank: 1

--- a/src/schema/portal_mixs_inspired.yaml
+++ b/src/schema/portal_mixs_inspired.yaml
@@ -111,11 +111,10 @@ slots:
         labeled compounds
     examples:
       - value: 13C glucose
-      - value: H218O
+      - value: 18O water
     see_also:
       - MIXS:0000751
     rank: 16
-    string_serialization: '{termLabel} {[termID]}; {timestamp}'
     slot_group: MIxS Inspired
     recommended: true
   micro_biomass_c_meth:

--- a/src/schema/portal_sample_id.yaml
+++ b/src/schema/portal_sample_id.yaml
@@ -28,7 +28,7 @@ slots:
     description: Select all the data types associated or available for this biosample
     title: analysis/data type
     examples:
-      - value: metagenomics; metabolomics; proteomics
+      - value: metagenomics; metabolomics; metaproteomics
     from_schema: https://example.com/nmdc_dh
     see_also:
       - MIxS:investigation_type


### PR DESCRIPTION
Related to https://github.com/microbiomedata/submission-schema/issues/227.

These changes update the `examples` attribute of slots where we don't make any further modifications when building `submission-schema`. So I think it makes the most sense to make the changes here and inherit the updates downstream.

The one exception is that I believe we decided to leave the example on `host_sex` in place and update the `host_sex_enum` permissible values. I don't recall exactly where @turbomam got the new permissible values from, but that's what I had in my notes.