### PR TITLE
Add slot and enumeration to `MetaproteomicsAnalysis` class and implement migrator.

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_1_0_to_11_2_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_1_0_to_11_2_0.py
@@ -14,17 +14,17 @@ class Migrator(MigratorBase):
 
     def set_metap_analysis_category(self, workflow: dict) -> dict:
         r"""
-        If the workflow execution records is of the type "nmdc:MetaprotemicsAnalysis", 
+        If the workflow execution records is of the type "nmdc:MetaproteomicsAnalysis", 
         add field `metaproteomics_analysis_category` and assign it the value "matched_metagenome".
 
         >>> m = Migrator()
-        >>> m.set_metap_analysis_category({'id': 123, 'type': 'nmdc:MetaprotemicsAnalysis'})  # field doesn't exist yet
-        {'id': 123, 'type': 'nmdc:MetaprotemicsAnalysis', 'metaproteomics_analysis_category': 'matched_metagenome'}
+        >>> m.set_metap_analysis_category({'id': 123, 'type': 'nmdc:MetaproteomicsAnalysis'})  # field doesn't exist yet
+        {'id': 123, 'type': 'nmdc:MetaproteomicsAnalysis', 'metaproteomics_analysis_category': 'matched_metagenome'}
         >>> m.set_metap_analysis_category({'id': 123, 'type': 'nmdc:MetabolomicsAnalysis'})  # not a metaproteomics analysis
         {'id': 123, 'type': 'nmdc:MetabolomicsAnalysis'}
         """
 
-        if workflow["type"] == "nmdc:MetaprotemicsAnalysis":
+        if workflow["type"] == "nmdc:MetaproteomicsAnalysis":
             if "metaproteomics_analysis_category" not in workflow:
                 workflow["metaproteomics_analysis_category"] = "matched_metagenome"
         return workflow

--- a/nmdc_schema/migrators/migrator_from_11_1_0_to_11_2_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_1_0_to_11_2_0.py
@@ -1,0 +1,30 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.1.0"
+    _to_version = "11.2.0"
+
+    def upgrade(self):
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+
+        self.adapter.process_each_document("workflow_execution_set", [self.set_metap_analysis_category])
+
+    def set_metap_analysis_category(self, workflow: dict) -> dict:
+        r"""
+        If the workflow execution records is of the type "nmdc:MetaprotemicsAnalysis", 
+        add field `metaproteomics_analysis_category` and assign it the value "matched_metagenome".
+
+        >>> m = Migrator()
+        >>> m.set_metap_analysis_category({'id': 123, 'type': 'nmdc:MetaprotemicsAnalysis'})  # field doesn't exist yet
+        {'id': 123, 'type': 'nmdc:MetaprotemicsAnalysis', 'metaproteomics_analysis_category': 'matched_metagenome'}
+        >>> m.set_metap_analysis_category({'id': 123, 'type': 'nmdc:MetabolomicsAnalysis'})  # not a metaproteomics analysis
+        {'id': 123, 'type': 'nmdc:MetabolomicsAnalysis'}
+        """
+
+        if workflow["type"] == "nmdc:MetaprotemicsAnalysis":
+            if "metaproteomics_analysis_category" not in workflow:
+                workflow["metaproteomics_analysis_category"] = "matched_metagenome"
+        return workflow

--- a/src/data/invalid/MetaproteomicsAnalysis-invalid-missing-metap-cat.yaml
+++ b/src/data/invalid/MetaproteomicsAnalysis-invalid-missing-metap-cat.yaml
@@ -1,0 +1,13 @@
+# This example is invalid because it is missing the required slot `metaproteomics_analysis_category` and that slot is required by the schema.
+id: nmdc:wfmp-99-74d83.1
+type: nmdc:MetaproteomicsAnalysis
+name: soil metaproteomics analysis
+has_input:
+  - nmdc:dobj-99-74d83z
+has_output:
+  - nmdc:dobj-99-74d83
+ended_at_time: '2023-08-11T17:00:00Z'
+execution_resource: EMSL
+git_url: https://github.com/microbiomedata/metaproteomics_analysis/releases/tag/v0.6.3
+was_informed_by: nmdc:dgms-12-384j8d
+started_at_time: '2023-08-11T11:00:00Z'

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -27,6 +27,7 @@ workflow_execution_set:
     git_url: https://github.com/microbiomedata/metaproteomics_analysis/releases/tag/v0.6.3
     was_informed_by: nmdc:dgms-12-384j8d
     started_at_time: '2023-08-11T11:00:00Z'
+    metaproteomics_analysis_category: matched_metagenome
 chemical_entity_set:
   - id: nmdc:chem-99-000016
     type: nmdc:ChemicalEntity

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -313,7 +313,7 @@ classes:
 slots:
 
   metaproteomics_analysis_category:
-    range: MetaProteomicsAnalysisCategoryEnum
+    range: MetaproteomicsAnalysisCategoryEnum
     description: >-
       The category of metaproteomics analysis being performed.
     required: true
@@ -563,7 +563,7 @@ slots:
     inlined_as_list: true
 
 enums:
-  MetaProteomicsAnalysisCategoryEnum:
+  MetaproteomicsAnalysisCategoryEnum:
     description: The category of metaproteomics analysis being performed.
     permissible_values:
       matched_metagenome:

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -568,7 +568,7 @@ enums:
     permissible_values:
       matched_metagenome:
         description: >-
-          A metaproteomics analysis that is matched to an experimental metagenome.
+          A metaproteomics analysis that is matched to a metagenome derived from the same biosample.
       in_silico_metagenome:
         description: >-
           A metaproteomics analysis that is matched to an in silico generated metagenome.

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -281,6 +281,8 @@ classes:
     is_a: WorkflowExecution
     in_subset:
       - workflow subset
+    slots:
+      - metaproteomics_analysis_category
     slot_usage:
       id:
         required: true
@@ -309,6 +311,12 @@ classes:
           interpolated: true
 
 slots:
+
+  metaproteomics_analysis_category:
+    range: MetaProteomicsAnalysisCategoryEnum
+    description: >-
+      The category of metaproteomics analysis being performed.
+    required: true
 
   metagenome_assembly_parameter:
     abstract: true
@@ -553,3 +561,14 @@ slots:
     range: MetaboliteIdentification
     multivalued: true
     inlined_as_list: true
+
+enums:
+  MetaProteomicsAnalysisCategoryEnum:
+    description: The category of metaproteomics analysis being performed.
+    permissible_values:
+      matched_metagenome:
+        description: >-
+          A metaproteomics analysis that is matched to an experimental metagenome.
+      in_silico_metagenome:
+        description: >-
+          A metaproteomics analysis that is matched to an in silico generated metagenome.


### PR DESCRIPTION
This MR will close #2256.

It will
1) Add the **required** slot `metaproteomics_analysis_category` to the `MetaproteomicsAnalysis` class
2) Add the definition of the slot `metaproteomics_analysis_category` to the schema, with a range of `MetaproteomicsAnalysisCategoryEnum`
3) Add definition of the `MetaproteomicsAnalysisCategoryEnum` to the schema
4) Adjust valid test to include the `metaproteomics_analysis_category`
5) Add invalid test for record that is missing the `metaproteomics_analysis_category`
6) Add migrator that populates the records of all existing `MetaproteomicsAnalysis` records with `metaproteomics_analysis_category` value of `matched_metagenome`.  Note that this logic is used because all current data use a `matched_metagenome` and we're adding this enumeration in preparation for the second category of analysis.

I have tested the migrator locally with no issues.