### PR TITLE
Generate release artifacts for schema version `11.6.0`

### DIFF
--- a/nmdc_schema/nmdc-pydantic.py
+++ b/nmdc_schema/nmdc-pydantic.py
@@ -2056,16 +2056,24 @@ class FileTypeEnum(str, Enum):
     GeNomad_Aggregated_Classification = "GeNomad Aggregated Classification"
     # A file that contains data used to calibrate a natural organic matter or metabalomics analysis.
     Reference_Calibration_File = "Reference Calibration File"
-    # Interleaved paired-end raw sequencing data
+    # Interleaved paired-end raw metagenome sequencing data
     Metagenome_Raw_Reads = "Metagenome Raw Reads"
-    # Read 1 raw sequencing data, aka forward reads
+    # Read 1 raw metagenome sequencing data, aka forward reads
     Metagenome_Raw_Read_1 = "Metagenome Raw Read 1"
-    # Read 2 raw sequencing data, aka reverse reads
+    # Read 2 raw metagenome sequencing data, aka reverse reads
     Metagenome_Raw_Read_2 = "Metagenome Raw Read 2"
+    # Interleaved paired-end raw metatranscriptome sequencing data
+    Metatranscriptome_Raw_Reads = "Metatranscriptome Raw Reads"
+    # Read 1 raw metatranscriptome sequencing data, aka forward reads
+    Metatranscriptome_Raw_Read_1 = "Metatranscriptome Raw Read 1"
+    # Read 2 raw metatranscriptome sequencing data, aka reverse reads
+    Metatranscriptome_Raw_Read_2 = "Metatranscriptome Raw Read 2"
     # FT ICR-MS-based molecular formula assignment results table
     FT_ICR_MS_Analysis_Results = "FT ICR-MS Analysis Results"
     # GC-MS-based metabolite assignment results table
     GC_MS_Metabolomics_Results = "GC-MS Metabolomics Results"
+    # LC-MS-based metabolite assignment results table
+    LC_MS_Metabolomics_Results = "LC-MS Metabolomics Results"
     # Aggregate workflow statistics file
     Metaproteomics_Workflow_Statistics = "Metaproteomics Workflow Statistics"
     # Filtered protein report file
@@ -2210,6 +2218,8 @@ class FileTypeEnum(str, Enum):
     LC_MS_Lipidomics_Results = "LC-MS Lipidomics Results"
     # Processed data for the LC-MS-based lipidomics analysis in hdf5 format
     LC_MS_Lipidomics_Processed_Data = "LC-MS Lipidomics Processed Data"
+    # Processed data for the LC-MS-based metabolomics analysis in hdf5 format
+    LC_MS_Metabolomics_Processed_Data = "LC-MS Metabolomics Processed Data"
     # FASTA amino acid file for contaminant proteins commonly observed in proteomics data.
     Contaminants_Amino_Acid_FASTA = "Contaminants Amino Acid FASTA"
     # A configuration file used by a single computational software tool that stores settings that are specific to that tool.
@@ -2351,6 +2361,7 @@ class RNASampleFormatEnum(str, Enum):
 
 class AnalysisTypeEnum(str, Enum):
     metabolomics = "metabolomics"
+    lipidomics = "lipidomics"
     # Standard short-read metagenomic sequencing
     Metagenomics = "metagenomics"
     # Long-read metagenomic sequencing
@@ -2456,12 +2467,12 @@ class FunctionalAnnotationAggMember(ConfiguredBaseModel):
                                   'name': 'count'},
                         'was_generated_by': {'name': 'was_generated_by',
                                              'pattern': '^(nmdc):(wfmgan|wfmp|wfmtan)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\\.[0-9]{1,})$',
+                                             'range': 'AnnotatingWorkflow',
                                              'required': True,
                                              'structured_pattern': {'interpolated': True,
                                                                     'syntax': '{id_nmdc_prefix}:(wfmgan|wfmp|wfmtan)-{id_shoulder}-{id_blade}{id_version}$'}}}})
 
     was_generated_by: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'was_generated_by',
-         'any_of': [{'range': 'WorkflowExecution'}, {'range': 'DataGeneration'}],
          'domain_of': ['FunctionalAnnotationAggMember',
                        'FunctionalAnnotation',
                        'DataObject'],
@@ -2561,7 +2572,7 @@ class Database(ConfiguredBaseModel):
          'domain_of': ['Database'],
          'mixins': ['object_set']} })
     study_set: Optional[List[Study]] = Field(None, description="""This property links a database object to the set of studies within it.""", json_schema_extra = { "linkml_meta": {'alias': 'study_set', 'domain_of': ['Database'], 'mixins': ['object_set']} })
-    workflow_execution_set: Optional[List[Union[WorkflowExecution,MetagenomeAnnotation,MetagenomeAssembly,MetatranscriptomeAssembly,MetatranscriptomeAnnotation,MetatranscriptomeExpressionAnalysis,MagsAnalysis,MetagenomeSequencing,ReadQcAnalysis,ReadBasedTaxonomyAnalysis,MetabolomicsAnalysis,MetaproteomicsAnalysis,NomAnalysis]]] = Field(None, description="""This property links a database object to the set of workflow executions.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_execution_set',
+    workflow_execution_set: Optional[List[Union[WorkflowExecution,AnnotatingWorkflow,MetagenomeAssembly,MetatranscriptomeAssembly,MetatranscriptomeExpressionAnalysis,MagsAnalysis,MetagenomeSequencing,ReadQcAnalysis,ReadBasedTaxonomyAnalysis,MetabolomicsAnalysis,NomAnalysis,MetagenomeAnnotation,MetatranscriptomeAnnotation,MetaproteomicsAnalysis]]] = Field(None, description="""This property links a database object to the set of workflow executions.""", json_schema_extra = { "linkml_meta": {'alias': 'workflow_execution_set',
          'domain_of': ['Database'],
          'mixins': ['object_set']} })
 
@@ -2645,7 +2656,6 @@ class PortionOfSubstance(ConfiguredBaseModel):
     mass: Optional[QuantityValue] = Field(None, title="mass", description="""A physical quality that inheres in a bearer by virtue of the proportion of the bearer's amount of matter.""", json_schema_extra = { "linkml_meta": {'alias': 'mass',
          'domain_of': ['SubSamplingProcess', 'PortionOfSubstance'],
          'exact_mappings': ['PATO:0000125']} })
-    sample_state_information: Optional[SampleStateEnum] = Field(None, description="""The chemical phase of a pure sample, or the state of a mixed sample""", json_schema_extra = { "linkml_meta": {'alias': 'sample_state_information', 'domain_of': ['PortionOfSubstance']} })
     source_concentration: Optional[QuantityValue] = Field(None, description="""When solutions A (containing substance X) and B are combined together, this slot captures the concentration of X in solution A""", json_schema_extra = { "linkml_meta": {'alias': 'source_concentration',
          'domain_of': ['PortionOfSubstance'],
          'is_a': 'concentration'} })
@@ -2934,7 +2944,6 @@ class FunctionalAnnotation(ConfiguredBaseModel):
                    'or closed']} })
     subject: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'subject', 'domain_of': ['FunctionalAnnotation', 'OntologyRelation']} })
     was_generated_by: Optional[str] = Field(None, description="""provenance for the annotation.""", json_schema_extra = { "linkml_meta": {'alias': 'was_generated_by',
-         'any_of': [{'range': 'WorkflowExecution'}, {'range': 'DataGeneration'}],
          'domain_of': ['FunctionalAnnotationAggMember',
                        'FunctionalAnnotation',
                        'DataObject'],
@@ -11970,10 +11979,12 @@ class StorageProcess(PlannedProcess):
          'related_mappings': ['OBI:0302893'],
          'slot_usage': {'has_input': {'name': 'has_input',
                                       'pattern': '^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                      'range': 'Sample',
                                       'structured_pattern': {'interpolated': True,
                                                              'syntax': '{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$'}},
                         'has_output': {'name': 'has_output',
                                        'pattern': '^(nmdc):procsm-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                       'range': 'ProcessedSample',
                                        'structured_pattern': {'interpolated': True,
                                                               'syntax': '{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$'}},
                         'id': {'name': 'id',
@@ -12158,7 +12169,9 @@ class MaterialProcessing(PlannedProcess):
                                                               'syntax': '{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$'}}}})
 
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -12239,6 +12252,18 @@ class MaterialProcessing(PlannedProcess):
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
 
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
+
     @field_validator('has_input')
     def pattern_has_input(cls, v):
         pattern=re.compile(r"^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
@@ -12315,7 +12340,9 @@ class Pooling(MaterialProcessing):
                                                       'syntax': '{id_nmdc_prefix}:poolp-{id_shoulder}-{id_blade}$'}}}})
 
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: List[str] = Field(..., description="""An input to a process.""", min_length=2, json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -12397,6 +12424,18 @@ class Pooling(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -12498,7 +12537,9 @@ class Extraction(MaterialProcessing):
                        'MobilePhaseSegment',
                        'PortionOfSubstance']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: List[str] = Field(..., description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -12580,6 +12621,18 @@ class Extraction(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -12707,7 +12760,9 @@ class LibraryPreparation(MaterialProcessing):
          'string_serialization': 'FWD:{dna};REV:{dna}'} })
     stranded_orientation: Optional[StrandedOrientationEnum] = Field(None, description="""Lists the strand orientiation for a stranded RNA library preparation.""", json_schema_extra = { "linkml_meta": {'alias': 'stranded_orientation', 'domain_of': ['LibraryPreparation']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: List[str] = Field(..., description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -12789,6 +12844,18 @@ class LibraryPreparation(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -12910,7 +12977,9 @@ class SubSamplingProcess(MaterialProcessing):
          'exact_mappings': ['PATO:0000125']} })
     sampled_portion: Optional[List[SamplePortionEnum]] = Field(None, description="""The portion of the sample that is taken for downstream activity.""", json_schema_extra = { "linkml_meta": {'alias': 'sampled_portion', 'domain_of': ['SubSamplingProcess']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -12992,6 +13061,18 @@ class SubSamplingProcess(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -13082,7 +13163,9 @@ class MixingProcess(MaterialProcessing):
                        'MobilePhaseSegment'],
          'examples': [{'value': "JsonObj(has_numeric_value=2, has_unit='hours')"}]} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -13163,6 +13246,18 @@ class MixingProcess(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -13272,7 +13367,9 @@ class FiltrationProcess(MaterialProcessing):
                        'MobilePhaseSegment',
                        'PortionOfSubstance']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -13354,6 +13451,18 @@ class FiltrationProcess(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -13446,7 +13555,9 @@ class ChromatographicSeparationProcess(MaterialProcessing):
                        'ChemicalConversionProcess'],
          'notes': ['Not to be confused with the MIXS:0000113']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -13527,6 +13638,18 @@ class ChromatographicSeparationProcess(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -13615,7 +13738,9 @@ class DissolvingProcess(MaterialProcessing):
                        'ChemicalConversionProcess',
                        'MobilePhaseSegment']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -13697,6 +13822,18 @@ class DissolvingProcess(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -13790,7 +13927,9 @@ class ChemicalConversionProcess(MaterialProcessing):
                        'MobilePhaseSegment']} })
     substances_volume: Optional[QuantityValue] = Field(None, description="""The volume of the combined substances that was included in a ChemicalConversionProcess.""", json_schema_extra = { "linkml_meta": {'alias': 'substances_volume', 'domain_of': ['ChemicalConversionProcess']} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
          'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
@@ -13872,6 +14011,18 @@ class ChemicalConversionProcess(MaterialProcessing):
          'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
                                                              'literal_form': 'workflow_execution_class',
                                                              'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
 
     @field_validator('has_input')
     def pattern_has_input(cls, v):
@@ -14020,10 +14171,17 @@ class Doi(ConfiguredBaseModel):
                                    'doi_provider is required.',
                     'postconditions': {'slot_conditions': {'doi_provider': {'name': 'doi_provider',
                                                                             'required': True}}},
-                    'preconditions': {'slot_conditions': {'doi_category': {'any_of': [{'equals_string': 'dataset_doi'},
-                                                                                      {'equals_string': 'award_doi'}],
+                    'preconditions': {'slot_conditions': {'doi_category': {'equals_string': 'dataset_doi',
                                                                            'name': 'doi_category'}}},
-                    'title': 'dataset_award_dois_required'}]})
+                    'title': 'dataset_dois_require_provider'},
+                   {'description': 'If doi_category is a publication_doi, then '
+                                   'doi_provider is not required. Otherwise, '
+                                   'doi_provider is required.',
+                    'postconditions': {'slot_conditions': {'doi_provider': {'name': 'doi_provider',
+                                                                            'required': True}}},
+                    'preconditions': {'slot_conditions': {'doi_category': {'equals_string': 'award_doi',
+                                                                           'name': 'doi_category'}}},
+                    'title': 'award_dois_require_provider'}]})
 
     doi_value: str = Field(..., description="""A digital object identifier, which is intended to persistantly identify some resource on the web.""", json_schema_extra = { "linkml_meta": {'alias': 'doi_value',
          'aliases': ['DOI', 'digital object identifier'],
@@ -15318,6 +15476,7 @@ class DataObject(InformationObject):
                         'name': {'name': 'name', 'required': True},
                         'was_generated_by': {'name': 'was_generated_by',
                                              'pattern': '^^(nmdc):(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\\.[0-9]{1,})$|^^(nmdc):(omprc|dgms|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                             'range': 'DataEmitterProcess',
                                              'structured_pattern': {'interpolated': True,
                                                                     'syntax': '^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -15343,7 +15502,6 @@ class DataObject(InformationObject):
          'domain_of': ['ImageValue', 'Protocol', 'DataObject'],
          'notes': ['See issue 207 - this clashes with the mixs field']} })
     was_generated_by: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'was_generated_by',
-         'any_of': [{'range': 'WorkflowExecution'}, {'range': 'DataGeneration'}],
          'domain_of': ['FunctionalAnnotationAggMember',
                        'FunctionalAnnotation',
                        'DataObject'],
@@ -15474,7 +15632,112 @@ class DataObject(InformationObject):
         return v
 
 
-class DataGeneration(PlannedProcess):
+class DataEmitterProcess(PlannedProcess):
+    """
+    A process that generates data objects as output.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
+         'class_uri': 'nmdc:DataEmitterProcess',
+         'from_schema': 'https://w3id.org/nmdc/nmdc'})
+
+    has_input: Optional[List[str]] = Field(None, description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input', 'aliases': ['input'], 'domain_of': ['PlannedProcess']} })
+    has_output: Optional[List[str]] = Field(None, description="""An output from a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_output', 'aliases': ['output'], 'domain_of': ['PlannedProcess']} })
+    processing_institution: Optional[ProcessingInstitutionEnum] = Field(None, description="""The organization that processed the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'processing_institution', 'domain_of': ['PlannedProcess']} })
+    protocol_link: Optional[Protocol] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'protocol_link', 'domain_of': ['PlannedProcess', 'Study']} })
+    start_date: Optional[str] = Field(None, description="""The date on which any process or activity was started""", json_schema_extra = { "linkml_meta": {'alias': 'start_date',
+         'comments': ['We are using string representations of dates until all '
+                      'components of our ecosystem can handle ISO 8610 dates',
+                      'The date should be formatted as YYYY-MM-DD'],
+         'domain_of': ['PlannedProcess'],
+         'todos': ['add date string validation pattern']} })
+    end_date: Optional[str] = Field(None, description="""The date on which any process or activity was ended""", json_schema_extra = { "linkml_meta": {'alias': 'end_date',
+         'comments': ['We are using string representations of dates until all '
+                      'components of our ecosystem can handle ISO 8610 dates',
+                      'The date should be formatted as YYYY-MM-DD'],
+         'domain_of': ['PlannedProcess'],
+         'todos': ['add date string validation pattern']} })
+    qc_status: Optional[StatusEnum] = Field(None, description="""Stores information about the result of a process (ie the process of sequencing a library may have for qc_status of 'fail' if not enough data was generated)""", json_schema_extra = { "linkml_meta": {'alias': 'qc_status', 'domain_of': ['PlannedProcess']} })
+    qc_comment: Optional[str] = Field(None, description="""Slot to store additional comments about laboratory or workflow output. For workflow output it may describe the particular workflow stage that failed. (ie Failed at call-stage due to a malformed fastq file).""", json_schema_extra = { "linkml_meta": {'alias': 'qc_comment', 'domain_of': ['PlannedProcess']} })
+    has_failure_categorization: Optional[List[FailureCategorization]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'has_failure_categorization', 'domain_of': ['PlannedProcess']} })
+    id: str = Field(..., description="""A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'domain_of': ['NamedThing'],
+         'examples': [{'description': 'https://github.com/microbiomedata/nmdc-schema/pull/499#discussion_r1018499248',
+                       'value': 'nmdc:mgmag-00-x012.1_7_c1'}],
+         'notes': ['abstracted pattern: '
+                   'prefix:typecode-authshoulder-blade(.version)?(_seqsuffix)?',
+                   'a minimum length of 3 characters is suggested for typecodes, but 1 '
+                   'or 2 characters will be accepted',
+                   'typecodes must correspond 1:1 to a class in the NMDC schema. this '
+                   'will be checked via per-class id slot usage assertions',
+                   'minting authority shoulders should probably be enumerated and '
+                   'checked in the pattern'],
+         'structured_aliases': {'data_object_id': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                   'literal_form': 'data_object_id',
+                                                   'predicate': 'NARROW_SYNONYM'},
+                                'workflow_execution_id': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                          'literal_form': 'workflow_execution_id',
+                                                          'predicate': 'NARROW_SYNONYM'}}} })
+    name: Optional[str] = Field(None, description="""A human readable label for an entity""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['PersonValue', 'NamedThing', 'Protocol']} })
+    description: Optional[str] = Field(None, description="""a human-readable description of a thing""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['ImageValue', 'NamedThing'],
+         'slot_uri': 'dcterms:description'} })
+    alternative_identifiers: Optional[List[str]] = Field(None, description="""A list of alternative identifiers for the entity.""", json_schema_extra = { "linkml_meta": {'alias': 'alternative_identifiers',
+         'domain_of': ['MetaboliteIdentification', 'NamedThing']} })
+    type: Literal["https://w3id.org/nmdc/DataEmitterProcess","nmdc:DataEmitterProcess"] = Field("nmdc:DataEmitterProcess", description="""the class_uri of the class that has been instantiated""", json_schema_extra = { "linkml_meta": {'alias': 'type',
+         'designates_type': True,
+         'domain_of': ['EukEval',
+                       'FunctionalAnnotationAggMember',
+                       'MobilePhaseSegment',
+                       'PortionOfSubstance',
+                       'MagBin',
+                       'MetaboliteIdentification',
+                       'GenomeFeature',
+                       'FunctionalAnnotation',
+                       'AttributeValue',
+                       'NamedThing',
+                       'OntologyRelation',
+                       'FailureCategorization',
+                       'Protocol',
+                       'CreditAssociation',
+                       'Doi'],
+         'examples': [{'value': 'nmdc:Biosample'}, {'value': 'nmdc:Study'}],
+         'notes': ['replaces legacy nmdc:type slot',
+                   'makes it easier to read example data files',
+                   'required for polymorphic MongoDB collections'],
+         'see_also': ['https://github.com/microbiomedata/nmdc-schema/issues/1048',
+                      'https://github.com/microbiomedata/nmdc-schema/issues/1233',
+                      'https://github.com/microbiomedata/nmdc-schema/issues/248'],
+         'slot_uri': 'rdf:type',
+         'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                             'literal_form': 'workflow_execution_class',
+                                                             'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('id')
+    def pattern_id(cls, v):
+        pattern=re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid id format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid id format: {v}")
+        return v
+
+    @field_validator('alternative_identifiers')
+    def pattern_alternative_identifiers(cls, v):
+        pattern=re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,\(\)\=\#]*$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid alternative_identifiers format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid alternative_identifiers format: {v}")
+        return v
+
+
+class DataGeneration(DataEmitterProcess):
     """
     The methods and processes used to generate omics data from a biosample or organism.
     """
@@ -15519,7 +15782,9 @@ class DataGeneration(PlannedProcess):
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:(sty)-{id_shoulder}-{id_blade}$'}} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     mod_date: Optional[str] = Field(None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'alias': 'mod_date', 'domain_of': ['Biosample', 'DataGeneration']} })
     principal_investigator: Optional[PersonValue] = Field(None, description="""Principal Investigator who led the study and/or generated the dataset.""", json_schema_extra = { "linkml_meta": {'alias': 'principal_investigator',
          'aliases': ['PI'],
@@ -15614,6 +15879,18 @@ class DataGeneration(PlannedProcess):
         elif isinstance(v,str):
             if not pattern.match(v):
                 raise ValueError(f"Invalid associated_studies format: {v}")
+        return v
+
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
         return v
 
     @field_validator('has_input')
@@ -15729,7 +16006,9 @@ class NucleotideSequencing(DataGeneration):
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:(sty)-{id_shoulder}-{id_blade}$'}} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     mod_date: Optional[str] = Field(None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'alias': 'mod_date', 'domain_of': ['Biosample', 'DataGeneration']} })
     principal_investigator: Optional[PersonValue] = Field(None, description="""Principal Investigator who led the study and/or generated the dataset.""", json_schema_extra = { "linkml_meta": {'alias': 'principal_investigator',
          'aliases': ['PI'],
@@ -15864,6 +16143,18 @@ class NucleotideSequencing(DataGeneration):
                 raise ValueError(f"Invalid associated_studies format: {v}")
         return v
 
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
+
     @field_validator('has_input')
     def pattern_has_input(cls, v):
         pattern=re.compile(r"^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
@@ -15929,14 +16220,21 @@ class MassSpectrometry(DataGeneration):
                                                                                            'name': 'eluent_introduction_category'}}},
                     'title': 'generates_calibration_required_if_gc'},
                    {'description': 'If eluent_introduction_category is '
-                                   'liquid_chromatography or gas_chromatography, then '
+                                   'liquid_chromatography, then '
                                    'has_chromatography_configuration is required.',
                     'postconditions': {'slot_conditions': {'has_chromatography_configuration': {'name': 'has_chromatography_configuration',
                                                                                                 'required': True}}},
-                    'preconditions': {'slot_conditions': {'eluent_introduction_category': {'any_of': [{'equals_string': 'liquid_chromatography'},
-                                                                                                      {'equals_string': 'gas_chromatography'}],
+                    'preconditions': {'slot_conditions': {'eluent_introduction_category': {'equals_string': 'liquid_chromatography',
                                                                                            'name': 'eluent_introduction_category'}}},
-                    'title': 'has_chromatography_configuration_required_if_lc_or_gc'}],
+                    'title': 'has_chromatography_configuration_required_if_lc'},
+                   {'description': 'If eluent_introduction_category is '
+                                   'gas_chromatography, then '
+                                   'has_chromatography_configuration is required.',
+                    'postconditions': {'slot_conditions': {'has_chromatography_configuration': {'name': 'has_chromatography_configuration',
+                                                                                                'required': True}}},
+                    'preconditions': {'slot_conditions': {'eluent_introduction_category': {'equals_string': 'gas_chromatography',
+                                                                                           'name': 'eluent_introduction_category'}}},
+                    'title': 'has_chromatography_configuration_required_if_gc'}],
          'slot_usage': {'analyte_category': {'name': 'analyte_category',
                                              'range': 'MassSpectrometryEnum'},
                         'has_chromatography_configuration': {'name': 'has_chromatography_configuration',
@@ -15979,7 +16277,9 @@ class MassSpectrometry(DataGeneration):
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:(sty)-{id_shoulder}-{id_blade}$'}} })
     instrument_used: Optional[List[str]] = Field(None, description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'alias': 'instrument_used',
-         'domain_of': ['MaterialProcessing', 'DataGeneration']} })
+         'domain_of': ['MaterialProcessing', 'DataGeneration'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
     mod_date: Optional[str] = Field(None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'alias': 'mod_date', 'domain_of': ['Biosample', 'DataGeneration']} })
     principal_investigator: Optional[PersonValue] = Field(None, description="""Principal Investigator who led the study and/or generated the dataset.""", json_schema_extra = { "linkml_meta": {'alias': 'principal_investigator',
          'aliases': ['PI'],
@@ -16114,6 +16414,18 @@ class MassSpectrometry(DataGeneration):
                 raise ValueError(f"Invalid associated_studies format: {v}")
         return v
 
+    @field_validator('instrument_used')
+    def pattern_instrument_used(cls, v):
+        pattern=re.compile(r"^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid instrument_used format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid instrument_used format: {v}")
+        return v
+
     @field_validator('has_input')
     def pattern_has_input(cls, v):
         pattern=re.compile(r"^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
@@ -16163,7 +16475,7 @@ class MassSpectrometry(DataGeneration):
         return v
 
 
-class WorkflowExecution(PlannedProcess):
+class WorkflowExecution(DataEmitterProcess):
     """
     Represents an instance of an execution of a particular workflow
     """
@@ -16198,11 +16510,13 @@ class WorkflowExecution(PlannedProcess):
                         'git_url': {'name': 'git_url', 'required': True},
                         'has_input': {'name': 'has_input',
                                       'pattern': '^(nmdc):(dobj)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                      'range': 'DataObject',
                                       'required': True,
                                       'structured_pattern': {'interpolated': True,
                                                              'syntax': '{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$'}},
                         'has_output': {'name': 'has_output',
                                        'pattern': '^(nmdc):(dobj)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                       'range': 'DataObject',
                                        'structured_pattern': {'interpolated': True,
                                                               'syntax': '{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$'}},
                         'started_at_time': {'name': 'started_at_time',
@@ -16389,7 +16703,194 @@ class WorkflowExecution(PlannedProcess):
         return v
 
 
-class MetagenomeAnnotation(WorkflowExecution):
+class AnnotatingWorkflow(WorkflowExecution):
+    """
+    A WorkflowExecution whose output indicates the potential functions of genes or gene products
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'abstract': True,
+         'class_uri': 'nmdc:AnnotatingWorkflow',
+         'from_schema': 'https://w3id.org/nmdc/nmdc'})
+
+    ended_at_time: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'ended_at_time',
+         'domain_of': ['WorkflowExecution'],
+         'mappings': ['prov:endedAtTime'],
+         'notes': ['The regex for ISO-8601 format was taken from here: '
+                   'https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ '
+                   'It may not be complete, but it is good enough for now.']} })
+    execution_resource: ExecutionResourceEnum = Field(..., description="""The computing resource or facility where the workflow was executed.""", json_schema_extra = { "linkml_meta": {'alias': 'execution_resource',
+         'domain_of': ['WorkflowExecution'],
+         'examples': [{'value': 'NERSC-Cori'}]} })
+    git_url: str = Field(..., description="""The url that points to the exact github location of a workflow.""", json_schema_extra = { "linkml_meta": {'alias': 'git_url',
+         'domain_of': ['WorkflowExecution'],
+         'examples': [{'value': 'https://github.com/microbiomedata/mg_annotation/releases/tag/0.1'},
+                      {'value': 'https://github.com/microbiomedata/metaMS/blob/master/metaMS/gcmsWorkflow.py'}]} })
+    started_at_time: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'started_at_time',
+         'domain_of': ['WorkflowExecution'],
+         'mappings': ['prov:startedAtTime'],
+         'notes': ['The regex for ISO-8601 format was taken from here: '
+                   'https://www.myintervals.com/blog/2009/05/20/iso-8601-date-validation-that-doesnt-suck/ '
+                   'It may not be complete, but it is good enough for now.']} })
+    version: Optional[str] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'version', 'domain_of': ['WorkflowExecution']} })
+    was_informed_by: str = Field(..., json_schema_extra = { "linkml_meta": {'alias': 'was_informed_by',
+         'domain_of': ['WorkflowExecution'],
+         'mappings': ['prov:wasInformedBy'],
+         'structured_aliases': {'was_informed_by': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                    'literal_form': 'was_informed_by',
+                                                    'predicate': 'EXACT_SYNONYM'}}} })
+    has_input: List[str] = Field(..., description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_input',
+         'aliases': ['input'],
+         'domain_of': ['PlannedProcess'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$'}} })
+    has_output: Optional[List[str]] = Field(None, description="""An output from a process.""", json_schema_extra = { "linkml_meta": {'alias': 'has_output',
+         'aliases': ['output'],
+         'domain_of': ['PlannedProcess'],
+         'structured_pattern': {'interpolated': True,
+                                'syntax': '{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$'}} })
+    processing_institution: Optional[ProcessingInstitutionEnum] = Field(None, description="""The organization that processed the sample.""", json_schema_extra = { "linkml_meta": {'alias': 'processing_institution', 'domain_of': ['PlannedProcess']} })
+    protocol_link: Optional[Protocol] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'protocol_link', 'domain_of': ['PlannedProcess', 'Study']} })
+    start_date: Optional[str] = Field(None, description="""The date on which any process or activity was started""", json_schema_extra = { "linkml_meta": {'alias': 'start_date',
+         'comments': ['We are using string representations of dates until all '
+                      'components of our ecosystem can handle ISO 8610 dates',
+                      'The date should be formatted as YYYY-MM-DD'],
+         'domain_of': ['PlannedProcess'],
+         'todos': ['add date string validation pattern']} })
+    end_date: Optional[str] = Field(None, description="""The date on which any process or activity was ended""", json_schema_extra = { "linkml_meta": {'alias': 'end_date',
+         'comments': ['We are using string representations of dates until all '
+                      'components of our ecosystem can handle ISO 8610 dates',
+                      'The date should be formatted as YYYY-MM-DD'],
+         'domain_of': ['PlannedProcess'],
+         'todos': ['add date string validation pattern']} })
+    qc_status: Optional[StatusEnum] = Field(None, description="""Stores information about the result of a process (ie the process of sequencing a library may have for qc_status of 'fail' if not enough data was generated)""", json_schema_extra = { "linkml_meta": {'alias': 'qc_status', 'domain_of': ['PlannedProcess']} })
+    qc_comment: Optional[str] = Field(None, description="""Slot to store additional comments about laboratory or workflow output. For workflow output it may describe the particular workflow stage that failed. (ie Failed at call-stage due to a malformed fastq file).""", json_schema_extra = { "linkml_meta": {'alias': 'qc_comment', 'domain_of': ['PlannedProcess']} })
+    has_failure_categorization: Optional[List[FailureCategorization]] = Field(None, json_schema_extra = { "linkml_meta": {'alias': 'has_failure_categorization', 'domain_of': ['PlannedProcess']} })
+    id: str = Field(..., description="""A unique identifier for a thing. Must be either a CURIE shorthand for a URI or a complete URI""", json_schema_extra = { "linkml_meta": {'alias': 'id',
+         'domain_of': ['NamedThing'],
+         'examples': [{'description': 'https://github.com/microbiomedata/nmdc-schema/pull/499#discussion_r1018499248',
+                       'value': 'nmdc:mgmag-00-x012.1_7_c1'}],
+         'notes': ['abstracted pattern: '
+                   'prefix:typecode-authshoulder-blade(.version)?(_seqsuffix)?',
+                   'a minimum length of 3 characters is suggested for typecodes, but 1 '
+                   'or 2 characters will be accepted',
+                   'typecodes must correspond 1:1 to a class in the NMDC schema. this '
+                   'will be checked via per-class id slot usage assertions',
+                   'minting authority shoulders should probably be enumerated and '
+                   'checked in the pattern'],
+         'structured_aliases': {'data_object_id': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                   'literal_form': 'data_object_id',
+                                                   'predicate': 'NARROW_SYNONYM'},
+                                'workflow_execution_id': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                          'literal_form': 'workflow_execution_id',
+                                                          'predicate': 'NARROW_SYNONYM'}}} })
+    name: Optional[str] = Field(None, description="""A human readable label for an entity""", json_schema_extra = { "linkml_meta": {'alias': 'name', 'domain_of': ['PersonValue', 'NamedThing', 'Protocol']} })
+    description: Optional[str] = Field(None, description="""a human-readable description of a thing""", json_schema_extra = { "linkml_meta": {'alias': 'description',
+         'domain_of': ['ImageValue', 'NamedThing'],
+         'slot_uri': 'dcterms:description'} })
+    alternative_identifiers: Optional[List[str]] = Field(None, description="""A list of alternative identifiers for the entity.""", json_schema_extra = { "linkml_meta": {'alias': 'alternative_identifiers',
+         'domain_of': ['MetaboliteIdentification', 'NamedThing']} })
+    type: Literal["https://w3id.org/nmdc/AnnotatingWorkflow","nmdc:AnnotatingWorkflow"] = Field("nmdc:AnnotatingWorkflow", description="""the class_uri of the class that has been instantiated""", json_schema_extra = { "linkml_meta": {'alias': 'type',
+         'designates_type': True,
+         'domain_of': ['EukEval',
+                       'FunctionalAnnotationAggMember',
+                       'MobilePhaseSegment',
+                       'PortionOfSubstance',
+                       'MagBin',
+                       'MetaboliteIdentification',
+                       'GenomeFeature',
+                       'FunctionalAnnotation',
+                       'AttributeValue',
+                       'NamedThing',
+                       'OntologyRelation',
+                       'FailureCategorization',
+                       'Protocol',
+                       'CreditAssociation',
+                       'Doi'],
+         'examples': [{'value': 'nmdc:Biosample'}, {'value': 'nmdc:Study'}],
+         'notes': ['replaces legacy nmdc:type slot',
+                   'makes it easier to read example data files',
+                   'required for polymorphic MongoDB collections'],
+         'see_also': ['https://github.com/microbiomedata/nmdc-schema/issues/1048',
+                      'https://github.com/microbiomedata/nmdc-schema/issues/1233',
+                      'https://github.com/microbiomedata/nmdc-schema/issues/248'],
+         'slot_uri': 'rdf:type',
+         'structured_aliases': {'workflow_execution_class': {'contexts': ['https://bitbucket.org/berkeleylab/jgi-jat/macros/nmdc_metadata.yaml'],
+                                                             'literal_form': 'workflow_execution_class',
+                                                             'predicate': 'NARROW_SYNONYM'}}} })
+
+    @field_validator('ended_at_time')
+    def pattern_ended_at_time(cls, v):
+        pattern=re.compile(r"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid ended_at_time format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid ended_at_time format: {v}")
+        return v
+
+    @field_validator('started_at_time')
+    def pattern_started_at_time(cls, v):
+        pattern=re.compile(r"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid started_at_time format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid started_at_time format: {v}")
+        return v
+
+    @field_validator('has_input')
+    def pattern_has_input(cls, v):
+        pattern=re.compile(r"^(nmdc):(dobj)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid has_input format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid has_input format: {v}")
+        return v
+
+    @field_validator('has_output')
+    def pattern_has_output(cls, v):
+        pattern=re.compile(r"^(nmdc):(dobj)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid has_output format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid has_output format: {v}")
+        return v
+
+    @field_validator('id')
+    def pattern_id(cls, v):
+        pattern=re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid id format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid id format: {v}")
+        return v
+
+    @field_validator('alternative_identifiers')
+    def pattern_alternative_identifiers(cls, v):
+        pattern=re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,\(\)\=\#]*$")
+        if isinstance(v,list):
+            for element in v:
+                if isinstance(v, str) and not pattern.match(element):
+                    raise ValueError(f"Invalid alternative_identifiers format: {element}")
+        elif isinstance(v,str):
+            if not pattern.match(v):
+                raise ValueError(f"Invalid alternative_identifiers format: {v}")
+        return v
+
+
+class MetagenomeAnnotation(AnnotatingWorkflow):
     """
     A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
     """
@@ -16408,6 +16909,7 @@ class MetagenomeAnnotation(WorkflowExecution):
                                             'name': 'img_identifiers'},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -16662,6 +17164,7 @@ class MetagenomeAssembly(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfmgas-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -16967,6 +17470,7 @@ class MetatranscriptomeAssembly(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfmtas-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -17262,7 +17766,7 @@ class MetatranscriptomeAssembly(WorkflowExecution):
         return v
 
 
-class MetatranscriptomeAnnotation(WorkflowExecution):
+class MetatranscriptomeAnnotation(AnnotatingWorkflow):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:MetatranscriptomeAnnotation',
          'from_schema': 'https://w3id.org/nmdc/nmdc',
          'slot_usage': {'gold_analysis_project_identifiers': {'name': 'gold_analysis_project_identifiers',
@@ -17286,6 +17790,7 @@ class MetatranscriptomeAnnotation(WorkflowExecution):
                                             'name': 'img_identifiers'},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -17540,6 +18045,7 @@ class MetatranscriptomeExpressionAnalysis(WorkflowExecution):
                                             'name': 'img_identifiers'},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -17776,6 +18282,7 @@ class MagsAnalysis(WorkflowExecution):
                                             'name': 'img_identifiers'},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}},
          'title': 'Metagenome-Assembled Genome analysis activity'})
@@ -18012,6 +18519,7 @@ class MetagenomeSequencing(WorkflowExecution):
          'from_schema': 'https://w3id.org/nmdc/nmdc',
          'slot_usage': {'has_input': {'name': 'has_input',
                                       'pattern': '^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                      'range': 'Sample',
                                       'structured_pattern': {'interpolated': True,
                                                              'syntax': '{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$'}},
                         'id': {'name': 'id',
@@ -18021,6 +18529,7 @@ class MetagenomeSequencing(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfmsa-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}},
          'title': 'Metagenome sequencing activity'})
@@ -18233,6 +18742,7 @@ class ReadQcAnalysis(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfrqc-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}},
          'title': 'Read quality control analysis activity'})
@@ -18459,6 +18969,7 @@ class ReadBasedTaxonomyAnalysis(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfrbt-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'NucleotideSequencing',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'}}},
          'title': 'Read based analysis activity'})
@@ -18668,6 +19179,7 @@ class MetabolomicsAnalysis(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfmb-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgms)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'MassSpectrometry',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgms)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -18889,7 +19401,7 @@ class MetabolomicsAnalysis(WorkflowExecution):
         return v
 
 
-class MetaproteomicsAnalysis(WorkflowExecution):
+class MetaproteomicsAnalysis(AnnotatingWorkflow):
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:MetaproteomicsAnalysis',
          'from_schema': 'https://w3id.org/nmdc/nmdc',
          'slot_usage': {'id': {'name': 'id',
@@ -18899,6 +19411,7 @@ class MetaproteomicsAnalysis(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfmp-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgms)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'MassSpectrometry',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgms)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -19109,6 +19622,7 @@ class NomAnalysis(WorkflowExecution):
                                                       'syntax': '{id_nmdc_prefix}:wfnom-{id_shoulder}-{id_blade}{id_version}$'}},
                         'was_informed_by': {'name': 'was_informed_by',
                                             'pattern': '^(nmdc):(omprc|dgms)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$',
+                                            'range': 'MassSpectrometry',
                                             'structured_pattern': {'interpolated': True,
                                                                    'syntax': '{id_nmdc_prefix}:(omprc|dgms)-{id_shoulder}-{id_blade}$'}}}})
 
@@ -19387,10 +19901,12 @@ ChromatographyConfiguration.model_rebuild()
 Manifest.model_rebuild()
 CalibrationInformation.model_rebuild()
 DataObject.model_rebuild()
+DataEmitterProcess.model_rebuild()
 DataGeneration.model_rebuild()
 NucleotideSequencing.model_rebuild()
 MassSpectrometry.model_rebuild()
 WorkflowExecution.model_rebuild()
+AnnotatingWorkflow.model_rebuild()
 MetagenomeAnnotation.model_rebuild()
 MetagenomeAssembly.model_rebuild()
 MetatranscriptomeAssembly.model_rebuild()

--- a/nmdc_schema/nmdc.py
+++ b/nmdc_schema/nmdc.py
@@ -1,5 +1,5 @@
 # Auto generated from nmdc.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-03-12T17:17:40
+# Generation date: 2025-04-16T00:57:58
 # Schema: NMDC
 #
 # id: https://w3id.org/nmdc/nmdc
@@ -339,7 +339,11 @@ class DataObjectId(InformationObjectId):
     pass
 
 
-class DataGenerationId(PlannedProcessId):
+class DataEmitterProcessId(PlannedProcessId):
+    pass
+
+
+class DataGenerationId(DataEmitterProcessId):
     pass
 
 
@@ -351,7 +355,7 @@ class MassSpectrometryId(DataGenerationId):
     pass
 
 
-class WorkflowExecutionId(PlannedProcessId):
+class WorkflowExecutionId(DataEmitterProcessId):
     pass
 
 
@@ -360,10 +364,6 @@ class MetagenomeAssemblyId(WorkflowExecutionId):
 
 
 class MetatranscriptomeAssemblyId(WorkflowExecutionId):
-    pass
-
-
-class MetatranscriptomeAnnotationId(WorkflowExecutionId):
     pass
 
 
@@ -391,15 +391,23 @@ class MetabolomicsAnalysisId(WorkflowExecutionId):
     pass
 
 
-class MetaproteomicsAnalysisId(WorkflowExecutionId):
-    pass
-
-
 class NomAnalysisId(WorkflowExecutionId):
     pass
 
 
-class MetagenomeAnnotationId(WorkflowExecutionId):
+class AnnotatingWorkflowId(WorkflowExecutionId):
+    pass
+
+
+class MetatranscriptomeAnnotationId(AnnotatingWorkflowId):
+    pass
+
+
+class MetaproteomicsAnalysisId(AnnotatingWorkflowId):
+    pass
+
+
+class MetagenomeAnnotationId(AnnotatingWorkflowId):
     pass
 
 
@@ -450,7 +458,7 @@ class FunctionalAnnotationAggMember(YAMLRoot):
     class_name: ClassVar[str] = "FunctionalAnnotationAggMember"
     class_model_uri: ClassVar[URIRef] = NMDC.FunctionalAnnotationAggMember
 
-    was_generated_by: Union[str, WorkflowExecutionId] = None
+    was_generated_by: Union[str, AnnotatingWorkflowId] = None
     gene_function_id: Union[str, URIorCURIE] = None
     count: int = None
     type: Union[str, URIorCURIE] = None
@@ -458,8 +466,8 @@ class FunctionalAnnotationAggMember(YAMLRoot):
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.was_generated_by):
             self.MissingRequiredField("was_generated_by")
-        if not isinstance(self.was_generated_by, WorkflowExecutionId):
-            self.was_generated_by = WorkflowExecutionId(self.was_generated_by)
+        if not isinstance(self.was_generated_by, AnnotatingWorkflowId):
+            self.was_generated_by = AnnotatingWorkflowId(self.was_generated_by)
 
         if self._is_empty(self.gene_function_id):
             self.MissingRequiredField("gene_function_id")
@@ -707,7 +715,6 @@ class PortionOfSubstance(YAMLRoot):
     type: Union[str, URIorCURIE] = None
     final_concentration: Optional[Union[dict, "QuantityValue"]] = None
     mass: Optional[Union[dict, "QuantityValue"]] = None
-    sample_state_information: Optional[Union[str, "SampleStateEnum"]] = None
     source_concentration: Optional[Union[dict, "QuantityValue"]] = None
     known_as: Optional[Union[str, "ChemicalEntityEnum"]] = None
     substance_role: Optional[Union[str, "SubstanceRoleEnum"]] = None
@@ -723,9 +730,6 @@ class PortionOfSubstance(YAMLRoot):
 
         if self.mass is not None and not isinstance(self.mass, QuantityValue):
             self.mass = QuantityValue(**as_dict(self.mass))
-
-        if self.sample_state_information is not None and not isinstance(self.sample_state_information, SampleStateEnum):
-            self.sample_state_information = SampleStateEnum(self.sample_state_information)
 
         if self.source_concentration is not None and not isinstance(self.source_concentration, QuantityValue):
             self.source_concentration = QuantityValue(**as_dict(self.source_concentration))
@@ -4377,8 +4381,8 @@ class StorageProcess(PlannedProcess):
     substances_used: Optional[Union[Union[dict, PortionOfSubstance], List[Union[dict, PortionOfSubstance]]]] = empty_list()
     contained_in: Optional[Union[str, "ContainerCategoryEnum"]] = None
     temperature: Optional[Union[dict, QuantityValue]] = None
-    has_input: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
-    has_output: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
+    has_input: Optional[Union[Union[str, SampleId], List[Union[str, SampleId]]]] = empty_list()
+    has_output: Optional[Union[Union[str, ProcessedSampleId], List[Union[str, ProcessedSampleId]]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -4398,11 +4402,11 @@ class StorageProcess(PlannedProcess):
 
         if not isinstance(self.has_input, list):
             self.has_input = [self.has_input] if self.has_input is not None else []
-        self.has_input = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_input]
+        self.has_input = [v if isinstance(v, SampleId) else SampleId(v) for v in self.has_input]
 
         if not isinstance(self.has_output, list):
             self.has_output = [self.has_output] if self.has_output is not None else []
-        self.has_output = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_output]
+        self.has_output = [v if isinstance(v, ProcessedSampleId) else ProcessedSampleId(v) for v in self.has_output]
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -5487,7 +5491,7 @@ class DataObject(InformationObject):
     insdc_experiment_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
     md5_checksum: Optional[str] = None
     url: Optional[str] = None
-    was_generated_by: Optional[Union[str, WorkflowExecutionId]] = None
+    was_generated_by: Optional[Union[str, DataEmitterProcessId]] = None
     in_manifest: Optional[Union[Union[str, ManifestId], List[Union[str, ManifestId]]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
@@ -5528,8 +5532,8 @@ class DataObject(InformationObject):
         if self.url is not None and not isinstance(self.url, str):
             self.url = str(self.url)
 
-        if self.was_generated_by is not None and not isinstance(self.was_generated_by, WorkflowExecutionId):
-            self.was_generated_by = WorkflowExecutionId(self.was_generated_by)
+        if self.was_generated_by is not None and not isinstance(self.was_generated_by, DataEmitterProcessId):
+            self.was_generated_by = DataEmitterProcessId(self.was_generated_by)
 
         if not isinstance(self.in_manifest, list):
             self.in_manifest = [self.in_manifest] if self.in_manifest is not None else []
@@ -5542,7 +5546,30 @@ class DataObject(InformationObject):
 
 
 @dataclass(repr=False)
-class DataGeneration(PlannedProcess):
+class DataEmitterProcess(PlannedProcess):
+    """
+    A process that generates data objects as output.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = NMDC["DataEmitterProcess"]
+    class_class_curie: ClassVar[str] = "nmdc:DataEmitterProcess"
+    class_name: ClassVar[str] = "DataEmitterProcess"
+    class_model_uri: ClassVar[URIRef] = NMDC.DataEmitterProcess
+
+    id: Union[str, DataEmitterProcessId] = None
+    type: Union[str, URIorCURIE] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_class_curie)
+
+
+@dataclass(repr=False)
+class DataGeneration(DataEmitterProcess):
     """
     The methods and processes used to generate omics data from a biosample or organism.
     """
@@ -5720,7 +5747,7 @@ class MassSpectrometry(DataGeneration):
 
 
 @dataclass(repr=False)
-class WorkflowExecution(PlannedProcess):
+class WorkflowExecution(DataEmitterProcess):
     """
     Represents an instance of an execution of a particular workflow
     """
@@ -5737,10 +5764,10 @@ class WorkflowExecution(PlannedProcess):
     git_url: str = None
     started_at_time: str = None
     was_informed_by: Union[str, DataGenerationId] = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     ended_at_time: Optional[str] = None
     version: Optional[str] = None
-    has_output: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
+    has_output: Optional[Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.execution_resource):
@@ -5767,7 +5794,7 @@ class WorkflowExecution(PlannedProcess):
             self.MissingRequiredField("has_input")
         if not isinstance(self.has_input, list):
             self.has_input = [self.has_input] if self.has_input is not None else []
-        self.has_input = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_input]
+        self.has_input = [v if isinstance(v, DataObjectId) else DataObjectId(v) for v in self.has_input]
 
         if self.ended_at_time is not None and not isinstance(self.ended_at_time, str):
             self.ended_at_time = str(self.ended_at_time)
@@ -5777,7 +5804,7 @@ class WorkflowExecution(PlannedProcess):
 
         if not isinstance(self.has_output, list):
             self.has_output = [self.has_output] if self.has_output is not None else []
-        self.has_output = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_output]
+        self.has_output = [v if isinstance(v, DataObjectId) else DataObjectId(v) for v in self.has_output]
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -5802,7 +5829,7 @@ class MetagenomeAssembly(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     asm_score: Optional[float] = None
     scaffolds: Optional[float] = None
     scaf_logsum: Optional[float] = None
@@ -5831,7 +5858,7 @@ class MetagenomeAssembly(WorkflowExecution):
     num_input_reads: Optional[float] = None
     num_aligned_reads: Optional[float] = None
     insdc_assembly_identifiers: Optional[str] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -5923,8 +5950,8 @@ class MetagenomeAssembly(WorkflowExecution):
         if self.insdc_assembly_identifiers is not None and not isinstance(self.insdc_assembly_identifiers, str):
             self.insdc_assembly_identifiers = str(self.insdc_assembly_identifiers)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -5946,7 +5973,7 @@ class MetatranscriptomeAssembly(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     asm_score: Optional[float] = None
     scaffolds: Optional[float] = None
     scaf_logsum: Optional[float] = None
@@ -5975,7 +6002,7 @@ class MetatranscriptomeAssembly(WorkflowExecution):
     num_input_reads: Optional[float] = None
     num_aligned_reads: Optional[float] = None
     insdc_assembly_identifiers: Optional[str] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6067,59 +6094,8 @@ class MetatranscriptomeAssembly(WorkflowExecution):
         if self.insdc_assembly_identifiers is not None and not isinstance(self.insdc_assembly_identifiers, str):
             self.insdc_assembly_identifiers = str(self.insdc_assembly_identifiers)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
-
-        super().__post_init__(**kwargs)
-        if self._is_empty(self.type):
-            self.MissingRequiredField("type")
-        self.type = str(self.class_class_curie)
-
-
-@dataclass(repr=False)
-class MetatranscriptomeAnnotation(WorkflowExecution):
-    _inherited_slots: ClassVar[List[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = NMDC["MetatranscriptomeAnnotation"]
-    class_class_curie: ClassVar[str] = "nmdc:MetatranscriptomeAnnotation"
-    class_name: ClassVar[str] = "MetatranscriptomeAnnotation"
-    class_model_uri: ClassVar[URIRef] = NMDC.MetatranscriptomeAnnotation
-
-    id: Union[str, MetatranscriptomeAnnotationId] = None
-    type: Union[str, URIorCURIE] = None
-    execution_resource: Union[str, "ExecutionResourceEnum"] = None
-    git_url: str = None
-    started_at_time: str = None
-    img_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
-    gold_analysis_project_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
-    has_input: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
-    has_output: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
-
-    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
-        if self._is_empty(self.id):
-            self.MissingRequiredField("id")
-        if not isinstance(self.id, MetatranscriptomeAnnotationId):
-            self.id = MetatranscriptomeAnnotationId(self.id)
-
-        if not isinstance(self.img_identifiers, list):
-            self.img_identifiers = [self.img_identifiers] if self.img_identifiers is not None else []
-        self.img_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.img_identifiers]
-
-        if not isinstance(self.gold_analysis_project_identifiers, list):
-            self.gold_analysis_project_identifiers = [self.gold_analysis_project_identifiers] if self.gold_analysis_project_identifiers is not None else []
-        self.gold_analysis_project_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.gold_analysis_project_identifiers]
-
-        if not isinstance(self.has_input, list):
-            self.has_input = [self.has_input] if self.has_input is not None else []
-        self.has_input = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_input]
-
-        if not isinstance(self.has_output, list):
-            self.has_output = [self.has_output] if self.has_output is not None else []
-        self.has_output = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_output]
-
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6144,9 +6120,9 @@ class MetatranscriptomeExpressionAnalysis(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     img_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6158,8 +6134,8 @@ class MetatranscriptomeExpressionAnalysis(WorkflowExecution):
             self.img_identifiers = [self.img_identifiers] if self.img_identifiers is not None else []
         self.img_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.img_identifiers]
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6184,7 +6160,7 @@ class MagsAnalysis(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     binned_contig_num: Optional[int] = None
     input_contig_num: Optional[int] = None
     low_depth_contig_num: Optional[int] = None
@@ -6192,7 +6168,7 @@ class MagsAnalysis(WorkflowExecution):
     too_short_contig_num: Optional[int] = None
     unbinned_contig_num: Optional[int] = None
     img_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6223,8 +6199,8 @@ class MagsAnalysis(WorkflowExecution):
             self.img_identifiers = [self.img_identifiers] if self.img_identifiers is not None else []
         self.img_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.img_identifiers]
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6250,8 +6226,8 @@ class MetagenomeSequencing(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    has_input: Optional[Union[Union[str, SampleId], List[Union[str, SampleId]]]] = empty_list()
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6261,10 +6237,10 @@ class MetagenomeSequencing(WorkflowExecution):
 
         if not isinstance(self.has_input, list):
             self.has_input = [self.has_input] if self.has_input is not None else []
-        self.has_input = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_input]
+        self.has_input = [v if isinstance(v, SampleId) else SampleId(v) for v in self.has_input]
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6291,14 +6267,14 @@ class ReadQcAnalysis(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     input_base_count: Optional[float] = None
     input_read_bases: Optional[float] = None
     input_read_count: Optional[float] = None
     output_base_count: Optional[float] = None
     output_read_bases: Optional[float] = None
     output_read_count: Optional[float] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6324,8 +6300,8 @@ class ReadQcAnalysis(WorkflowExecution):
         if self.output_read_count is not None and not isinstance(self.output_read_count, float):
             self.output_read_count = float(self.output_read_count)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6350,8 +6326,8 @@ class ReadBasedTaxonomyAnalysis(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6359,8 +6335,8 @@ class ReadBasedTaxonomyAnalysis(WorkflowExecution):
         if not isinstance(self.id, ReadBasedTaxonomyAnalysisId):
             self.id = ReadBasedTaxonomyAnalysisId(self.id)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6382,11 +6358,11 @@ class MetabolomicsAnalysis(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     metabolomics_analysis_category: Union[str, "MetabolomicsAnalysisCategoryEnum"] = None
     has_metabolite_identifications: Optional[Union[Union[dict, MetaboliteIdentification], List[Union[dict, MetaboliteIdentification]]]] = empty_list()
     uses_calibration: Optional[Union[str, CalibrationInformationId]] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, MassSpectrometryId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6406,46 +6382,8 @@ class MetabolomicsAnalysis(WorkflowExecution):
         if self.uses_calibration is not None and not isinstance(self.uses_calibration, CalibrationInformationId):
             self.uses_calibration = CalibrationInformationId(self.uses_calibration)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
-
-        super().__post_init__(**kwargs)
-        if self._is_empty(self.type):
-            self.MissingRequiredField("type")
-        self.type = str(self.class_class_curie)
-
-
-@dataclass(repr=False)
-class MetaproteomicsAnalysis(WorkflowExecution):
-    _inherited_slots: ClassVar[List[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = NMDC["MetaproteomicsAnalysis"]
-    class_class_curie: ClassVar[str] = "nmdc:MetaproteomicsAnalysis"
-    class_name: ClassVar[str] = "MetaproteomicsAnalysis"
-    class_model_uri: ClassVar[URIRef] = NMDC.MetaproteomicsAnalysis
-
-    id: Union[str, MetaproteomicsAnalysisId] = None
-    type: Union[str, URIorCURIE] = None
-    execution_resource: Union[str, "ExecutionResourceEnum"] = None
-    git_url: str = None
-    started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
-    metaproteomics_analysis_category: Union[str, "MetaproteomicsAnalysisCategoryEnum"] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
-
-    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
-        if self._is_empty(self.id):
-            self.MissingRequiredField("id")
-        if not isinstance(self.id, MetaproteomicsAnalysisId):
-            self.id = MetaproteomicsAnalysisId(self.id)
-
-        if self._is_empty(self.metaproteomics_analysis_category):
-            self.MissingRequiredField("metaproteomics_analysis_category")
-        if not isinstance(self.metaproteomics_analysis_category, MetaproteomicsAnalysisCategoryEnum):
-            self.metaproteomics_analysis_category = MetaproteomicsAnalysisCategoryEnum(self.metaproteomics_analysis_category)
-
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, MassSpectrometryId):
+            self.was_informed_by = MassSpectrometryId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6467,9 +6405,9 @@ class NomAnalysis(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     uses_calibration: Optional[Union[str, CalibrationInformationId]] = None
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, MassSpectrometryId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6480,8 +6418,8 @@ class NomAnalysis(WorkflowExecution):
         if self.uses_calibration is not None and not isinstance(self.uses_calibration, CalibrationInformationId):
             self.uses_calibration = CalibrationInformationId(self.uses_calibration)
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, MassSpectrometryId):
+            self.was_informed_by = MassSpectrometryId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -6490,7 +6428,124 @@ class NomAnalysis(WorkflowExecution):
 
 
 @dataclass(repr=False)
-class MetagenomeAnnotation(WorkflowExecution):
+class AnnotatingWorkflow(WorkflowExecution):
+    """
+    A WorkflowExecution whose output indicates the potential functions of genes or gene products
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = NMDC["AnnotatingWorkflow"]
+    class_class_curie: ClassVar[str] = "nmdc:AnnotatingWorkflow"
+    class_name: ClassVar[str] = "AnnotatingWorkflow"
+    class_model_uri: ClassVar[URIRef] = NMDC.AnnotatingWorkflow
+
+    id: Union[str, AnnotatingWorkflowId] = None
+    type: Union[str, URIorCURIE] = None
+    execution_resource: Union[str, "ExecutionResourceEnum"] = None
+    git_url: str = None
+    started_at_time: str = None
+    was_informed_by: Union[str, DataGenerationId] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_class_curie)
+
+
+@dataclass(repr=False)
+class MetatranscriptomeAnnotation(AnnotatingWorkflow):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = NMDC["MetatranscriptomeAnnotation"]
+    class_class_curie: ClassVar[str] = "nmdc:MetatranscriptomeAnnotation"
+    class_name: ClassVar[str] = "MetatranscriptomeAnnotation"
+    class_model_uri: ClassVar[URIRef] = NMDC.MetatranscriptomeAnnotation
+
+    id: Union[str, MetatranscriptomeAnnotationId] = None
+    type: Union[str, URIorCURIE] = None
+    execution_resource: Union[str, "ExecutionResourceEnum"] = None
+    git_url: str = None
+    started_at_time: str = None
+    img_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
+    gold_analysis_project_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
+    has_input: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
+    has_output: Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]] = empty_list()
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, MetatranscriptomeAnnotationId):
+            self.id = MetatranscriptomeAnnotationId(self.id)
+
+        if not isinstance(self.img_identifiers, list):
+            self.img_identifiers = [self.img_identifiers] if self.img_identifiers is not None else []
+        self.img_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.img_identifiers]
+
+        if not isinstance(self.gold_analysis_project_identifiers, list):
+            self.gold_analysis_project_identifiers = [self.gold_analysis_project_identifiers] if self.gold_analysis_project_identifiers is not None else []
+        self.gold_analysis_project_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.gold_analysis_project_identifiers]
+
+        if not isinstance(self.has_input, list):
+            self.has_input = [self.has_input] if self.has_input is not None else []
+        self.has_input = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_input]
+
+        if not isinstance(self.has_output, list):
+            self.has_output = [self.has_output] if self.has_output is not None else []
+        self.has_output = [v if isinstance(v, NamedThingId) else NamedThingId(v) for v in self.has_output]
+
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_class_curie)
+
+
+@dataclass(repr=False)
+class MetaproteomicsAnalysis(AnnotatingWorkflow):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = NMDC["MetaproteomicsAnalysis"]
+    class_class_curie: ClassVar[str] = "nmdc:MetaproteomicsAnalysis"
+    class_name: ClassVar[str] = "MetaproteomicsAnalysis"
+    class_model_uri: ClassVar[URIRef] = NMDC.MetaproteomicsAnalysis
+
+    id: Union[str, MetaproteomicsAnalysisId] = None
+    type: Union[str, URIorCURIE] = None
+    execution_resource: Union[str, "ExecutionResourceEnum"] = None
+    git_url: str = None
+    started_at_time: str = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
+    metaproteomics_analysis_category: Union[str, "MetaproteomicsAnalysisCategoryEnum"] = None
+    was_informed_by: Optional[Union[str, MassSpectrometryId]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, MetaproteomicsAnalysisId):
+            self.id = MetaproteomicsAnalysisId(self.id)
+
+        if self._is_empty(self.metaproteomics_analysis_category):
+            self.MissingRequiredField("metaproteomics_analysis_category")
+        if not isinstance(self.metaproteomics_analysis_category, MetaproteomicsAnalysisCategoryEnum):
+            self.metaproteomics_analysis_category = MetaproteomicsAnalysisCategoryEnum(self.metaproteomics_analysis_category)
+
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, MassSpectrometryId):
+            self.was_informed_by = MassSpectrometryId(self.was_informed_by)
+
+        super().__post_init__(**kwargs)
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        self.type = str(self.class_class_curie)
+
+
+@dataclass(repr=False)
+class MetagenomeAnnotation(AnnotatingWorkflow):
     """
     A workflow execution activity that provides functional and structural annotation of assembled metagenome contigs
     """
@@ -6506,10 +6561,10 @@ class MetagenomeAnnotation(WorkflowExecution):
     execution_resource: Union[str, "ExecutionResourceEnum"] = None
     git_url: str = None
     started_at_time: str = None
-    has_input: Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]] = None
+    has_input: Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]] = None
     img_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
     gold_analysis_project_identifiers: Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]] = empty_list()
-    was_informed_by: Optional[Union[str, DataGenerationId]] = None
+    was_informed_by: Optional[Union[str, NucleotideSequencingId]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self._is_empty(self.id):
@@ -6525,8 +6580,8 @@ class MetagenomeAnnotation(WorkflowExecution):
             self.gold_analysis_project_identifiers = [self.gold_analysis_project_identifiers] if self.gold_analysis_project_identifiers is not None else []
         self.gold_analysis_project_identifiers = [v if isinstance(v, ExternalIdentifier) else ExternalIdentifier(v) for v in self.gold_analysis_project_identifiers]
 
-        if self.was_informed_by is not None and not isinstance(self.was_informed_by, DataGenerationId):
-            self.was_informed_by = DataGenerationId(self.was_informed_by)
+        if self.was_informed_by is not None and not isinstance(self.was_informed_by, NucleotideSequencingId):
+            self.was_informed_by = NucleotideSequencingId(self.was_informed_by)
 
         super().__post_init__(**kwargs)
         if self._is_empty(self.type):
@@ -7354,15 +7409,27 @@ class FileTypeEnum(EnumDefinitionImpl):
         setattr(cls, "Metagenome Raw Reads",
             PermissibleValue(
                 text="Metagenome Raw Reads",
-                description="Interleaved paired-end raw sequencing data"))
+                description="Interleaved paired-end raw metagenome sequencing data"))
         setattr(cls, "Metagenome Raw Read 1",
             PermissibleValue(
                 text="Metagenome Raw Read 1",
-                description="Read 1 raw sequencing data, aka forward reads"))
+                description="Read 1 raw metagenome sequencing data, aka forward reads"))
         setattr(cls, "Metagenome Raw Read 2",
             PermissibleValue(
                 text="Metagenome Raw Read 2",
-                description="Read 2 raw sequencing data, aka reverse reads"))
+                description="Read 2 raw metagenome sequencing data, aka reverse reads"))
+        setattr(cls, "Metatranscriptome Raw Reads",
+            PermissibleValue(
+                text="Metatranscriptome Raw Reads",
+                description="Interleaved paired-end raw metatranscriptome sequencing data"))
+        setattr(cls, "Metatranscriptome Raw Read 1",
+            PermissibleValue(
+                text="Metatranscriptome Raw Read 1",
+                description="Read 1 raw metatranscriptome sequencing data, aka forward reads"))
+        setattr(cls, "Metatranscriptome Raw Read 2",
+            PermissibleValue(
+                text="Metatranscriptome Raw Read 2",
+                description="Read 2 raw metatranscriptome sequencing data, aka reverse reads"))
         setattr(cls, "FT ICR-MS Analysis Results",
             PermissibleValue(
                 text="FT ICR-MS Analysis Results",
@@ -7371,6 +7438,10 @@ class FileTypeEnum(EnumDefinitionImpl):
             PermissibleValue(
                 text="GC-MS Metabolomics Results",
                 description="GC-MS-based metabolite assignment results table"))
+        setattr(cls, "LC-MS Metabolomics Results",
+            PermissibleValue(
+                text="LC-MS Metabolomics Results",
+                description="LC-MS-based metabolite assignment results table"))
         setattr(cls, "Metaproteomics Workflow Statistics",
             PermissibleValue(
                 text="Metaproteomics Workflow Statistics",
@@ -7659,6 +7730,10 @@ class FileTypeEnum(EnumDefinitionImpl):
             PermissibleValue(
                 text="LC-MS Lipidomics Processed Data",
                 description="Processed data for the LC-MS-based lipidomics analysis in hdf5 format"))
+        setattr(cls, "LC-MS Metabolomics Processed Data",
+            PermissibleValue(
+                text="LC-MS Metabolomics Processed Data",
+                description="Processed data for the LC-MS-based metabolomics analysis in hdf5 format"))
         setattr(cls, "Contaminants Amino Acid FASTA",
             PermissibleValue(
                 text="Contaminants Amino Acid FASTA",
@@ -7934,6 +8009,7 @@ class RNASampleFormatEnum(EnumDefinitionImpl):
 class AnalysisTypeEnum(EnumDefinitionImpl):
 
     metabolomics = PermissibleValue(text="metabolomics")
+    lipidomics = PermissibleValue(text="lipidomics")
     metagenomics = PermissibleValue(
         text="metagenomics",
         description="Standard short-read metagenomic sequencing")
@@ -10473,9 +10549,6 @@ slots.smiles = Slot(uri=NMDC.smiles, name="smiles", curie=NMDC.curie('smiles'),
 slots.volume = Slot(uri=NMDC.volume, name="volume", curie=NMDC.curie('volume'),
                    model_uri=NMDC.volume, domain=None, range=Optional[Union[dict, QuantityValue]])
 
-slots.sample_state_information = Slot(uri=NMDC.sample_state_information, name="sample_state_information", curie=NMDC.curie('sample_state_information'),
-                   model_uri=NMDC.sample_state_information, domain=None, range=Optional[Union[str, "SampleStateEnum"]])
-
 slots.known_as = Slot(uri=NMDC.known_as, name="known_as", curie=NMDC.curie('known_as'),
                    model_uri=NMDC.known_as, domain=None, range=Optional[Union[str, "ChemicalEntityEnum"]])
 
@@ -10677,7 +10750,7 @@ slots.principal_investigator = Slot(uri=NMDC['basic_classes/principal_investigat
                    model_uri=NMDC.principal_investigator, domain=None, range=Optional[Union[dict, PersonValue]])
 
 slots.was_generated_by = Slot(uri=NMDC['basic_classes/was_generated_by'], name="was_generated_by", curie=NMDC.curie('basic_classes/was_generated_by'),
-                   model_uri=NMDC.was_generated_by, domain=None, range=Optional[Union[str, WorkflowExecutionId]], mappings = [PROV["wasGeneratedBy"]])
+                   model_uri=NMDC.was_generated_by, domain=None, range=Optional[Union[str, DataEmitterProcessId]], mappings = [PROV["wasGeneratedBy"]])
 
 slots.associated_dois = Slot(uri=NMDC['basic_classes/associated_dois'], name="associated_dois", curie=NMDC.curie('basic_classes/associated_dois'),
                    model_uri=NMDC.associated_dois, domain=None, range=Optional[Union[Union[dict, Doi], List[Union[dict, Doi]]]])
@@ -12642,7 +12715,7 @@ slots.CalibrationInformation_id = Slot(uri=NMDC.id, name="CalibrationInformation
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.FunctionalAnnotationAggMember_was_generated_by = Slot(uri=NMDC['basic_classes/was_generated_by'], name="FunctionalAnnotationAggMember_was_generated_by", curie=NMDC.curie('basic_classes/was_generated_by'),
-                   model_uri=NMDC.FunctionalAnnotationAggMember_was_generated_by, domain=FunctionalAnnotationAggMember, range=Union[str, WorkflowExecutionId], mappings = [PROV["wasGeneratedBy"]])
+                   model_uri=NMDC.FunctionalAnnotationAggMember_was_generated_by, domain=FunctionalAnnotationAggMember, range=Union[str, AnnotatingWorkflowId], mappings = [PROV["wasGeneratedBy"]])
 
 slots.FunctionalAnnotationAggMember_count = Slot(uri=NMDC.count, name="FunctionalAnnotationAggMember_count", curie=NMDC.curie('count'),
                    model_uri=NMDC.FunctionalAnnotationAggMember_count, domain=FunctionalAnnotationAggMember, range=int)
@@ -12740,10 +12813,10 @@ slots.StorageProcess_id = Slot(uri=NMDC.id, name="StorageProcess_id", curie=NMDC
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.StorageProcess_has_input = Slot(uri=NMDC['basic_classes/has_input'], name="StorageProcess_has_input", curie=NMDC.curie('basic_classes/has_input'),
-                   model_uri=NMDC.StorageProcess_has_input, domain=StorageProcess, range=Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]])
+                   model_uri=NMDC.StorageProcess_has_input, domain=StorageProcess, range=Optional[Union[Union[str, SampleId], List[Union[str, SampleId]]]])
 
 slots.StorageProcess_has_output = Slot(uri=NMDC['basic_classes/has_output'], name="StorageProcess_has_output", curie=NMDC.curie('basic_classes/has_output'),
-                   model_uri=NMDC.StorageProcess_has_output, domain=StorageProcess, range=Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]])
+                   model_uri=NMDC.StorageProcess_has_output, domain=StorageProcess, range=Optional[Union[Union[str, ProcessedSampleId], List[Union[str, ProcessedSampleId]]]])
 
 slots.ChromatographicSeparationProcess_id = Slot(uri=NMDC.id, name="ChromatographicSeparationProcess_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.ChromatographicSeparationProcess_id, domain=ChromatographicSeparationProcess, range=Union[str, ChromatographicSeparationProcessId],
@@ -12780,14 +12853,14 @@ slots.MetagenomeAssembly_id = Slot(uri=NMDC.id, name="MetagenomeAssembly_id", cu
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.MetagenomeAssembly_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetagenomeAssembly_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetagenomeAssembly_was_informed_by, domain=MetagenomeAssembly, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetagenomeAssembly_was_informed_by, domain=MetagenomeAssembly, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetatranscriptomeAssembly_id = Slot(uri=NMDC.id, name="MetatranscriptomeAssembly_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.MetatranscriptomeAssembly_id, domain=MetatranscriptomeAssembly, range=Union[str, MetatranscriptomeAssemblyId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.MetatranscriptomeAssembly_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetatranscriptomeAssembly_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetatranscriptomeAssembly_was_informed_by, domain=MetatranscriptomeAssembly, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetatranscriptomeAssembly_was_informed_by, domain=MetatranscriptomeAssembly, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetatranscriptomeAnnotation_id = Slot(uri=NMDC.id, name="MetatranscriptomeAnnotation_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.MetatranscriptomeAnnotation_id, domain=MetatranscriptomeAnnotation, range=Union[str, MetatranscriptomeAnnotationId],
@@ -12804,7 +12877,7 @@ slots.MetatranscriptomeAnnotation_has_output = Slot(uri=NMDC['basic_classes/has_
                    model_uri=NMDC.MetatranscriptomeAnnotation_has_output, domain=MetatranscriptomeAnnotation, range=Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]])
 
 slots.MetatranscriptomeAnnotation_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetatranscriptomeAnnotation_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetatranscriptomeAnnotation_was_informed_by, domain=MetatranscriptomeAnnotation, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetatranscriptomeAnnotation_was_informed_by, domain=MetatranscriptomeAnnotation, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetatranscriptomeAnnotation_gold_analysis_project_identifiers = Slot(uri=NMDC.gold_analysis_project_identifiers, name="MetatranscriptomeAnnotation_gold_analysis_project_identifiers", curie=NMDC.curie('gold_analysis_project_identifiers'),
                    model_uri=NMDC.MetatranscriptomeAnnotation_gold_analysis_project_identifiers, domain=MetatranscriptomeAnnotation, range=Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]],
@@ -12819,7 +12892,7 @@ slots.MetatranscriptomeExpressionAnalysis_img_identifiers = Slot(uri=NMDC.img_id
                    pattern=re.compile(r'^img\.taxon:[a-zA-Z0-9_][a-zA-Z0-9_\/\.]*$'))
 
 slots.MetatranscriptomeExpressionAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetatranscriptomeExpressionAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetatranscriptomeExpressionAnalysis_was_informed_by, domain=MetatranscriptomeExpressionAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetatranscriptomeExpressionAnalysis_was_informed_by, domain=MetatranscriptomeExpressionAnalysis, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MagsAnalysis_id = Slot(uri=NMDC.id, name="MagsAnalysis_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.MagsAnalysis_id, domain=MagsAnalysis, range=Union[str, MagsAnalysisId],
@@ -12830,52 +12903,52 @@ slots.MagsAnalysis_img_identifiers = Slot(uri=NMDC.img_identifiers, name="MagsAn
                    pattern=re.compile(r'^img\.taxon:[a-zA-Z0-9_][a-zA-Z0-9_\/\.]*$'))
 
 slots.MagsAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MagsAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MagsAnalysis_was_informed_by, domain=MagsAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MagsAnalysis_was_informed_by, domain=MagsAnalysis, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetagenomeSequencing_id = Slot(uri=NMDC.id, name="MetagenomeSequencing_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.MetagenomeSequencing_id, domain=MetagenomeSequencing, range=Union[str, MetagenomeSequencingId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.MetagenomeSequencing_has_input = Slot(uri=NMDC['basic_classes/has_input'], name="MetagenomeSequencing_has_input", curie=NMDC.curie('basic_classes/has_input'),
-                   model_uri=NMDC.MetagenomeSequencing_has_input, domain=MetagenomeSequencing, range=Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]])
+                   model_uri=NMDC.MetagenomeSequencing_has_input, domain=MetagenomeSequencing, range=Optional[Union[Union[str, SampleId], List[Union[str, SampleId]]]])
 
 slots.MetagenomeSequencing_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetagenomeSequencing_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetagenomeSequencing_was_informed_by, domain=MetagenomeSequencing, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetagenomeSequencing_was_informed_by, domain=MetagenomeSequencing, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.ReadQcAnalysis_id = Slot(uri=NMDC.id, name="ReadQcAnalysis_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.ReadQcAnalysis_id, domain=ReadQcAnalysis, range=Union[str, ReadQcAnalysisId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.ReadQcAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="ReadQcAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.ReadQcAnalysis_was_informed_by, domain=ReadQcAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.ReadQcAnalysis_was_informed_by, domain=ReadQcAnalysis, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.ReadBasedTaxonomyAnalysis_id = Slot(uri=NMDC.id, name="ReadBasedTaxonomyAnalysis_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.ReadBasedTaxonomyAnalysis_id, domain=ReadBasedTaxonomyAnalysis, range=Union[str, ReadBasedTaxonomyAnalysisId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.ReadBasedTaxonomyAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="ReadBasedTaxonomyAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.ReadBasedTaxonomyAnalysis_was_informed_by, domain=ReadBasedTaxonomyAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.ReadBasedTaxonomyAnalysis_was_informed_by, domain=ReadBasedTaxonomyAnalysis, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetabolomicsAnalysis_id = Slot(uri=NMDC.id, name="MetabolomicsAnalysis_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.MetabolomicsAnalysis_id, domain=MetabolomicsAnalysis, range=Union[str, MetabolomicsAnalysisId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.MetabolomicsAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetabolomicsAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetabolomicsAnalysis_was_informed_by, domain=MetabolomicsAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetabolomicsAnalysis_was_informed_by, domain=MetabolomicsAnalysis, range=Optional[Union[str, MassSpectrometryId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetaproteomicsAnalysis_id = Slot(uri=NMDC.id, name="MetaproteomicsAnalysis_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.MetaproteomicsAnalysis_id, domain=MetaproteomicsAnalysis, range=Union[str, MetaproteomicsAnalysisId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.MetaproteomicsAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetaproteomicsAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetaproteomicsAnalysis_was_informed_by, domain=MetaproteomicsAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetaproteomicsAnalysis_was_informed_by, domain=MetaproteomicsAnalysis, range=Optional[Union[str, MassSpectrometryId]], mappings = [PROV["wasInformedBy"]])
 
 slots.NomAnalysis_id = Slot(uri=NMDC.id, name="NomAnalysis_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.NomAnalysis_id, domain=NomAnalysis, range=Union[str, NomAnalysisId],
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.NomAnalysis_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="NomAnalysis_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.NomAnalysis_was_informed_by, domain=NomAnalysis, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.NomAnalysis_was_informed_by, domain=NomAnalysis, range=Optional[Union[str, MassSpectrometryId]], mappings = [PROV["wasInformedBy"]])
 
 slots.ChemicalConversionProcess_id = Slot(uri=NMDC.id, name="ChemicalConversionProcess_id", curie=NMDC.curie('id'),
                    model_uri=NMDC.ChemicalConversionProcess_id, domain=ChemicalConversionProcess, range=Union[str, ChemicalConversionProcessId],
@@ -12890,7 +12963,7 @@ slots.MetagenomeAnnotation_img_identifiers = Slot(uri=NMDC.img_identifiers, name
                    pattern=re.compile(r'^img\.taxon:[a-zA-Z0-9_][a-zA-Z0-9_\/\.]*$'))
 
 slots.MetagenomeAnnotation_was_informed_by = Slot(uri=NMDC['basic_classes/was_informed_by'], name="MetagenomeAnnotation_was_informed_by", curie=NMDC.curie('basic_classes/was_informed_by'),
-                   model_uri=NMDC.MetagenomeAnnotation_was_informed_by, domain=MetagenomeAnnotation, range=Optional[Union[str, DataGenerationId]], mappings = [PROV["wasInformedBy"]])
+                   model_uri=NMDC.MetagenomeAnnotation_was_informed_by, domain=MetagenomeAnnotation, range=Optional[Union[str, NucleotideSequencingId]], mappings = [PROV["wasInformedBy"]])
 
 slots.MetagenomeAnnotation_gold_analysis_project_identifiers = Slot(uri=NMDC.gold_analysis_project_identifiers, name="MetagenomeAnnotation_gold_analysis_project_identifiers", curie=NMDC.curie('gold_analysis_project_identifiers'),
                    model_uri=NMDC.MetagenomeAnnotation_gold_analysis_project_identifiers, domain=MetagenomeAnnotation, range=Optional[Union[Union[str, ExternalIdentifier], List[Union[str, ExternalIdentifier]]]],
@@ -13121,7 +13194,7 @@ slots.DataObject_id = Slot(uri=NMDC.id, name="DataObject_id", curie=NMDC.curie('
                    pattern=re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'))
 
 slots.DataObject_was_generated_by = Slot(uri=NMDC['basic_classes/was_generated_by'], name="DataObject_was_generated_by", curie=NMDC.curie('basic_classes/was_generated_by'),
-                   model_uri=NMDC.DataObject_was_generated_by, domain=DataObject, range=Optional[Union[str, WorkflowExecutionId]], mappings = [PROV["wasGeneratedBy"]])
+                   model_uri=NMDC.DataObject_was_generated_by, domain=DataObject, range=Optional[Union[str, DataEmitterProcessId]], mappings = [PROV["wasGeneratedBy"]])
 
 slots.DataGeneration_has_input = Slot(uri=NMDC['basic_classes/has_input'], name="DataGeneration_has_input", curie=NMDC.curie('basic_classes/has_input'),
                    model_uri=NMDC.DataGeneration_has_input, domain=DataGeneration, range=Union[Union[str, SampleId], List[Union[str, SampleId]]])
@@ -13140,10 +13213,10 @@ slots.WorkflowExecution_git_url = Slot(uri=NMDC.git_url, name="WorkflowExecution
                    model_uri=NMDC.WorkflowExecution_git_url, domain=WorkflowExecution, range=str)
 
 slots.WorkflowExecution_has_input = Slot(uri=NMDC['basic_classes/has_input'], name="WorkflowExecution_has_input", curie=NMDC.curie('basic_classes/has_input'),
-                   model_uri=NMDC.WorkflowExecution_has_input, domain=WorkflowExecution, range=Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]])
+                   model_uri=NMDC.WorkflowExecution_has_input, domain=WorkflowExecution, range=Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]])
 
 slots.WorkflowExecution_has_output = Slot(uri=NMDC['basic_classes/has_output'], name="WorkflowExecution_has_output", curie=NMDC.curie('basic_classes/has_output'),
-                   model_uri=NMDC.WorkflowExecution_has_output, domain=WorkflowExecution, range=Optional[Union[Union[str, NamedThingId], List[Union[str, NamedThingId]]]])
+                   model_uri=NMDC.WorkflowExecution_has_output, domain=WorkflowExecution, range=Optional[Union[Union[str, DataObjectId], List[Union[str, DataObjectId]]]])
 
 slots.WorkflowExecution_execution_resource = Slot(uri=NMDC.execution_resource, name="WorkflowExecution_execution_resource", curie=NMDC.curie('execution_resource'),
                    model_uri=NMDC.WorkflowExecution_execution_resource, domain=WorkflowExecution, range=Union[str, "ExecutionResourceEnum"])

--- a/nmdc_schema/nmdc.schema.json
+++ b/nmdc_schema/nmdc.schema.json
@@ -4,6 +4,7 @@
             "description": "",
             "enum": [
                 "metabolomics",
+                "lipidomics",
                 "metagenomics",
                 "metagenomics_long_read",
                 "metaproteomics",
@@ -6679,18 +6680,10 @@
                     ]
                 },
                 "was_generated_by": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
@@ -6910,16 +6903,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/$defs/MetagenomeAnnotation"
-                            },
-                            {
                                 "$ref": "#/$defs/MetagenomeAssembly"
                             },
                             {
                                 "$ref": "#/$defs/MetatranscriptomeAssembly"
-                            },
-                            {
-                                "$ref": "#/$defs/MetatranscriptomeAnnotation"
                             },
                             {
                                 "$ref": "#/$defs/MetatranscriptomeExpressionAnalysis"
@@ -6940,10 +6927,16 @@
                                 "$ref": "#/$defs/MetabolomicsAnalysis"
                             },
                             {
-                                "$ref": "#/$defs/MetaproteomicsAnalysis"
+                                "$ref": "#/$defs/NomAnalysis"
                             },
                             {
-                                "$ref": "#/$defs/NomAnalysis"
+                                "$ref": "#/$defs/MetagenomeAnnotation"
+                            },
+                            {
+                                "$ref": "#/$defs/MetatranscriptomeAnnotation"
+                            },
+                            {
+                                "$ref": "#/$defs/MetaproteomicsAnalysis"
                             }
                         ]
                     },
@@ -7140,24 +7133,49 @@
         },
         "Doi": {
             "additionalProperties": false,
-            "description": "A centrally registered identifier symbol used to uniquely identify objects given by the International DOI Foundation. The DOI system is particularly used for electronic documents.",
-            "if": {
-                "properties": {
-                    "doi_category": {
-                        "anyOf": [
-                            {
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "doi_category": {
                                 "const": "dataset_doi"
-                            },
-                            {
-                                "const": "award_doi"
                             }
+                        },
+                        "required": [
+                            "doi_category"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "doi_provider": {}
+                        },
+                        "required": [
+                            "doi_provider"
                         ]
                     }
                 },
-                "required": [
-                    "doi_category"
-                ]
-            },
+                {
+                    "if": {
+                        "properties": {
+                            "doi_category": {
+                                "const": "award_doi"
+                            }
+                        },
+                        "required": [
+                            "doi_category"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "doi_provider": {}
+                        },
+                        "required": [
+                            "doi_provider"
+                        ]
+                    }
+                }
+            ],
+            "description": "A centrally registered identifier symbol used to uniquely identify objects given by the International DOI Foundation. The DOI system is particularly used for electronic documents.",
             "properties": {
                 "doi_category": {
                     "$ref": "#/$defs/DoiCategoryEnum",
@@ -7185,14 +7203,6 @@
                 "doi_category",
                 "type"
             ],
-            "then": {
-                "properties": {
-                    "doi_provider": {}
-                },
-                "required": [
-                    "doi_provider"
-                ]
-            },
             "title": "Doi",
             "type": "object"
         },
@@ -7966,8 +7976,12 @@
                 "Metagenome Raw Reads",
                 "Metagenome Raw Read 1",
                 "Metagenome Raw Read 2",
+                "Metatranscriptome Raw Reads",
+                "Metatranscriptome Raw Read 1",
+                "Metatranscriptome Raw Read 2",
                 "FT ICR-MS Analysis Results",
                 "GC-MS Metabolomics Results",
+                "LC-MS Metabolomics Results",
                 "Metaproteomics Workflow Statistics",
                 "Protein Report",
                 "Peptide Report",
@@ -8040,6 +8054,7 @@
                 "Configuration toml",
                 "LC-MS Lipidomics Results",
                 "LC-MS Lipidomics Processed Data",
+                "LC-MS Metabolomics Processed Data",
                 "Contaminants Amino Acid FASTA",
                 "Analysis Tool Parameter File",
                 "Workflow Operation Summary",
@@ -8376,19 +8391,11 @@
                     "type": "string"
                 },
                 "was_generated_by": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "description": "provenance for the annotation.",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
@@ -8417,14 +8424,6 @@
                     "type": "string"
                 },
                 "was_generated_by": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ],
                     "type": "string"
                 }
             },
@@ -9705,14 +9704,27 @@
                     "if": {
                         "properties": {
                             "eluent_introduction_category": {
-                                "anyOf": [
-                                    {
-                                        "const": "liquid_chromatography"
-                                    },
-                                    {
-                                        "const": "gas_chromatography"
-                                    }
-                                ]
+                                "const": "liquid_chromatography"
+                            }
+                        },
+                        "required": [
+                            "eluent_introduction_category"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "has_chromatography_configuration": {}
+                        },
+                        "required": [
+                            "has_chromatography_configuration"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "eluent_introduction_category": {
+                                "const": "gas_chromatography"
                             }
                         },
                         "required": [
@@ -13317,10 +13329,6 @@
                     ],
                     "description": "A physical quality that inheres in a bearer by virtue of the proportion of the bearer's amount of matter."
                 },
-                "sample_state_information": {
-                    "$ref": "#/$defs/SampleStateEnum",
-                    "description": "The chemical phase of a pure sample, or the state of a mixed sample"
-                },
                 "source_concentration": {
                     "anyOf": [
                         {
@@ -15709,16 +15717,10 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "#/$defs/MetagenomeAnnotation"
-                    },
-                    {
                         "$ref": "#/$defs/MetagenomeAssembly"
                     },
                     {
                         "$ref": "#/$defs/MetatranscriptomeAssembly"
-                    },
-                    {
-                        "$ref": "#/$defs/MetatranscriptomeAnnotation"
                     },
                     {
                         "$ref": "#/$defs/MetatranscriptomeExpressionAnalysis"
@@ -15739,10 +15741,16 @@
                         "$ref": "#/$defs/MetabolomicsAnalysis"
                     },
                     {
-                        "$ref": "#/$defs/MetaproteomicsAnalysis"
+                        "$ref": "#/$defs/NomAnalysis"
                     },
                     {
-                        "$ref": "#/$defs/NomAnalysis"
+                        "$ref": "#/$defs/MetagenomeAnnotation"
+                    },
+                    {
+                        "$ref": "#/$defs/MetatranscriptomeAnnotation"
+                    },
+                    {
+                        "$ref": "#/$defs/MetaproteomicsAnalysis"
                     }
                 ]
             },

--- a/nmdc_schema/nmdc_materialized_patterns.schema.json
+++ b/nmdc_schema/nmdc_materialized_patterns.schema.json
@@ -4,6 +4,7 @@
             "description": "",
             "enum": [
                 "metabolomics",
+                "lipidomics",
                 "metagenomics",
                 "metagenomics_long_read",
                 "metaproteomics",
@@ -5801,6 +5802,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -6096,6 +6098,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -6689,19 +6692,11 @@
                     ]
                 },
                 "was_generated_by": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "pattern": "^^(nmdc):(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\\.[0-9]{1,})$|^^(nmdc):(omprc|dgms|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
@@ -6921,16 +6916,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/$defs/MetagenomeAnnotation"
-                            },
-                            {
                                 "$ref": "#/$defs/MetagenomeAssembly"
                             },
                             {
                                 "$ref": "#/$defs/MetatranscriptomeAssembly"
-                            },
-                            {
-                                "$ref": "#/$defs/MetatranscriptomeAnnotation"
                             },
                             {
                                 "$ref": "#/$defs/MetatranscriptomeExpressionAnalysis"
@@ -6951,10 +6940,16 @@
                                 "$ref": "#/$defs/MetabolomicsAnalysis"
                             },
                             {
-                                "$ref": "#/$defs/MetaproteomicsAnalysis"
+                                "$ref": "#/$defs/NomAnalysis"
                             },
                             {
-                                "$ref": "#/$defs/NomAnalysis"
+                                "$ref": "#/$defs/MetagenomeAnnotation"
+                            },
+                            {
+                                "$ref": "#/$defs/MetatranscriptomeAnnotation"
+                            },
+                            {
+                                "$ref": "#/$defs/MetaproteomicsAnalysis"
                             }
                         ]
                     },
@@ -7069,6 +7064,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -7153,24 +7149,49 @@
         },
         "Doi": {
             "additionalProperties": false,
-            "description": "A centrally registered identifier symbol used to uniquely identify objects given by the International DOI Foundation. The DOI system is particularly used for electronic documents.",
-            "if": {
-                "properties": {
-                    "doi_category": {
-                        "anyOf": [
-                            {
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "doi_category": {
                                 "const": "dataset_doi"
-                            },
-                            {
-                                "const": "award_doi"
                             }
+                        },
+                        "required": [
+                            "doi_category"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "doi_provider": {}
+                        },
+                        "required": [
+                            "doi_provider"
                         ]
                     }
                 },
-                "required": [
-                    "doi_category"
-                ]
-            },
+                {
+                    "if": {
+                        "properties": {
+                            "doi_category": {
+                                "const": "award_doi"
+                            }
+                        },
+                        "required": [
+                            "doi_category"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "doi_provider": {}
+                        },
+                        "required": [
+                            "doi_provider"
+                        ]
+                    }
+                }
+            ],
+            "description": "A centrally registered identifier symbol used to uniquely identify objects given by the International DOI Foundation. The DOI system is particularly used for electronic documents.",
             "properties": {
                 "doi_category": {
                     "$ref": "#/$defs/DoiCategoryEnum",
@@ -7198,14 +7219,6 @@
                 "doi_category",
                 "type"
             ],
-            "then": {
-                "properties": {
-                    "doi_provider": {}
-                },
-                "required": [
-                    "doi_provider"
-                ]
-            },
             "title": "Doi",
             "type": "object"
         },
@@ -7653,6 +7666,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -7982,8 +7996,12 @@
                 "Metagenome Raw Reads",
                 "Metagenome Raw Read 1",
                 "Metagenome Raw Read 2",
+                "Metatranscriptome Raw Reads",
+                "Metatranscriptome Raw Read 1",
+                "Metatranscriptome Raw Read 2",
                 "FT ICR-MS Analysis Results",
                 "GC-MS Metabolomics Results",
+                "LC-MS Metabolomics Results",
                 "Metaproteomics Workflow Statistics",
                 "Protein Report",
                 "Peptide Report",
@@ -8056,6 +8074,7 @@
                 "Configuration toml",
                 "LC-MS Lipidomics Results",
                 "LC-MS Lipidomics Processed Data",
+                "LC-MS Metabolomics Processed Data",
                 "Contaminants Amino Acid FASTA",
                 "Analysis Tool Parameter File",
                 "Workflow Operation Summary",
@@ -8195,6 +8214,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -8394,20 +8414,12 @@
                     "type": "string"
                 },
                 "was_generated_by": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ],
                     "description": "provenance for the annotation.",
                     "pattern": "^(nmdc):(wfmgan)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\\.[0-9]{1,})$",
-                    "type": "string"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             },
             "required": [
@@ -8436,14 +8448,6 @@
                     "type": "string"
                 },
                 "was_generated_by": {
-                    "anyOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ],
                     "pattern": "^(nmdc):(wfmgan|wfmp|wfmtan)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\\.[0-9]{1,})$",
                     "type": "string"
                 }
@@ -9041,6 +9045,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -9730,14 +9735,27 @@
                     "if": {
                         "properties": {
                             "eluent_introduction_category": {
-                                "anyOf": [
-                                    {
-                                        "const": "liquid_chromatography"
-                                    },
-                                    {
-                                        "const": "gas_chromatography"
-                                    }
-                                ]
+                                "const": "liquid_chromatography"
+                            }
+                        },
+                        "required": [
+                            "eluent_introduction_category"
+                        ]
+                    },
+                    "then": {
+                        "properties": {
+                            "has_chromatography_configuration": {}
+                        },
+                        "required": [
+                            "has_chromatography_configuration"
+                        ]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "eluent_introduction_category": {
+                                "const": "gas_chromatography"
                             }
                         },
                         "required": [
@@ -9864,6 +9882,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -12233,6 +12252,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -12660,6 +12680,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -13291,6 +13312,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -13383,10 +13405,6 @@
                         }
                     ],
                     "description": "A physical quality that inheres in a bearer by virtue of the proportion of the bearer's amount of matter."
-                },
-                "sample_state_information": {
-                    "$ref": "#/$defs/SampleStateEnum",
-                    "description": "The chemical phase of a pure sample, or the state of a mixed sample"
                 },
                 "source_concentration": {
                     "anyOf": [
@@ -15081,6 +15099,7 @@
                 "instrument_used": {
                     "description": "What instrument was used during DataGeneration or MaterialProcessing.",
                     "items": {
+                        "pattern": "^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$",
                         "type": "string"
                     },
                     "type": [
@@ -15787,16 +15806,10 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "#/$defs/MetagenomeAnnotation"
-                    },
-                    {
                         "$ref": "#/$defs/MetagenomeAssembly"
                     },
                     {
                         "$ref": "#/$defs/MetatranscriptomeAssembly"
-                    },
-                    {
-                        "$ref": "#/$defs/MetatranscriptomeAnnotation"
                     },
                     {
                         "$ref": "#/$defs/MetatranscriptomeExpressionAnalysis"
@@ -15817,10 +15830,16 @@
                         "$ref": "#/$defs/MetabolomicsAnalysis"
                     },
                     {
-                        "$ref": "#/$defs/MetaproteomicsAnalysis"
+                        "$ref": "#/$defs/NomAnalysis"
                     },
                     {
-                        "$ref": "#/$defs/NomAnalysis"
+                        "$ref": "#/$defs/MetagenomeAnnotation"
+                    },
+                    {
+                        "$ref": "#/$defs/MetatranscriptomeAnnotation"
+                    },
+                    {
+                        "$ref": "#/$defs/MetaproteomicsAnalysis"
                     }
                 ]
             },

--- a/nmdc_schema/nmdc_materialized_patterns.yaml
+++ b/nmdc_schema/nmdc_materialized_patterns.yaml
@@ -3796,14 +3796,14 @@ enums:
           matter or metabalomics analysis.
       Metagenome Raw Reads:
         text: Metagenome Raw Reads
-        description: Interleaved paired-end raw sequencing data
+        description: Interleaved paired-end raw metagenome sequencing data
         annotations:
           file_name_pattern:
             tag: file_name_pattern
             value: ^\.fastq(\.gz)?$
       Metagenome Raw Read 1:
         text: Metagenome Raw Read 1
-        description: Read 1 raw sequencing data, aka forward reads
+        description: Read 1 raw metagenome sequencing data, aka forward reads
         annotations:
           file_name_pattern:
             tag: file_name_pattern
@@ -3812,7 +3812,32 @@ enums:
         - value: BMI_H25VYBGXH_19S_31WellG1_R1.fastq.gz
       Metagenome Raw Read 2:
         text: Metagenome Raw Read 2
-        description: Read 2 raw sequencing data, aka reverse reads
+        description: Read 2 raw metagenome sequencing data, aka reverse reads
+        annotations:
+          file_name_pattern:
+            tag: file_name_pattern
+            value: ^.+_R2\.fastq(\.gz)?$
+        examples:
+        - value: BMI_H25VYBGXH_19S_31WellG1_R2.fastq.gz
+      Metatranscriptome Raw Reads:
+        text: Metatranscriptome Raw Reads
+        description: Interleaved paired-end raw metatranscriptome sequencing data
+        annotations:
+          file_name_pattern:
+            tag: file_name_pattern
+            value: ^\.fastq(\.gz)?$
+      Metatranscriptome Raw Read 1:
+        text: Metatranscriptome Raw Read 1
+        description: Read 1 raw metatranscriptome sequencing data, aka forward reads
+        annotations:
+          file_name_pattern:
+            tag: file_name_pattern
+            value: ^.+_R1\.fastq(\.gz)?$
+        examples:
+        - value: BMI_H25VYBGXH_19S_31WellG1_R1.fastq.gz
+      Metatranscriptome Raw Read 2:
+        text: Metatranscriptome Raw Read 2
+        description: Read 2 raw metatranscriptome sequencing data, aka reverse reads
         annotations:
           file_name_pattern:
             tag: file_name_pattern
@@ -3825,6 +3850,9 @@ enums:
       GC-MS Metabolomics Results:
         text: GC-MS Metabolomics Results
         description: GC-MS-based metabolite assignment results table
+      LC-MS Metabolomics Results:
+        text: LC-MS Metabolomics Results
+        description: LC-MS-based metabolite assignment results table
       Metaproteomics Workflow Statistics:
         text: Metaproteomics Workflow Statistics
         description: Aggregate workflow statistics file
@@ -4224,6 +4252,10 @@ enums:
         text: LC-MS Lipidomics Processed Data
         description: Processed data for the LC-MS-based lipidomics analysis in hdf5
           format
+      LC-MS Metabolomics Processed Data:
+        text: LC-MS Metabolomics Processed Data
+        description: Processed data for the LC-MS-based metabolomics analysis in hdf5
+          format
       Contaminants Amino Acid FASTA:
         text: Contaminants Amino Acid FASTA
         description: FASTA amino acid file for contaminant proteins commonly observed
@@ -4578,6 +4610,8 @@ enums:
     permissible_values:
       metabolomics:
         text: metabolomics
+      lipidomics:
+        text: lipidomics
       metagenomics:
         text: metagenomics
         description: Standard short-read metagenomic sequencing
@@ -17251,10 +17285,7 @@ slots:
     from_schema: https://w3id.org/nmdc/nmdc
     mappings:
     - prov:wasGeneratedBy
-    range: WorkflowExecution
-    any_of:
-    - range: WorkflowExecution
-    - range: DataGeneration
+    range: DataEmitterProcess
   associated_dois:
     name: associated_dois
     description: A list of DOIs associated with a resource, such as a list of DOIS
@@ -17370,6 +17401,10 @@ slots:
     from_schema: https://w3id.org/nmdc/nmdc
     range: Instrument
     multivalued: true
+    pattern: ^^(nmdc):inst-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
+    structured_pattern:
+      syntax: ^{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$
+      interpolated: true
   in_manifest:
     name: in_manifest
     description: one or more combinations of other DataObjects that can be analyzed
@@ -19298,17 +19333,28 @@ classes:
         slot_conditions:
           eluent_introduction_category:
             name: eluent_introduction_category
-            any_of:
-            - equals_string: liquid_chromatography
-            - equals_string: gas_chromatography
+            equals_string: liquid_chromatography
       postconditions:
         slot_conditions:
           has_chromatography_configuration:
             name: has_chromatography_configuration
             required: true
-      description: If eluent_introduction_category is liquid_chromatography or gas_chromatography,
-        then has_chromatography_configuration is required.
-      title: has_chromatography_configuration_required_if_lc_or_gc
+      description: If eluent_introduction_category is liquid_chromatography, then
+        has_chromatography_configuration is required.
+      title: has_chromatography_configuration_required_if_lc
+    - preconditions:
+        slot_conditions:
+          eluent_introduction_category:
+            name: eluent_introduction_category
+            equals_string: gas_chromatography
+      postconditions:
+        slot_conditions:
+          has_chromatography_configuration:
+            name: has_chromatography_configuration
+            required: true
+      description: If eluent_introduction_category is gas_chromatography, then has_chromatography_configuration
+        is required.
+      title: has_chromatography_configuration_required_if_gc
   Configuration:
     name: Configuration
     description: A set of parameters that define the actions of a process and is shared
@@ -19459,6 +19505,7 @@ classes:
     slot_usage:
       was_generated_by:
         name: was_generated_by
+        range: AnnotatingWorkflow
         required: true
         pattern: ^(nmdc):(wfmgan|wfmp|wfmtan)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\.[0-9]{1,})$
         structured_pattern:
@@ -19829,12 +19876,14 @@ classes:
           interpolated: true
       has_input:
         name: has_input
+        range: Sample
         pattern: ^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$'
           interpolated: true
       has_output:
         name: has_output
+        range: ProcessedSample
         pattern: ^(nmdc):procsm-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$'
@@ -19936,12 +19985,20 @@ classes:
           syntax: '{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}$'
           interpolated: true
     class_uri: nmdc:ChemicalConversionProcess
+  AnnotatingWorkflow:
+    name: AnnotatingWorkflow
+    description: A WorkflowExecution whose output indicates the potential functions
+      of genes or gene products
+    from_schema: https://w3id.org/nmdc/nmdc
+    is_a: WorkflowExecution
+    abstract: true
+    class_uri: nmdc:AnnotatingWorkflow
   MetagenomeAnnotation:
     name: MetagenomeAnnotation
     description: A workflow execution activity that provides functional and structural
       annotation of assembled metagenome contigs
     from_schema: https://w3id.org/nmdc/nmdc
-    is_a: WorkflowExecution
+    is_a: AnnotatingWorkflow
     slots:
     - img_identifiers
     - gold_analysis_project_identifiers
@@ -19958,6 +20015,7 @@ classes:
         maximum_cardinality: 1
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -21110,7 +21168,6 @@ classes:
     slots:
     - final_concentration
     - mass
-    - sample_state_information
     - source_concentration
     - known_as
     - substance_role
@@ -21692,9 +21749,7 @@ classes:
         slot_conditions:
           doi_category:
             name: doi_category
-            any_of:
-            - equals_string: dataset_doi
-            - equals_string: award_doi
+            equals_string: dataset_doi
       postconditions:
         slot_conditions:
           doi_provider:
@@ -21702,7 +21757,20 @@ classes:
             required: true
       description: If doi_category is a publication_doi, then doi_provider is not
         required. Otherwise, doi_provider is required.
-      title: dataset_award_dois_required
+      title: dataset_dois_require_provider
+    - preconditions:
+        slot_conditions:
+          doi_category:
+            name: doi_category
+            equals_string: award_doi
+      postconditions:
+        slot_conditions:
+          doi_provider:
+            name: doi_provider
+            required: true
+      description: If doi_category is a publication_doi, then doi_provider is not
+        required. Otherwise, doi_provider is required.
+      title: award_dois_require_provider
   Study:
     name: Study
     description: A study summarizes the overall goal of a research initiative and
@@ -21910,11 +21978,19 @@ classes:
           interpolated: true
       was_generated_by:
         name: was_generated_by
+        range: DataEmitterProcess
         pattern: ^^(nmdc):(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})(\.[0-9]{1,})$|^^(nmdc):(omprc|dgms|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: ^{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|^{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$
           interpolated: true
     class_uri: nmdc:DataObject
+  DataEmitterProcess:
+    name: DataEmitterProcess
+    description: A process that generates data objects as output.
+    from_schema: https://w3id.org/nmdc/nmdc
+    is_a: PlannedProcess
+    abstract: true
+    class_uri: nmdc:DataEmitterProcess
   DataGeneration:
     name: DataGeneration
     description: The methods and processes used to generate omics data from a biosample
@@ -21934,7 +22010,7 @@ classes:
     broad_mappings:
     - OBI:0000070
     - ISA:Assay
-    is_a: PlannedProcess
+    is_a: DataEmitterProcess
     abstract: true
     slots:
     - add_date
@@ -21981,7 +22057,7 @@ classes:
     from_schema: https://w3id.org/nmdc/nmdc
     aliases:
     - analysis
-    is_a: PlannedProcess
+    is_a: DataEmitterProcess
     abstract: true
     slots:
     - ended_at_time
@@ -21999,6 +22075,7 @@ classes:
         required: true
       has_input:
         name: has_input
+        range: DataObject
         required: true
         pattern: ^(nmdc):(dobj)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
@@ -22006,6 +22083,7 @@ classes:
           interpolated: true
       has_output:
         name: has_output
+        range: DataObject
         pattern: ^(nmdc):(dobj)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$'
@@ -22090,6 +22168,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22138,6 +22217,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22146,7 +22226,7 @@ classes:
   MetatranscriptomeAnnotation:
     name: MetatranscriptomeAnnotation
     from_schema: https://w3id.org/nmdc/nmdc
-    is_a: WorkflowExecution
+    is_a: AnnotatingWorkflow
     slots:
     - img_identifiers
     - gold_analysis_project_identifiers
@@ -22175,6 +22255,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22207,6 +22288,7 @@ classes:
         maximum_cardinality: 1
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22240,6 +22322,7 @@ classes:
         maximum_cardinality: 1
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22262,12 +22345,14 @@ classes:
           interpolated: true
       has_input:
         name: has_input
+        range: Sample
         pattern: ^(nmdc):(bsm|procsm)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$'
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22299,6 +22384,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22321,6 +22407,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: NucleotideSequencing
         pattern: ^(nmdc):(omprc|dgns)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$'
@@ -22344,6 +22431,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: MassSpectrometry
         pattern: ^(nmdc):(omprc|dgms)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgms)-{id_shoulder}-{id_blade}$'
@@ -22352,7 +22440,7 @@ classes:
   MetaproteomicsAnalysis:
     name: MetaproteomicsAnalysis
     from_schema: https://w3id.org/nmdc/nmdc
-    is_a: WorkflowExecution
+    is_a: AnnotatingWorkflow
     slots:
     - metaproteomics_analysis_category
     slot_usage:
@@ -22365,6 +22453,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: MassSpectrometry
         pattern: ^(nmdc):(omprc|dgms)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgms)-{id_shoulder}-{id_blade}$'
@@ -22386,6 +22475,7 @@ classes:
           interpolated: true
       was_informed_by:
         name: was_informed_by
+        range: MassSpectrometry
         pattern: ^(nmdc):(omprc|dgms)-([0-9][a-z]{0,6}[0-9])-([A-Za-z0-9]{1,})$
         structured_pattern:
           syntax: '{id_nmdc_prefix}:(omprc|dgms)-{id_shoulder}-{id_blade}$'


### PR DESCRIPTION
In this PR, I have generated release artifacts based upon the latest commit on the `main` branch as of Tuesday evening (i.e. commit 957b389b181a5f3e132cf25bca5f010a3217d591). This was my attempt at getting a head start at generating the release artifacts for the upcoming release.

If we merge additional PRs into `main` before doing the release, these release artifacts will become obsolete; in which case, we can either merge `main` into this branch and re-generate the release artifacts here, or we can close this branch.

CC: @turbomam 