### PR TITLE
Add "Collection name(s)" column to typecode-to-class map table

### DIFF
--- a/src/scripts/make_typecode_to_class_map.py
+++ b/src/scripts/make_typecode_to_class_map.py
@@ -58,16 +58,11 @@ def extract_comparison_key(class_name_and_typecodes: Tuple[str, List[str]]) -> s
 
 def get_collection_names_for_class_name(class_name: str) -> List[str]:
     r"""
-    Returns the names of the collections the schema says can contain instances of the specified class.
+    Returns the names of the collection(s) the schema says can contain instances of the specified class.
 
-    Note: In the schema, the `multivalued`, `inlined_as_list` slots of the `Database` class represent collections (e.g.,
-          `workflow_execution_set`). Each such slot has a range indicated by its `range` attribute (e.g., the
-          `workflow_execution_set` slot has a range of `WorkflowExecution`). The effective range of the slot
-          consists of `WorkflowExecution` and each of its descendant classes (e.g., `MetagenomeAnnotation`).
-
-    References:
-    - https://microbiomedata.github.io/nmdc-schema/workflow_execution_set/ (for an example range)
-    - https://microbiomedata.github.io/nmdc-schema/WorkflowExecution/ (for an example class hierarchy)
+    Note: In the schema, each `multivalued`, `inlined_as_list` slot of the `Database` class represents a collection.
+          Each such slot has a range indicated by its `range` attribute. The _effective_ range of the slot consists of
+          both (a) the class identified by its `range` attribute and (b) all descendant classes of that class.
 
     >>> get_collection_names_for_class_name("")  # empty string
     []

--- a/src/scripts/make_typecode_to_class_map.py
+++ b/src/scripts/make_typecode_to_class_map.py
@@ -132,7 +132,7 @@ def main():
         collection_names = get_collection_names_for_class_name(class_name)
         formatted_collection_names = [f"`{collection_name}`" for collection_name in collection_names]
         collection_cell = ", ".join(formatted_collection_names)  # if multiple exist, separates them with commas
-        md_table_lines.append(f"| {typecode_cell} | {class_cell} | {collection_cell}")
+        md_table_lines.append(f"| {typecode_cell} | {class_cell} | {collection_cell} |")
 
     # Build the entire Markdown document.
     md_document = make_document(md_table="\n".join(md_table_lines))

--- a/src/scripts/make_typecode_to_class_map.py
+++ b/src/scripts/make_typecode_to_class_map.py
@@ -2,9 +2,12 @@ from typing import Dict, List, Tuple
 
 import click
 from linkml_runtime import SchemaView
+
 from nmdc_schema.nmdc_data import get_nmdc_schema_definition
 from nmdc_schema.id_helpers import get_compatible_typecodes
 
+
+DATABASE_CLASS_NAME = "Database"
 schema_view = SchemaView(get_nmdc_schema_definition())
 
 
@@ -32,7 +35,7 @@ def make_document(md_table: str = "") -> str:
     md_intro: str = (r"Schema class definitions include structured patterns that constrain the format of their `id` "
                      r"values. One element of the structured pattern is the _typecode_. The following table—which was "
                      r"derived from the schema—shows which schema class can have a given string in the _typecode_ "
-                     r"portion of its `id` values.")
+                     r"portion of its `id` values, and which collections can contain instances of that schema class.")
     md_footer: str = r""  # currently empty — it's here if we need it
     return "\n\n".join([md_header, md_intro, md_table, md_footer])
 
@@ -51,6 +54,47 @@ def extract_comparison_key(class_name_and_typecodes: Tuple[str, List[str]]) -> s
     class_name, typecodes = class_name_and_typecodes
     first_typecode = typecodes[0] if len(typecodes) > 0 else ""
     return first_typecode
+
+
+def get_collection_names_for_class_name(class_name: str) -> List[str]:
+    r"""
+    Returns the names of the collections the schema says can contain instances of the specified class.
+
+    Note: In the schema, the `multivalued`, `inlined_as_list` slots of the `Database` class represent collections (e.g.,
+          `workflow_execution_set`). Each such slot has a range indicated by its `range` attribute (e.g., the
+          `workflow_execution_set` slot has a range of `WorkflowExecution`). The effective range of the slot
+          consists of `WorkflowExecution` and each of its descendant classes (e.g., `MetagenomeAnnotation`).
+
+    References:
+    - https://microbiomedata.github.io/nmdc-schema/workflow_execution_set/ (for an example range)
+    - https://microbiomedata.github.io/nmdc-schema/WorkflowExecution/ (for an example class hierarchy)
+
+    >>> get_collection_names_for_class_name("")  # empty string
+    []
+    >>> get_collection_names_for_class_name("NonExistentClass")  # non-existent class
+    []
+    >>> get_collection_names_for_class_name("Study")  # class having no descendants
+    ['study_set']
+    >>> get_collection_names_for_class_name("DataGeneration")  # class having some descendants
+    ['data_generation_set']
+    >>> get_collection_names_for_class_name("NucleotideSequencing")
+    ['data_generation_set']
+    >>> get_collection_names_for_class_name("MassSpectrometry")
+    ['data_generation_set']
+    """
+    collection_names_for_class_name = []
+
+    # Process each slot of the "Database" class.
+    for slot_name in schema_view.class_slots(class_name=DATABASE_CLASS_NAME):
+        slot_definition = schema_view.induced_slot(slot_name, class_name=DATABASE_CLASS_NAME)
+
+        # If this slot represents a collection, check whether the specified class is within the slot's range.
+        if slot_definition.multivalued and slot_definition.inlined_as_list:
+            class_names_in_slot_range = schema_view.class_descendants(class_name=slot_definition.range)
+            if class_name in class_names_in_slot_range:
+                collection_names_for_class_name.append(slot_name)
+
+    return collection_names_for_class_name
 
 
 @click.command()
@@ -79,8 +123,8 @@ def main():
                     class_name_to_typecodes[class_name] = sorted(compatible_typecodes)  # sorts them alphabetically
 
     # Build the Markdown table.
-    md_table_lines: List[str] = [r"| Typecode(s) | Schema class |",
-                                 r"| ----------- | ------------ |"]
+    md_table_lines: List[str] = [r"| Typecode(s) | Schema class | Collection name(s) |",
+                                 r"| ----------- | ------------ | ------------------ |"]
     for class_name, compatible_typecodes in sorted(class_name_to_typecodes.items(), key=extract_comparison_key):
         formatted_typecodes = [f"`{typecode}`" for typecode in compatible_typecodes]  # wraps each one in backticks
         typecode_cell = ", ".join(formatted_typecodes)  # if multiple exist, separates them with commas
@@ -90,7 +134,10 @@ def main():
                       f'title="View {class_name} documentation">'
                       f'{class_name}'
                       f'</a>')  # uses HTML instead of Markdown so we can specify the `target` attribute
-        md_table_lines.append(f"| {typecode_cell} | {class_cell} |")
+        collection_names = get_collection_names_for_class_name(class_name)
+        formatted_collection_names = [f"`{collection_name}`" for collection_name in collection_names]
+        collection_cell = ", ".join(formatted_collection_names)  # if multiple exist, separates them with commas
+        md_table_lines.append(f"| {typecode_cell} | {class_cell} | {collection_cell}")
 
     # Build the entire Markdown document.
     md_document = make_document(md_table="\n".join(md_table_lines))


### PR DESCRIPTION
On this branch, I added a column to the newly-introduced "Typecode to class map" table in the schema documentation. The column is named "Collection name(s)" and, on each row, contains the names of the database collections the schema allows documents representing instances of the specified schema class to reside in.

Here's what the resulting table looks like:

![image](https://github.com/user-attachments/assets/bf872a87-61df-435c-a3b9-d5cee1d79589)

Fixes #2323 