### PR TITLE
Add more range constraints to match range implied by structured_patterns.

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -356,6 +356,7 @@ classes:
         structured_pattern:
           syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
+        range: DataEmitterProcess
   DataEmitterProcess:
     class_uri: nmdc:DataEmitterProcess
     is_a: PlannedProcess
@@ -503,12 +504,9 @@ slots:
     range: PersonValue
     description: Principal Investigator who led the study and/or generated the dataset.
   was_generated_by:
-    range: WorkflowExecution
+    range: DataEmitterProcess
     mappings:
       - prov:wasGeneratedBy
-    any_of:
-      - range: WorkflowExecution
-      - range: DataGeneration
   associated_dois:
     description: A list of DOIs associated with a resource, such as a list of DOIS associated with a Study.
     aliases:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -356,9 +356,16 @@ classes:
         structured_pattern:
           syntax: "^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
+  DataEmitterProcess:
+    class_uri: nmdc:DataEmitterProcess
+    is_a: PlannedProcess
+    abstract: true
+    description: >-
+      A process that generates data objects as output.
+  
   DataGeneration:
     class_uri: nmdc:DataGeneration
-    is_a: PlannedProcess
+    is_a: DataEmitterProcess
     abstract: true
     aliases:
       - OmicsProcessing
@@ -405,7 +412,7 @@ classes:
   WorkflowExecution:
     abstract: true
     class_uri: nmdc:WorkflowExecution
-    is_a: PlannedProcess
+    is_a: DataEmitterProcess
     aliases:
       - analysis
     comments:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -243,6 +243,7 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
+        range: NucleotideSequencing
       gold_analysis_project_identifiers:
         structured_pattern:
           syntax: "^gold:Ga[0-9]+$"

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -224,10 +224,16 @@ classes:
           syntax: "{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}$"
           interpolated: true
 
+  AnnotatingWorkflow:
+    class_uri: nmdc:AnnotatingWorkflow
+    description: A WorkflowExecution whose output indicates the potential functions of genes or gene products
+    is_a: WorkflowExecution
+    abstract: true
+
   MetagenomeAnnotation:
     class_uri: nmdc:MetagenomeAnnotation
     description: A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
-    is_a: WorkflowExecution
+    is_a: AnnotatingWorkflow
     slots:
       - img_identifiers
       - gold_analysis_project_identifiers

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -320,7 +320,10 @@ classes:
           syntax: "{id_nmdc_prefix}:(wfmgan|wfmp|wfmtan)-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
         required: true
-        range: WorkflowExecution
+        any_of:
+          - range: MetagenomeAnnotation
+          - range: MetaproteomicsAnalysis
+          - range: MetatranscriptomeAnnotation
       count: 
           description: The number of sequences (for a metagenome or metatranscriptome) or spectra (for metaproteomics) associated with the specified function.
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -320,10 +320,7 @@ classes:
           syntax: "{id_nmdc_prefix}:(wfmgan|wfmp|wfmtan)-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
         required: true
-        any_of:
-          - range: MetagenomeAnnotation
-          - range: MetaproteomicsAnalysis
-          - range: MetatranscriptomeAnnotation
+        range: AnnotatingWorkflow
       count: 
           description: The number of sequences (for a metagenome or metatranscriptome) or spectra (for metaproteomics) associated with the specified function.
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -320,6 +320,7 @@ classes:
           syntax: "{id_nmdc_prefix}:(wfmgan|wfmp|wfmtan)-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
         required: true
+        range: WorkflowExecution
       count: 
           description: The number of sequences (for a metagenome or metatranscriptome) or spectra (for metaproteomics) associated with the specified function.
 

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -202,6 +202,7 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
+        range: Sample
       was_informed_by:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$"

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -108,7 +108,7 @@ classes:
 
   MetatranscriptomeAnnotation:
     class_uri: nmdc:MetatranscriptomeAnnotation
-    is_a: WorkflowExecution
+    is_a: AnnotatingWorkflow
     slots:
       - img_identifiers
       - gold_analysis_project_identifiers
@@ -271,7 +271,7 @@ classes:
 
   MetaproteomicsAnalysis:
     class_uri: nmdc:MetaproteomicsAnalysis
-    is_a: WorkflowExecution
+    is_a: AnnotatingWorkflow
     slots:
       - metaproteomics_analysis_category
     slot_usage:


### PR DESCRIPTION
Two grouping classes added:
- `DataEmitterProcess` - offspring of `PlannedProcess`, parent of `WorkflowExecution` and `DataGeneration`
- `AnnotatingWorkflow` - offspring of `WorkflowExecution`, parent of `MetagenomeAnnotation`, `MetatranscriptomeAnnotation`, and `MetaproteomicsAnalysis`

Closes #2393
Closes #2392 

Ranges added or altered
- `MetagenomeSequencing`'s `has_input` (`Sample`)
- `MetagenomeAnnotation`'s `was_informed_by` (`NucleotideSequencing`)
- `FunctionalAnnotationAggMember`'s `was_generated_by` (`AnnotatingWorkflow`)
- global `was_generated_by` (`DataEmitterProcess`)

Closes #2385 
Closes #2384 
Closes #2381 