### PR TITLE
Move deprecated elements from previous release to deprecated yaml

### DIFF
--- a/src/data/invalid/Database-functional_annotation_agg-missing_gene_function_id.yaml
+++ b/src/data/invalid/Database-functional_annotation_agg-missing_gene_function_id.yaml
@@ -1,5 +1,5 @@
 #invalid because gene_function_id is required but missing
 functional_annotation_agg:
-  - metagenome_annotation_id: nmdc:wfmgan-3a9-A.3
+  - was_generated_by: nmdc:wfmgan-3a9-A.3
     count: 120
     type: nmdc:FunctionalAnnotationAggMember

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1313,18 +1313,6 @@ classes:
       - metabolite_identified
       - type
 
-  ProteinQuantification:
-    class_uri: nmdc:ProteinQuantification
-    description: This is used to link a metaproteomics analysis workflow to a specific protein
-    slots:
-      - all_proteins
-      - best_protein
-      - peptide_sequence_count
-      - protein_spectral_count
-      - protein_sum_masic_abundance
-      - type
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-
   ChemicalEntity:
     class_uri: nmdc:ChemicalEntity
     aliases:
@@ -1737,33 +1725,7 @@ slots:
     description: the specific metabolite identifier
     range: ChemicalEntity
 
-  all_proteins:
-    description: the list of protein identifiers that are associated with the peptide sequence
-    range: GeneProduct
-    multivalued: true
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  best_protein:
-    description: the specific protein identifier most correctly associated with the peptide sequence
-    range: GeneProduct
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  min_q_value:
-    description: smallest Q-Value associated with the peptide sequence as provided by MSGFPlus tool
-    range: float
-    see_also:
-      - OBI:0001442
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  peptide_sequence:
-    range: string
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  peptide_spectral_count:
-    description: sum of filter passing MS2 spectra associated with the peptide sequence within a given LC-MS/MS data file
-    range: integer
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  peptide_sum_masic_abundance:
-    description: >-
-      combined MS1 extracted ion chromatograms derived from MS2 spectra associated with the peptide sequence from a given LC-MS/MS data file using the MASIC tool
-    range: integer
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+
   chemical_formula:
     description: A generic grouping for molecular formulae and empirical formulae
     range: string
@@ -1774,19 +1736,7 @@ slots:
       - "key set to false due to rare collisions: Pletnev I, Erin A, McNaught A, Blinov K, Tchekhovskoi D, Heller S (2012) InChIKey collision resistance: an experimental testing. J Cheminform. 4:12"
   inchi:
     range: string
-  peptide_sequence_count:
-    description: count of peptide sequences grouped to the best_protein
-    range: integer
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  protein_spectral_count:
-    description: sum of filter passing MS2 spectra associated with the best protein within a given LC-MS/MS data file
-    range: integer
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-  protein_sum_masic_abundance:
-    description: >-
-      combined MS1 extracted ion chromatograms derived from MS2 spectra associated with the best protein from a given LC-MS/MS data file using the MASIC tool
-    range: integer
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+
   smiles:
     description: >-
       A string encoding of a molecular graph, no chiral or isotopic information. There are usually a large number of valid SMILES which represent a given structure. For example, CCO, OCC and C(O)C all specify the structure of ethanol.

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1313,19 +1313,6 @@ classes:
       - metabolite_identified
       - type
 
-  PeptideQuantification:
-    class_uri: nmdc:PeptideQuantification
-    description: This is used to link a metaproteomics analysis workflow to a specific peptide sequence and related information
-    slots:
-      - type
-      - all_proteins
-      - best_protein
-      - min_q_value
-      - peptide_sequence
-      - peptide_spectral_count
-      - peptide_sum_masic_abundance
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-
   ProteinQuantification:
     class_uri: nmdc:ProteinQuantification
     description: This is used to link a metaproteomics analysis workflow to a specific protein

--- a/src/schema/deprecated.yaml
+++ b/src/schema/deprecated.yaml
@@ -33,6 +33,30 @@ default_prefix: nmdc
 default_range: string
 
 classes:
+  PeptideQuantification:
+    class_uri: nmdc:PeptideQuantification
+    description: This is used to link a metaproteomics analysis workflow to a specific peptide sequence and related information
+    slots:
+      - type
+      - all_proteins
+      - best_protein
+      - min_q_value
+      - peptide_sequence
+      - peptide_spectral_count
+      - peptide_sum_masic_abundance
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+
+  ProteinQuantification:
+    class_uri: nmdc:ProteinQuantification
+    description: This is used to link a metaproteomics analysis workflow to a specific protein
+    slots:
+      - all_proteins
+      - best_protein
+      - peptide_sequence_count
+      - protein_spectral_count
+      - protein_sum_masic_abundance
+      - type
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
 
 slots:
   omics_type:
@@ -42,3 +66,53 @@ slots:
     examples:
       - value: metatranscriptome
       - value: metagenome
+  all_proteins:
+    description: the list of protein identifiers that are associated with the peptide sequence
+    range: GeneProduct
+    multivalued: true
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  best_protein:
+    description: the specific protein identifier most correctly associated with the peptide sequence
+    range: GeneProduct
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  min_q_value:
+    description: smallest Q-Value associated with the peptide sequence as provided by MSGFPlus tool
+    range: float
+    see_also:
+      - OBI:0001442
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  peptide_sequence:
+    range: string
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  peptide_spectral_count:
+    description: sum of filter passing MS2 spectra associated with the peptide sequence within a given LC-MS/MS data file
+    range: integer
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  peptide_sum_masic_abundance:
+    description: >-
+      combined MS1 extracted ion chromatograms derived from MS2 spectra associated with the peptide sequence from a given LC-MS/MS data file using the MASIC tool
+    range: integer
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  peptide_sequence_count:
+    description: count of peptide sequences grouped to the best_protein
+    range: integer
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  protein_spectral_count:
+    description: sum of filter passing MS2 spectra associated with the best protein within a given LC-MS/MS data file
+    range: integer
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  protein_sum_masic_abundance:
+    description: >-
+      combined MS1 extracted ion chromatograms derived from MS2 spectra associated with the best protein from a given LC-MS/MS data file using the MASIC tool
+    range: integer
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  metagenome_annotation_id:
+    range: WorkflowExecution
+    description: The identifier for the analysis activity that generated the functional annotation results, where the analysis activity is an instance of the/an appropriate subclass of WorkflowExecution
+    required: true
+    deprecated: "not used. 2024-10 https://github.com/microbiomedata/nmdc-schema/issues/1253"
+  has_peptide_quantifications:
+    range: PeptideQuantification
+    multivalued: true
+    inlined_as_list: true
+    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1056,13 +1056,6 @@ slots:
     range: ChromatographyConfiguration
     description: The identifier of the associated ChromatographyConfiguration, providing information about how a sample was introduced into the mass spectrometer.
 
-  metagenome_annotation_id:
-    range: WorkflowExecution
-    description: The identifier for the analysis activity that generated the functional annotation results, where the analysis activity is an instance of the/an appropriate subclass of WorkflowExecution
-    required: true
-    deprecated: "not used. 2024-10 https://github.com/microbiomedata/nmdc-schema/issues/1253"
-
-
   gene_function_id:
     range: uriorcurie
     description: The identifier for the gene function.

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -313,12 +313,6 @@ slots:
   metagenome_assembly_parameter:
     abstract: true
 
-  has_peptide_quantifications:
-    range: PeptideQuantification
-    multivalued: true
-    inlined_as_list: true
-    deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
-
   asm_score:
     is_a: metagenome_assembly_parameter
     description: >-


### PR DESCRIPTION
This PR addresses #2257.

This PR will

1. Move the **previously deprecated** classes and slots to the deprecated.yaml file, in compliance with the [deprecation guidelines](https://github.com/microbiomedata/nmdc-schema/blob/a5c3f4e7fe221b01d24151e536bfe00cbeb3ac19/src/docs/schema_element_deprecation_guide.md#L4).
2. Update one invalid test so it is invalid only for a single reason by eliminating its use of a deprecated slot. 

------

slots moved:

- all_proteins
- best_protein
- min_q_value
- peptide_sequence
- peptide_spectral_count
- peptide_sum_masic_abundance
- peptide_sequence_count
- protein_spectral_count
- protein_sum_masic_abundance
- has_peptide_quantifications
- metagenome_annotation_id

classes moved:

- ProteinQuantification
- PeptideQuantification

There are no longer any references to these slots or classes in any src/schema .yaml files besides the deprecation.yaml file.
