### PR TITLE
Cleanup: Move `ProtocolExecution` and related slots to `deprecated.yaml`

### DIFF
--- a/src/schema/deprecated.yaml
+++ b/src/schema/deprecated.yaml
@@ -58,6 +58,35 @@ classes:
       - type
     deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
 
+  ProtocolExecution:
+    class_uri: 'nmdc:ProtocolExecution'
+    is_a: PlannedProcess
+    description: A PlannedProces that has PlannedProcess parts. Can be used to represent the case of someone following a Protocol.
+    slots:
+      - has_process_parts
+      - protocol_execution_category
+    slot_usage:
+      id:
+        required: true
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:pex-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_input:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_output:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      has_process_parts:
+        required: true
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:(extrp|filtpr|dispro|poolp|libprp|subspr|mixpro|chcpr|cspro)-{id_shoulder}-{id_blade}$"
+          interpolated: true
+        description: The MaterialProcessing steps that are discrete parts of the ProtocolExecution.
+    deprecated: "not used, not fulfilling intended purpose https://github.com/microbiomedata/nmdc-schema/issues/2336"
+
 slots:
   omics_type:
     deprecated_element_has_exact_replacement: analyte_category
@@ -116,3 +145,19 @@ slots:
     multivalued: true
     inlined_as_list: true
     deprecated: "not used. 2024-11 https://github.com/microbiomedata/nmdc-schema/issues/2250"
+  protocol_execution_set:
+    mixins: object_set
+    range: ProtocolExecution
+    description: This property links a database object to the set of protocol executions within it.
+    deprecated: "not used https://github.com/microbiomedata/nmdc-schema/issues/2336"
+  protocol_execution_category:
+    range: ProtocolCategoryEnum
+    required: true
+    deprecated: "not used https://github.com/microbiomedata/nmdc-schema/issues/2336"
+  has_process_parts:
+    range: PlannedProcess
+    description: A list of process parts that make up a protocol.
+    required: true
+    multivalued: true
+    list_elements_ordered: true
+    deprecated: "not used https://github.com/microbiomedata/nmdc-schema/issues/2336"

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -475,35 +475,6 @@ classes:
           syntax: "{id_nmdc_prefix}:clsite-{id_shoulder}-{id_blade}$"
           interpolated: true
 
-  ProtocolExecution:
-    class_uri: 'nmdc:ProtocolExecution'
-    is_a: PlannedProcess
-    description: A PlannedProces that has PlannedProcess parts. Can be used to represent the case of someone following a Protocol.
-    slots:
-      - has_process_parts
-      - protocol_execution_category
-    slot_usage:
-      id:
-        required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:pex-{id_shoulder}-{id_blade}$"
-          interpolated: true
-      has_input:
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
-      has_output:
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
-      has_process_parts:
-        required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(extrp|filtpr|dispro|poolp|libprp|subspr|mixpro|chcpr|cspro)-{id_shoulder}-{id_blade}$"
-          interpolated: true
-        description: The MaterialProcessing steps that are discrete parts of the ProtocolExecution.
-    deprecated: "not used, not fulfilling intended purpose https://github.com/microbiomedata/nmdc-schema/issues/2336"
-
   SubSamplingProcess:
     class_uri: 'nmdc:SubSamplingProcess'
     description: >
@@ -1235,12 +1206,6 @@ slots:
     range: Manifest
     description: This property links a database object to the set of manifests within it.
 
-  protocol_execution_set:
-    mixins: object_set
-    range: ProtocolExecution
-    description: This property links a database object to the set of protocol executions within it.
-    deprecated: "not used https://github.com/microbiomedata/nmdc-schema/issues/2336"
-
   storage_process_set:
     mixins: object_set
     range: StorageProcess
@@ -1277,19 +1242,6 @@ slots:
     contributors:
       - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
       - ORCID:0000-0002-8683-0050 #Montana Smith
-
-  protocol_execution_category:
-    range: ProtocolCategoryEnum
-    required: true
-    deprecated: "not used https://github.com/microbiomedata/nmdc-schema/issues/2336"
-
-  has_process_parts:
-    range: PlannedProcess
-    description: A list of process parts that make up a protocol.
-    required: true
-    multivalued: true
-    list_elements_ordered: true
-    deprecated: "not used https://github.com/microbiomedata/nmdc-schema/issues/2336"
 
   filter_material:
     description: "A porous material on which solid particles present in air or other fluid which flows through it are largely caught and retained."


### PR DESCRIPTION
Follow up to https://github.com/microbiomedata/nmdc-schema/pull/2338. 
Moves class and slot definitions to `deprecated.yaml`