### PR TITLE
Add new PVs for LC NOM workflow

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_6_1_to_11_7_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_6_1_to_11_7_0.py
@@ -1,0 +1,31 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.6.1"
+    _to_version = "11.7.0"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+
+        self.adapter.process_each_document("data_object_set", [self.clarify_ft_data_object_type])
+
+    def clarify_ft_data_object_type(self, data_object: dict) -> dict:
+        r"""
+        If the data object has the data_object_type of "FT ICR-MS Analysis Results", replace it with "Direct Infusion FT-ICR MS Analysis Results".
+        If the data object has any other value for data_object_type; ignore it.
+
+        >>> m = Migrator()
+        >>> m.clarify_ft_data_object_type({"id":123, "type":"nmdc:DataObject", "data_object_type": "FT ICR-MS Analysis Results"})
+        {'id': 123, 'type': 'nmdc:DataObject', 'data_object_type': 'Direct Infusion FT-ICR MS Analysis Results'}
+        >>> m.clarify_ft_data_object_type({"id":123, "type":"nmdc:DataObject", "data_object_type": "Another Type"})
+        {'id': 123, 'type': 'nmdc:DataObject', 'data_object_type': 'Another Type'}
+        >>> m.clarify_ft_data_object_type({"id":123, "type":"nmdc:DataObject"})
+        {'id': 123, 'type': 'nmdc:DataObject'}
+        """
+
+        if data_object.get("data_object_type") == "FT ICR-MS Analysis Results":
+            data_object["data_object_type"] = "Direct Infusion FT-ICR MS Analysis Results"
+        return data_object

--- a/src/data/valid/Database-Metabolomics-configuration.yaml
+++ b/src/data/valid/Database-Metabolomics-configuration.yaml
@@ -30,7 +30,7 @@ data_object_set:
     type: nmdc:DataObject
   - id: nmdc:dobj-90-izwYW61
     data_category: processed_data
-    data_object_type: FT ICR-MS Analysis Results
+    data_object_type: Direct Infusion FT-ICR MS Analysis Results
     name: Froze_Core_2015_S1_20_30_19_Metab_raw_data.processed
     description: Full scan GC-MS (but not GC QExactive, which is EI-HMS)
     file_size_bytes: 5262400

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -3105,7 +3105,7 @@ data_object_set:
     name: Froze_Core_2015_S1_20_30_19_Metab_raw_data.processed
     description: Full scan GC-MS (but not GC QExactive, which is EI-HMS)
     data_category: processed_data
-    data_object_type: FT ICR-MS Analysis Results
+    data_object_type: Direct Infusion FT-ICR MS Analysis Results
     file_size_bytes: 5262400
   - id: nmdc:dobj-12-krhrtjw9
     type: nmdc:DataObject

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -995,13 +995,12 @@ enums:
 
       Direct Infusion FT ICR-MS Raw Data:
         description:
-          Direct infusion 21 Tesla Fourier Transform ion cyclotron resonance
-          mass spectrometry raw data acquired in broadband full scan mode
+          Direct infusion Fourier transform ion cyclotron resonance
+          mass spectrometry raw data
       
       LC FT-ICR MS Raw Data:
         description:
-          Fourier Transform ion cyclotron resonance mass spectrometry raw data acquired with liquid chromatography
-          in broadband full scan mode
+          Fourier transform ion cyclotron resonance mass spectrometry raw data acquired with liquid chromatography
 
       LC-DDA-MS/MS Raw Data:
         description: Liquid chromatographically separated MS1 and Data-Dependent MS2 binary instrument file

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -57,7 +57,7 @@ slots:
     range: FileTypeEnum
     description: The type of file represented by the data object.
     examples:
-      - value: FT ICR-MS Analysis Results
+      - value: Direct Infusion FT-ICR MS Analysis Results
       - value: GC-MS Metabolomics Results
     structured_aliases:
       data_object_type:
@@ -686,15 +686,15 @@ enums:
         annotations:
           file_name_pattern: '^.+_R2\.fastq(\.gz)?$'
 
-      FT ICR-MS Analysis Results:
-        description: FT ICR-MS-based molecular formula assignment results table
+      Direct Infusion FT-ICR MS Analysis Results:
+        description: FT-ICR MS based molecular formula assignment results table
       
       Direct Infusion FT-ICR MS QC Plots:
         description:
           Quality control plots for FT-ICR MS raw data acquired by direct infusion
 
       LC FT-ICR MS Analysis Results:
-        description: FT-ICR MS-based molecular formula assignment results tables
+        description: LC FT-ICR MS-based molecular formula assignment results tables
 
       LC FT-ICR MS QC Plots:
         description:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -688,6 +688,17 @@ enums:
 
       FT ICR-MS Analysis Results:
         description: FT ICR-MS-based molecular formula assignment results table
+      
+      Direct Infusion FT-ICR MS QC Plots:
+        description:
+          Quality control plots for FT-ICR MS raw data acquired by direct infusion
+
+      LC FT-ICR MS Analysis Results:
+        description: FT-ICR MS-based molecular formula assignment results tables
+
+      LC FT-ICR MS QC Plots:
+        description:
+          Quality control plots for FT-ICR MS raw data acquired with liquid chromatography
 
       GC-MS Metabolomics Results:
         description: GC-MS-based metabolite assignment results table
@@ -986,6 +997,11 @@ enums:
         description:
           Direct infusion 21 Tesla Fourier Transform ion cyclotron resonance
           mass spectrometry raw data acquired in broadband full scan mode
+      
+      LC FT-ICR MS Raw Data:
+        description:
+          Fourier Transform ion cyclotron resonance mass spectrometry raw data acquired with liquid chromatography
+          in broadband full scan mode
 
       LC-DDA-MS/MS Raw Data:
         description: Liquid chromatographically separated MS1 and Data-Dependent MS2 binary instrument file


### PR DESCRIPTION
Addresses #2440 

Adds the following permissible values to FileTypeEnum:
- LC FT-ICR MS Raw Data
- LC FT-ICR MS Analysis Results
- LC FT-ICR MS QC Plots
- Direct Infusion FT-ICR MS QC Plots
- Direct Infusion FT-ICR MS Analysis Results. _This PV replaces "FT ICR-MS Analysis Results"_

I also clarified some definitions for existing permissible values.

This PR includes a migrator which migrate all data objects with the value in `data_object_type` with of "FT ICR-MS Analysis Results" to "Direct Infusion FT-ICR MS Analysis Results".