### PR TITLE
add lipidomics to PV list

### DIFF
--- a/src/schema/portal_enums.yaml
+++ b/src/schema/portal_enums.yaml
@@ -68,6 +68,7 @@ enums:
   AnalysisTypeEnum:
     permissible_values:
       metabolomics:
+      lipidomics:
       metagenomics:
         description: Standard short-read metagenomic sequencing
         title: Metagenomics


### PR DESCRIPTION
NMDC now supports lipidomics! And EMSL users send samples for lipidomics.
~Add it as a permissible value to AnalysisTypeEnum, and associate samples in the submission portal that have lipidomics with the EMSL tempalte~
-- Does this happen in NMDC schema or submission-schema?
-- submission-schema! Do this in a separate PR!

- [x] add lipidomics PV
- [ ] ~associate lipidomics with EMSL template~