### PR TITLE
Add pattern constraint to `in_manifest` on `DataObject`

### DIFF
--- a/src/data/invalid/DataObject-in_manifest-invalid.yaml
+++ b/src/data/invalid/DataObject-in_manifest-invalid.yaml
@@ -1,4 +1,4 @@
-#this test should fail because the value of in_manifest should be a list, not a list of lists
+#this test should fail because the id mention for in_manifest is not formatted correctly
 id: nmdc:dobj-11-hfjbht29
 name: nmdc_dobj-11-agsd2f41_nmdc_dobj-11-8yvaz057_QC_metrics.tsv
 description: Overall statistics from MSGF+ search results filtered to ~5% FDR

--- a/src/data/invalid/DataObject-in_manifest-invalid.yaml
+++ b/src/data/invalid/DataObject-in_manifest-invalid.yaml
@@ -1,0 +1,11 @@
+#this test should fail because the value of in_manifest should be a list, not a list of lists
+id: nmdc:dobj-11-hfjbht29
+name: nmdc_dobj-11-agsd2f41_nmdc_dobj-11-8yvaz057_QC_metrics.tsv
+description: Overall statistics from MSGF+ search results filtered to ~5% FDR
+file_size_bytes: 173
+md5_checksum: 299fa9e3ce6b29edc515146fdd452acd
+data_object_type: Metaproteomics Workflow Statistics
+url: https://nmdcdemo.emsl.pnnl.gov/proteomics/results/nmdc_dobj-11-agsd2f41_nmdc_dobj-11-8yvaz057_QC_metrics.tsv
+type: nmdc:DataObject
+in_manifest:
+- "['nmdc:manif-11-7796sg87']"

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -305,10 +305,6 @@ classes:
         structured_pattern:
           syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
-      in_manifest:
-        structured_pattern:
-          syntax: "^{id_nmdc_prefix}:manif-{id_shoulder}-{id_blade}$"
-          interpolated: true
   
   DataGeneration:
     class_uri: nmdc:DataGeneration

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -531,6 +531,9 @@ slots:
     description: one or more combinations of other DataObjects that can be analyzed together
     comments:
       - A DataObject can be part of multiple manifests, for example, a DataObject could be part of a manifest for a single run of an instrument and a manifest for technical replicates of a single sample.
+    structured_pattern:
+      syntax: "^{id_nmdc_prefix}:manif-{id_shoulder}-{id_blade}$"
+      interpolated: true  
 
   manifest_category:
     range: ManifestCategoryEnum

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -305,7 +305,6 @@ classes:
         structured_pattern:
           syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
-  
   DataGeneration:
     class_uri: nmdc:DataGeneration
     is_a: PlannedProcess

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -305,7 +305,11 @@ classes:
         structured_pattern:
           syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
-
+      in_manifest:
+        structured_pattern:
+          syntax: "^{id_nmdc_prefix}:manif-{id_shoulder}-{id_blade}$"
+          interpolated: true
+  
   DataGeneration:
     class_uri: nmdc:DataGeneration
     is_a: PlannedProcess


### PR DESCRIPTION
This PR adds a pattern constraint to in_manifest. Without this it is possible to malform the id mention such that it causes voliations for refscan and for linkml_runtime/utils/metamodelcore.py in nmdc_automation.

Fixes https://github.com/microbiomedata/nmdc-schema/issues/2274

Related to https://github.com/microbiomedata/issues/issues/948