### PR TITLE
Add metatranscriptome raw read permissible values to `FileTypeEnum`

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_4_0_to_11_5_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_4_0_to_11_5_0.py
@@ -1,0 +1,12 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.4.0"
+    _to_version = "11.5.0"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_5_0_to_11_5_1.py
+++ b/nmdc_schema/migrators/migrator_from_11_5_0_to_11_5_1.py
@@ -1,0 +1,12 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.5.0"
+    _to_version = "11.5.1"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
@@ -76,15 +76,18 @@ class Migrator(MigratorBase):
 
         >>> m = Migrator()
         >>> m.ids_of_metatranscriptome_data_generation_with_no_output = {'nmdc:dgns-11-12345678'}
-        >>> m.scan_workflow_execution_set({'id': 'nmdc:wfnom-11-12345678', 'was_informed_by': 'nmdc:dgns-11-12345678', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.scan_workflow_execution_set({'id': 'nmdc:wfmsa-11-12345678', 'type': 'nmdc:MetagenomeSequencing', 'was_informed_by': 'nmdc:dgns-11-12345678', 'has_output': ["nmdc:dobj-11-abcd1234"]})
         >>> m.ids_of_data_objects_to_update
         {'nmdc:dobj-11-abcd1234'}
         >>> m = Migrator()
         >>> m.ids_of_metatranscriptome_data_generation_with_no_output = {'nmdc:dgns-11-12345678'}
-        >>> m.scan_workflow_execution_set({'id': 'nmdc:wfnom-11-12345678', 'was_informed_by': 'nmdc:dgns-11-98765432', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.scan_workflow_execution_set({'id': 'nmdc:wfmsa-11-12345678', 'type': 'nmdc:MetagenomeSequencing', 'was_informed_by': 'nmdc:dgns-11-98765432', 'has_output': ["nmdc:dobj-11-abcd1234"]})
         >>> m.ids_of_data_objects_to_update
         set()
         """
+        if workflow_execution.get("type") != "nmdc:MetagenomeSequencing":
+            return
+
         if "was_informed_by" in workflow_execution:
             data_generation_id = workflow_execution["was_informed_by"]
             if data_generation_id in self.ids_of_metatranscriptome_data_generation_with_no_output:

--- a/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
@@ -1,4 +1,4 @@
-from adapters.adapter_base import AdapterBase
+from nmdc_schema.migrators.adapters.adapter_base import AdapterBase
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 

--- a/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
@@ -11,6 +11,7 @@ class Migrator(MigratorBase):
     def __init__(self, adapter: AdapterBase=None, logger=None):
         super().__init__(adapter, logger)
 
+        self.ids_of_metatranscriptome_data_generation_with_no_output = set()
         self.ids_of_data_objects_to_update = set()
         self.data_object_type_update_map = {
             "Metagenome Raw Reads": "Metatranscriptome Raw Reads",
@@ -20,29 +21,75 @@ class Migrator(MigratorBase):
 
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
-        self.adapter.do_for_each_document("data_generation_set", self.find_metatranscriptome_data_objects)
+
+        self.ids_of_metatranscriptome_data_generation_with_no_output = set()
+        self.ids_of_data_objects_to_update = set()
+
+        self.adapter.do_for_each_document("data_generation_set", self.scan_data_generation_set)
+        self.adapter.do_for_each_document("workflow_execution_set", self.scan_workflow_execution_set)
         self.logger.info(f"Found {len(self.ids_of_data_objects_to_update)} data objects to update.")
 
         self.adapter.process_each_document("data_object_set",[self.update_data_object_type])
 
-    def find_metatranscriptome_data_objects(self, data_generation: dict) -> None:
+    def scan_data_generation_set(self, data_generation: dict) -> None:
         r"""
         If the incoming data_generation object has analyte_category set to "metatranscriptome", and
-        it has_output a data_object with data_object_type set to "Metagenome Raw Reads", then
-        add the data_object to the set of ids_of_data_objects_to_update.
+        has_output is not set, add the id of the data_generation object to the set of
+        ids_of_metatranscriptome_data_generation_with_no_output. This set will be used when scanning
+        the workflow_execution_set. If the incoming data_generation object has analyte_category set
+        to "metatranscriptome", and has_output is set, add each data_generation id in the has_output
+        list to the set of ids_of_data_objects_to_update.
 
         >>> m = Migrator()
-        >>> m.find_metatranscriptome_data_objects({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metatranscriptome', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.scan_data_generation_set({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metatranscriptome', 'has_output': ["nmdc:dobj-11-abcd1234"]})
         >>> m.ids_of_data_objects_to_update
         {'nmdc:dobj-11-abcd1234'}
-        >>> m.find_metatranscriptome_data_objects({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metagenome', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.ids_of_metatranscriptome_data_generation_with_no_output
+        set()
+        >>> m = Migrator()
+        >>> m.scan_data_generation_set({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metagenome', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.ids_of_data_objects_to_update
+        set()
+        >>> m.ids_of_metatranscriptome_data_generation_with_no_output
+        set()
+        >>> m = Migrator()
+        >>> m.scan_data_generation_set({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metatranscriptome'})
+        >>> m.ids_of_data_objects_to_update
+        set()
+        >>> m.ids_of_metatranscriptome_data_generation_with_no_output
+        {'nmdc:dgns-11-12345678'}
+        """
+        if data_generation.get("analyte_category") == "metatranscriptome":
+            if "has_output" not in data_generation:
+                self.ids_of_metatranscriptome_data_generation_with_no_output.add(data_generation["id"])
+            else:
+                for output in data_generation.get("has_output", []):
+                    self.ids_of_data_objects_to_update.add(output)
+
+    def scan_workflow_execution_set(self, workflow_execution: dict) -> None:
+        r"""
+        If the incoming workflow_execution object has was_informed_by relationship to a
+        data_generation object that was flagged in the scan_data_generation_set step (i.e. it is
+        in the ids_of_metatranscriptome_data_generation_with_no_output set), and the
+        workflow_execution object has a has_output field, add each data_generation id in the
+        has_output list to the set of ids_of_data_objects_to_update.
+
+        >>> m = Migrator()
+        >>> m.ids_of_metatranscriptome_data_generation_with_no_output = {'nmdc:dgns-11-12345678'}
+        >>> m.scan_workflow_execution_set({'id': 'nmdc:wfnom-11-12345678', 'was_informed_by': 'nmdc:dgns-11-12345678', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.ids_of_data_objects_to_update
+        {'nmdc:dobj-11-abcd1234'}
+        >>> m = Migrator()
+        >>> m.ids_of_metatranscriptome_data_generation_with_no_output = {'nmdc:dgns-11-12345678'}
+        >>> m.scan_workflow_execution_set({'id': 'nmdc:wfnom-11-12345678', 'was_informed_by': 'nmdc:dgns-11-98765432', 'has_output': ["nmdc:dobj-11-abcd1234"]})
         >>> m.ids_of_data_objects_to_update
         set()
         """
-        self.ids_of_data_objects_to_update = set()
-        if data_generation.get("analyte_category") == "metatranscriptome":
-            for output in data_generation.get("has_output", []):
-                self.ids_of_data_objects_to_update.add(output)
+        if "was_informed_by" in workflow_execution:
+            data_generation_id = workflow_execution["was_informed_by"]
+            if data_generation_id in self.ids_of_metatranscriptome_data_generation_with_no_output:
+                for output in workflow_execution.get("has_output", []):
+                    self.ids_of_data_objects_to_update.add(output)
 
     def update_data_object_type(self, data_object: dict) -> dict:
         r"""
@@ -54,7 +101,7 @@ class Migrator(MigratorBase):
 
         >>> m = Migrator()
 
-        # In reality, this would be set by the find_metatranscriptome_data_objects method
+        # In reality, this would be set by scan_data_generation_set and scan_workflow_execution_set
         >>> m.ids_of_data_objects_to_update = {"nmdc:dobj-11-abcd1234"}
 
         >>> m.update_data_object_type({'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metagenome Raw Reads'})

--- a/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_5_1_to_11_6_0.py
@@ -1,0 +1,84 @@
+from adapters.adapter_base import AdapterBase
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.5.1"
+    _to_version = "11.6.0"
+
+    def __init__(self, adapter: AdapterBase=None, logger=None):
+        super().__init__(adapter, logger)
+
+        self.data_objects_to_update = set()
+        self.data_object_type_update_map = {
+            "Metagenome Raw Reads": "Metatranscriptome Raw Reads",
+            "Metagenome Raw Read 1": "Metatranscriptome Raw Read 1",
+            "Metagenome Raw Read 2": "Metatranscriptome Raw Read 2",
+        }
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        self.adapter.do_for_each_document("data_generation_set", self.find_metatranscriptome_data_objects)
+        self.logger.info(f"Found {len(self.data_objects_to_update)} data objects to update.")
+
+        self.adapter.process_each_document("data_object_set",[self.update_data_object_type])
+
+    def find_metatranscriptome_data_objects(self, data_generation: dict) -> None:
+        r"""
+        If the incoming data_generation object has analyte_category set to "metatranscriptome", and
+        it has_output a data_object with data_object_type set to "Metagenome Raw Reads", then
+        add the data_object to the set of data_objects_to_update.
+
+        >>> m = Migrator()
+        >>> m.find_metatranscriptome_data_objects({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metatranscriptome', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.data_objects_to_update
+        {'nmdc:dobj-11-abcd1234'}
+        >>> m.find_metatranscriptome_data_objects({'id': 'nmdc:dgns-11-12345678', 'analyte_category': 'metagenome', 'has_output': ["nmdc:dobj-11-abcd1234"]})
+        >>> m.data_objects_to_update
+        set()
+        """
+        self.data_objects_to_update = set()
+        if data_generation.get("analyte_category") == "metatranscriptome":
+            for output in data_generation.get("has_output", []):
+                self.data_objects_to_update.add(output)
+
+    def update_data_object_type(self, data_object: dict) -> dict:
+        r"""
+        Update the data_object_type of data_objects that are in the data_objects_to_update set. If
+        the current data_object_type is "Metagenome Raw Reads", change it to "Metatranscriptome Raw
+        Reads". If the data_object_type is "Metagenome Raw Read 1", change it to "Metatranscriptome
+        Raw Read 1". If the data_object_type is "Metagenome Raw Read 2", change it to
+        "Metatranscriptome Raw Read 2". Otherwise, do nothing.
+
+        >>> m = Migrator()
+
+        # In reality, this would be set by the find_metatranscriptome_data_objects method
+        >>> m.data_objects_to_update = {"nmdc:dobj-11-abcd1234"}
+
+        >>> m.update_data_object_type({'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metagenome Raw Reads'})
+        {'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metatranscriptome Raw Reads'}
+        >>> m.update_data_object_type({'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metagenome Raw Read 1'})
+        {'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metatranscriptome Raw Read 1'}
+        >>> m.update_data_object_type({'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metagenome Raw Read 2'})
+        {'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metatranscriptome Raw Read 2'}
+
+        # Don't update data_objects that have a data_object_type that we don't care about
+        >>> m.update_data_object_type({'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metagenome Bins Barplot'})
+        {'id': 'nmdc:dobj-11-abcd1234', 'data_object_type': 'Metagenome Bins Barplot'}
+
+        # Don't update data_objects that are not in the data_objects_to_update set
+        >>> m.update_data_object_type({'id': 'nmdc:dobj-11-wxyz9871', 'data_object_type': 'Metagenome Raw Reads'})
+        {'id': 'nmdc:dobj-11-wxyz9871', 'data_object_type': 'Metagenome Raw Reads'}
+        """
+        data_object_id = data_object["id"]
+        if data_object_id not in self.data_objects_to_update:
+            return data_object
+
+        data_object_type = data_object["data_object_type"]
+        if data_object_type not in self.data_object_type_update_map:
+            return data_object
+
+        data_object["data_object_type"] = self.data_object_type_update_map[data_object_type]
+        return data_object

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -641,19 +641,38 @@ enums:
         description: A file that contains data used to calibrate a natural organic matter or metabalomics analysis.
       
       Metagenome Raw Reads:
-        description: Interleaved paired-end raw sequencing data
+        description: Interleaved paired-end raw metagenome sequencing data
         annotations:
           file_name_pattern: '^\.fastq(\.gz)?$'
 
       Metagenome Raw Read 1:
-        description: Read 1 raw sequencing data, aka forward reads
+        description: Read 1 raw metagenome sequencing data, aka forward reads
         examples:
           value: "BMI_H25VYBGXH_19S_31WellG1_R1.fastq.gz"
         annotations:
           file_name_pattern: '^.+_R1\.fastq(\.gz)?$'
 
       Metagenome Raw Read 2:
-        description: Read 2 raw sequencing data, aka reverse reads
+        description: Read 2 raw metagenome sequencing data, aka reverse reads
+        examples:
+          value: "BMI_H25VYBGXH_19S_31WellG1_R2.fastq.gz"
+        annotations:
+          file_name_pattern: '^.+_R2\.fastq(\.gz)?$'
+
+      Metatranscriptome Raw Reads:
+        description: Interleaved paired-end raw metatranscriptome sequencing data
+        annotations:
+          file_name_pattern: '^\.fastq(\.gz)?$'
+
+      Metatranscriptome Raw Read 1:
+        description: Read 1 raw metatranscriptome sequencing data, aka forward reads
+        examples:
+          value: "BMI_H25VYBGXH_19S_31WellG1_R1.fastq.gz"
+        annotations:
+          file_name_pattern: '^.+_R1\.fastq(\.gz)?$'
+
+      Metatranscriptome Raw Read 2:
+        description: Read 2 raw metatranscriptome sequencing data, aka reverse reads
         examples:
           value: "BMI_H25VYBGXH_19S_31WellG1_R2.fastq.gz"
         annotations:


### PR DESCRIPTION
Fixes #2412 

These changes add three new permissible values to `FileTypeEnum`:

* `Metatranscriptome Raw Reads`
* `Metatranscriptome Raw Read 1`
* `Metatranscriptome Raw Read 2`

Additionally a migrator is added which does the following:

* Find records in `data_generation_set` with `analyte_category = metatranscriptome`.
* For each such `nmdc:DataGeneration` instance, find the the `nmdc:DataObject` instances associated via the `has_output` relationship
* Foe each such `nmdc:DataObject`, if the `data_object_type` is `Metagenome Raw Reads`, `Metagenome Raw Read 1`, or `Metagenome Raw Read 2`, change it to the equivalent `Metatranscriptome` value.