### PR TITLE
Add `Illumina NovaSeq 600` to `assets/misc/neon_sequencingMethod_to_nmdc_instrument_set.tsv`

### DIFF
--- a/assets/misc/neon_sequencingMethod_to_nmdc_instrument_set.tsv
+++ b/assets/misc/neon_sequencingMethod_to_nmdc_instrument_set.tsv
@@ -1,3 +1,4 @@
 NEON sequencingMethod	NMDC instrument_set id
 NextSeq550	nmdc:inst-14-xz5tb342
 Illumina HiSeq	nmdc:inst-14-79zxap02
+Illumina NovaSeq 6000	nmdc:inst-14-mr4r2w09


### PR DESCRIPTION
Some new `data_generation_set` records that were recently inserted into dev and prod Mongo for the NEON surface water study are missing the `instrument_used` slot on them.

These two records specifically:
* `nmdc:dgns-11-0ve44694`
* `nmdc:dgns-11-tzr8bn32`

We need to add the an instrument mapping for `Illumina NovaSeq 6000` for the NEON translators to pick it up correctly, so i'm adding it here.

We will also need to submit a changesheet to update the `instrument_used` slot value on both of those `data_generation_set` records to make sure the NCBI XML Export code that consumes it works properly.