### PR TITLE
Add NMDC `instrument_set` mapping value for GOLD Illumina MiSeq

### DIFF
--- a/assets/misc/gold_seqMethod_to_nmdc_instrument_set.tsv
+++ b/assets/misc/gold_seqMethod_to_nmdc_instrument_set.tsv
@@ -10,3 +10,4 @@ Illumina NovaSeq 6000	nmdc:inst-14-mr4r2w09
 Illumina NovaSeq S2	nmdc:inst-14-mr4r2w09
 Illumina NovaSeq S4	nmdc:inst-14-mr4r2w09
 Illumina NovaSeq SP	nmdc:inst-14-mr4r2w09
+Illumina MiSeq	nmdc:inst-12-yqr7e137


### PR DESCRIPTION
There is a `seqMethod` value in the GOLD API called "Illumina MiSeq". There is an `instrument_set` record in the database corresponding to this instrument that has the value `nmdc:inst-12-yqr7e137`, so we are adding the corresponding mapping to this file.