### PR TITLE
add env triad grouping slot

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -951,6 +951,11 @@ enums:
 
 
 slots:
+  mixs_environmental_triad:
+    range: ControlledIdentifiedTermValue
+    description: >-
+      The MIxS environmental triad provides context about where a sample was collected from and what type of sample was collected.  
+      This information is required by the Genomic Standards Consortium (GSC).  For more information see https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS. 
   generates_calibration:
     range: CalibrationInformation
     description: calibration information is generated a process


### PR DESCRIPTION
This PR adds a grouping slot for the environmental triad and updates the MIxS slots to use is_a.