### PR TITLE
2441 validation error on metatranscriptome expression id generated by minter

### DIFF
--- a/src/data/valid/DataObject-metatranscriptome-expression.yaml
+++ b/src/data/valid/DataObject-metatranscriptome-expression.yaml
@@ -1,0 +1,9 @@
+data_object_type: Metatranscriptome Expression
+description: "Expression counts for nmdc:wfmtex-12-2y23pa57.1"
+file_size_bytes: 90701023
+id: "nmdc:dobj-11-dtTMNb"
+md5_checksum: "31f21654dc7360a8a54064fc1723f624"
+name: "nmdc_wfmtex-12-2y23pa57.1.rnaseq_gea.txt"
+url: "https://data.microbiomedata.org/data/nmdc:dgns-11-6tsbsj80/nmdc:wfmtex-12-2y23pa57.1/nmdc_wfmtex-12-2y23pa57.1.rnaseq_gea.txt"
+type: "nmdc:DataObject"
+was_generated_by: "nmdc:wfmtex-12-2y23pa57.1"

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -371,7 +371,7 @@ classes:
           interpolated: true
       was_generated_by:
         structured_pattern:
-          syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
+          syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfmtex|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
         range: DataEmitterProcess
   DataEmitterProcess:


### PR DESCRIPTION
This PR provides a fix for #2441 

The error was a ValidationError for DataObjects being create for Metatranscriptome Expression workflow execution.
The Changes include:
- add `wfmtex` to the structured pattern for DataObject.was_generated_by
- add a valid example file for an MT expression DataObject

