### PR TITLE
Make schema-derived JSON and YAML files downloadable via docs website

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -39,6 +39,10 @@ jobs:
           mkdir -p docs
           touch docs/.nojekyll
           make gendoc
+          mkdir -p docs/downloads
+          cp nmdc_schema/nmdc.schema.json                       docs/downloads/nmdc.schema.json
+          cp nmdc_schema/nmdc_materialized_patterns.schema.json docs/downloads/nmdc_materialized_patterns.schema.json
+          cp nmdc_schema/nmdc_materialized_patterns.yaml        docs/downloads/nmdc_materialized_patterns.yaml
 
         # Deploy the docs to GitHub Pages.
         #

--- a/.github/workflows/test_pages_build.yaml
+++ b/.github/workflows/test_pages_build.yaml
@@ -47,6 +47,10 @@ jobs:
           mkdir -p docs
           touch docs/.nojekyll
           make gendoc
+          mkdir -p docs/downloads
+          cp nmdc_schema/nmdc.schema.json                       docs/downloads/nmdc.schema.json
+          cp nmdc_schema/nmdc_materialized_patterns.schema.json docs/downloads/nmdc_materialized_patterns.schema.json
+          cp nmdc_schema/nmdc_materialized_patterns.yaml        docs/downloads/nmdc_materialized_patterns.yaml
           poetry run mkdocs build -d site
 
       - name: Deploy preview

--- a/src/docs/downloads.md
+++ b/src/docs/downloads.md
@@ -1,0 +1,5 @@
+# Downloads
+
+1. [`nmdc.schema.json`](downloads/nmdc.schema.json)
+2. [`nmdc_materialized_patterns.schema.json`](downloads/nmdc_materialized_patterns.schema.json)
+3. [`nmdc_materialized_patterns.yaml`](downloads/nmdc_materialized_patterns.yaml)


### PR DESCRIPTION
In this branch, I'm working on making the schema-derived YAML and JSON files be accessible via the documentation website, so they can be omitted from the repository, itself.

The task of omitting them from the repository is represented by Issue #1960, although that Issue represents it in the context of people's local development environments.