### PR TITLE
Generate release artifacts for `nmdc-schema` version `v11.4.0`

### DIFF
--- a/nmdc_schema/nmdc-pydantic.py
+++ b/nmdc_schema/nmdc-pydantic.py
@@ -740,6 +740,8 @@ class BiosampleCategoryEnum(str, Enum):
     Department_of_Energy_Office_of_Science_Biological_and_Environmental_Research_Program_Laboratory_Science_Focus_Areas = "SFA"
     Facilities_Integrating_Collaborations_for_User_Science = "FICUS"
     National_Science_FoundationAPOSTROPHEs_National_Ecological_Observatory_Network = "NEON"
+    # Bioenergy Research Centers funded by the Biological Systems Science Division of the U.S. Department of Energy's Biological and Environmental Research Program.
+    Bioenergy_Research_Centers = "BRC"
 
 
 class SubstanceRoleEnum(str, Enum):
@@ -2200,6 +2202,8 @@ class FileTypeEnum(str, Enum):
     Direct_Infusion_FT_ICR_MS_Raw_Data = "Direct Infusion FT ICR-MS Raw Data"
     # Liquid chromatographically separated MS1 and Data-Dependent MS2 binary instrument file
     LC_DDA_MSSOLIDUSMS_Raw_Data = "LC-DDA-MS/MS Raw Data"
+    # Gas chromatography-mass spectrometry raw data, full scan mode.
+    GC_MS_Raw_Data = "GC-MS Raw Data"
     # A configuration toml file used by various programs to store settings that are specific to their respective software.
     Configuration_toml = "Configuration toml"
     # LC-MS-based lipidomics analysis results table
@@ -2550,9 +2554,6 @@ class Database(ConfiguredBaseModel):
          'domain_of': ['Database'],
          'mixins': ['object_set']} })
     processed_sample_set: Optional[List[ProcessedSample]] = Field(None, description="""This property links a database object to the set of processed samples within it.""", json_schema_extra = { "linkml_meta": {'alias': 'processed_sample_set',
-         'domain_of': ['Database'],
-         'mixins': ['object_set']} })
-    protocol_execution_set: Optional[List[ProtocolExecution]] = Field(None, description="""This property links a database object to the set of protocol executions within it.""", json_schema_extra = { "linkml_meta": {'alias': 'protocol_execution_set',
          'domain_of': ['Database'],
          'mixins': ['object_set']} })
     storage_process_set: Optional[List[StorageProcess]] = Field(None, description="""This property links a database object to the set of storage processes within it.""", json_schema_extra = { "linkml_meta": {'alias': 'storage_process_set',
@@ -11922,6 +11923,8 @@ class ProtocolExecution(PlannedProcess):
     A PlannedProces that has PlannedProcess parts. Can be used to represent the case of someone following a Protocol.
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:ProtocolExecution',
+         'deprecated': 'not used, not fulfilling intended purpose '
+                       'https://github.com/microbiomedata/nmdc-schema/issues/2336',
          'from_schema': 'https://w3id.org/nmdc/nmdc',
          'slot_usage': {'has_input': {'name': 'has_input',
                                       'pattern': '^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
@@ -11947,11 +11950,16 @@ class ProtocolExecution(PlannedProcess):
                                                       'syntax': '{id_nmdc_prefix}:pex-{id_shoulder}-{id_blade}$'}}}})
 
     has_process_parts: List[str] = Field(..., description="""The MaterialProcessing steps that are discrete parts of the ProtocolExecution.""", json_schema_extra = { "linkml_meta": {'alias': 'has_process_parts',
+         'deprecated': 'not used '
+                       'https://github.com/microbiomedata/nmdc-schema/issues/2336',
          'domain_of': ['ProtocolExecution'],
          'list_elements_ordered': True,
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:(extrp|filtpr|dispro|poolp|libprp|subspr|mixpro|chcpr|cspro)-{id_shoulder}-{id_blade}$'}} })
-    protocol_execution_category: ProtocolCategoryEnum = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'protocol_execution_category', 'domain_of': ['ProtocolExecution']} })
+    protocol_execution_category: ProtocolCategoryEnum = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'protocol_execution_category',
+         'deprecated': 'not used '
+                       'https://github.com/microbiomedata/nmdc-schema/issues/2336',
+         'domain_of': ['ProtocolExecution']} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],

--- a/nmdc_schema/nmdc.py
+++ b/nmdc_schema/nmdc.py
@@ -1,5 +1,5 @@
 # Auto generated from nmdc.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-01-30T16:05:51
+# Generation date: 2025-02-12T08:47:56
 # Schema: NMDC
 #
 # id: https://w3id.org/nmdc/nmdc
@@ -511,7 +511,6 @@ class Database(YAMLRoot):
     manifest_set: Optional[Union[Dict[Union[str, ManifestId], Union[dict, "Manifest"]], List[Union[dict, "Manifest"]]]] = empty_dict()
     material_processing_set: Optional[Union[Dict[Union[str, MaterialProcessingId], Union[dict, "MaterialProcessing"]], List[Union[dict, "MaterialProcessing"]]]] = empty_dict()
     processed_sample_set: Optional[Union[Dict[Union[str, ProcessedSampleId], Union[dict, "ProcessedSample"]], List[Union[dict, "ProcessedSample"]]]] = empty_dict()
-    protocol_execution_set: Optional[Union[Dict[Union[str, ProtocolExecutionId], Union[dict, "ProtocolExecution"]], List[Union[dict, "ProtocolExecution"]]]] = empty_dict()
     storage_process_set: Optional[Union[Dict[Union[str, StorageProcessId], Union[dict, "StorageProcess"]], List[Union[dict, "StorageProcess"]]]] = empty_dict()
     study_set: Optional[Union[Dict[Union[str, StudyId], Union[dict, "Study"]], List[Union[dict, "Study"]]]] = empty_dict()
     workflow_execution_set: Optional[Union[Dict[Union[str, WorkflowExecutionId], Union[dict, "WorkflowExecution"]], List[Union[dict, "WorkflowExecution"]]]] = empty_dict()
@@ -550,8 +549,6 @@ class Database(YAMLRoot):
         self._normalize_inlined_as_list(slot_name="material_processing_set", slot_type=MaterialProcessing, key_name="id", keyed=True)
 
         self._normalize_inlined_as_list(slot_name="processed_sample_set", slot_type=ProcessedSample, key_name="id", keyed=True)
-
-        self._normalize_inlined_as_list(slot_name="protocol_execution_set", slot_type=ProtocolExecution, key_name="id", keyed=True)
 
         self._normalize_inlined_as_list(slot_name="storage_process_set", slot_type=StorageProcess, key_name="id", keyed=True)
 
@@ -6932,6 +6929,10 @@ class BiosampleCategoryEnum(EnumDefinitionImpl):
     NEON = PermissibleValue(
         text="NEON",
         meaning=None)
+    BRC = PermissibleValue(
+        text="BRC",
+        description="""Bioenergy Research Centers funded by the Biological Systems Science Division of the U.S. Department of Energy's Biological and Environmental Research Program.""",
+        meaning=None)
 
     _defn = EnumDefinition(
         name="BiosampleCategoryEnum",
@@ -7688,6 +7689,10 @@ class FileTypeEnum(EnumDefinitionImpl):
             PermissibleValue(
                 text="LC-DDA-MS/MS Raw Data",
                 description="Liquid chromatographically separated MS1 and Data-Dependent MS2 binary instrument file"))
+        setattr(cls, "GC-MS Raw Data",
+            PermissibleValue(
+                text="GC-MS Raw Data",
+                description="Gas chromatography-mass spectrometry raw data, full scan mode."))
         setattr(cls, "Configuration toml",
             PermissibleValue(
                 text="Configuration toml",

--- a/nmdc_schema/nmdc.schema.json
+++ b/nmdc_schema/nmdc.schema.json
@@ -5441,7 +5441,8 @@
                 "SIP",
                 "SFA",
                 "FICUS",
-                "NEON"
+                "NEON",
+                "BRC"
             ],
             "title": "BiosampleCategoryEnum",
             "type": "string"
@@ -6870,16 +6871,6 @@
                         "null"
                     ]
                 },
-                "protocol_execution_set": {
-                    "description": "This property links a database object to the set of protocol executions within it.",
-                    "items": {
-                        "$ref": "#/$defs/ProtocolExecution"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
                 "storage_process_set": {
                     "description": "This property links a database object to the set of storage processes within it.",
                     "items": {
@@ -8016,6 +8007,7 @@
                 "Annotation Statistics",
                 "Direct Infusion FT ICR-MS Raw Data",
                 "LC-DDA-MS/MS Raw Data",
+                "GC-MS Raw Data",
                 "Configuration toml",
                 "LC-MS Lipidomics Results",
                 "LC-MS Lipidomics Processed Data",
@@ -15744,16 +15736,6 @@
             "description": "This property links a database object to the set of processed samples within it.",
             "items": {
                 "$ref": "#/$defs/ProcessedSample"
-            },
-            "type": [
-                "array",
-                "null"
-            ]
-        },
-        "protocol_execution_set": {
-            "description": "This property links a database object to the set of protocol executions within it.",
-            "items": {
-                "$ref": "#/$defs/ProtocolExecution"
             },
             "type": [
                 "array",

--- a/nmdc_schema/nmdc_materialized_patterns.schema.json
+++ b/nmdc_schema/nmdc_materialized_patterns.schema.json
@@ -5443,7 +5443,8 @@
                 "SIP",
                 "SFA",
                 "FICUS",
-                "NEON"
+                "NEON",
+                "BRC"
             ],
             "title": "BiosampleCategoryEnum",
             "type": "string"
@@ -6881,16 +6882,6 @@
                         "null"
                     ]
                 },
-                "protocol_execution_set": {
-                    "description": "This property links a database object to the set of protocol executions within it.",
-                    "items": {
-                        "$ref": "#/$defs/ProtocolExecution"
-                    },
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
                 "storage_process_set": {
                     "description": "This property links a database object to the set of storage processes within it.",
                     "items": {
@@ -8032,6 +8023,7 @@
                 "Annotation Statistics",
                 "Direct Infusion FT ICR-MS Raw Data",
                 "LC-DDA-MS/MS Raw Data",
+                "GC-MS Raw Data",
                 "Configuration toml",
                 "LC-MS Lipidomics Results",
                 "LC-MS Lipidomics Processed Data",
@@ -15825,16 +15817,6 @@
             "description": "This property links a database object to the set of processed samples within it.",
             "items": {
                 "$ref": "#/$defs/ProcessedSample"
-            },
-            "type": [
-                "array",
-                "null"
-            ]
-        },
-        "protocol_execution_set": {
-            "description": "This property links a database object to the set of protocol executions within it.",
-            "items": {
-                "$ref": "#/$defs/ProtocolExecution"
             },
             "type": [
                 "array",

--- a/nmdc_schema/nmdc_materialized_patterns.yaml
+++ b/nmdc_schema/nmdc_materialized_patterns.yaml
@@ -1018,6 +1018,13 @@ enums:
         text: NEON
         meaning: https://www.neonscience.org
         title: National Science Foundation's National Ecological Observatory Network
+      BRC:
+        text: BRC
+        description: Bioenergy Research Centers funded by the Biological Systems Science
+          Division of the U.S. Department of Energy's Biological and Environmental
+          Research Program.
+        meaning: https://www.genomicscience.energy.gov/bioenergy-research-centers/
+        title: Bioenergy Research Centers
   SubstanceRoleEnum:
     name: SubstanceRoleEnum
     from_schema: https://w3id.org/nmdc/nmdc
@@ -4201,6 +4208,9 @@ enums:
         text: LC-DDA-MS/MS Raw Data
         description: Liquid chromatographically separated MS1 and Data-Dependent MS2
           binary instrument file
+      GC-MS Raw Data:
+        text: GC-MS Raw Data
+        description: Gas chromatography-mass spectrometry raw data, full scan mode.
       Configuration toml:
         text: Configuration toml
         description: A configuration toml file used by various programs to store settings
@@ -4975,6 +4985,7 @@ slots:
     name: protocol_execution_set
     description: This property links a database object to the set of protocol executions
       within it.
+    deprecated: not used https://github.com/microbiomedata/nmdc-schema/issues/2336
     from_schema: https://w3id.org/nmdc/nmdc
     mixins:
     - object_set
@@ -5034,12 +5045,14 @@ slots:
     range: QuantityValue
   protocol_execution_category:
     name: protocol_execution_category
+    deprecated: not used https://github.com/microbiomedata/nmdc-schema/issues/2336
     from_schema: https://w3id.org/nmdc/nmdc
     range: ProtocolCategoryEnum
     required: true
   has_process_parts:
     name: has_process_parts
     description: A list of process parts that make up a protocol.
+    deprecated: not used https://github.com/microbiomedata/nmdc-schema/issues/2336
     from_schema: https://w3id.org/nmdc/nmdc
     list_elements_ordered: true
     range: PlannedProcess
@@ -19478,7 +19491,6 @@ classes:
     - manifest_set
     - material_processing_set
     - processed_sample_set
-    - protocol_execution_set
     - storage_process_set
     - study_set
     - workflow_execution_set
@@ -19641,6 +19653,7 @@ classes:
     name: ProtocolExecution
     description: A PlannedProces that has PlannedProcess parts. Can be used to represent
       the case of someone following a Protocol.
+    deprecated: not used, not fulfilling intended purpose https://github.com/microbiomedata/nmdc-schema/issues/2336
     from_schema: https://w3id.org/nmdc/nmdc
     is_a: PlannedProcess
     slots:


### PR DESCRIPTION
In this branch, I generated the release artifacts for NMDC Schema version `v11.4.0`. I did that by running:

```shell
$ docker compose run --rm -it --name nmdc-schema-builder app \
  sh -c 'poetry install && make squeaky-clean all test'
```

That's a Docker-based alternative to the `$ make squeaky-clean all test` command shown in the [release documentation](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md#making-a-release) (internal).