### PR TITLE
Make `data_object_type` slot required on `DataObject` and implement migrator

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -1,0 +1,28 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.7.0"
+    _to_version = "11.8.0"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        self.adapter.process_each_document("data_object_set", [self.validate_data_object_type])
+
+    def validate_data_object_type(self, data_object: dict) -> dict:
+        r"""
+        If the data object does not have data_category field, add a value based on the data_object_type.
+        If the data object has any other value for data_object_type; ignore it.
+
+        >>> m = Migrator()
+        >>> m.validate_data_object_type({"id":123, "type":"nmdc:DataObject", "data_object_type":"Type"})
+        {'id': 123, 'type': 'nmdc:DataObject', 'data_object_type': 'Type'}
+        >>> m.validate_data_object_type({"id":123, "type":"nmdc:DataObject"})
+        Traceback (most recent call last):
+        ...
+        ValueError: data_object_type is required and is not present in the data object 123
+        """
+        if not data_object.get("data_object_type"):
+            raise ValueError(f"data_object_type is required and is not present in the data object {data_object.get('id')}")
+        return data_object

--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -12,8 +12,7 @@ class Migrator(MigratorBase):
 
     def validate_data_object_type(self, data_object: dict) -> None:
         r"""
-        Raises an exception if the document either lacks a `data_object_type`
-        field or it has a `data_object_type` field whose value is falsey.
+        Raises an exception if the document lacks a `data_object_type` field.
 
         >>> m = Migrator()
         >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject", "data_object_type": "Type"})

--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -8,16 +8,15 @@ class Migrator(MigratorBase):
 
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
-        self.adapter.process_each_document("data_object_set", [self.validate_data_object_type])
+        self.adapter.do_for_each_document("data_object_set", self.validate_data_object_type)
 
-    def validate_data_object_type(self, data_object: dict) -> dict:
+    def validate_data_object_type(self, data_object: dict) -> None:
         r"""
         Raises an exception if the document either lacks a `data_object_type`
         field or it has a `data_object_type` field whose value is falsey.
 
         >>> m = Migrator()
         >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject", "data_object_type": "Type"})
-        {'id': 123, 'type': 'nmdc:DataObject', 'data_object_type': 'Type'}
         >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject"})
         Traceback (most recent call last):
         ...
@@ -25,4 +24,3 @@ class Migrator(MigratorBase):
         """
         if not data_object.get("data_object_type"):
             raise ValueError(f"data_object_type is required and is not present in the data object {data_object.get('id')}")
-        return data_object

--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -22,5 +22,5 @@ class Migrator(MigratorBase):
         ...
         ValueError: data_object_type is required and is not present in the data object 123
         """
-        if not data_object.get("data_object_type"):
+        if "data_object_type" not in data_object:
             raise ValueError(f"data_object_type is required and is not present in the data object {data_object.get('id')}")

--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -12,8 +12,8 @@ class Migrator(MigratorBase):
 
     def validate_data_object_type(self, data_object: dict) -> dict:
         r"""
-        If the data object does not have data_category field, add a value based on the data_object_type.
-        If the data object has any other value for data_object_type; ignore it.
+        Raises an exception if the document either lacks a `data_object_type`
+        field or it has a `data_object_type` field whose value is falsey.
 
         >>> m = Migrator()
         >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject", "data_object_type": "Type"})

--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -18,7 +18,7 @@ class Migrator(MigratorBase):
         >>> m = Migrator()
         >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject", "data_object_type": "Type"})
         {'id': 123, 'type': 'nmdc:DataObject', 'data_object_type': 'Type'}
-        >>> m.validate_data_object_type({"id":123, "type":"nmdc:DataObject"})
+        >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject"})
         Traceback (most recent call last):
         ...
         ValueError: data_object_type is required and is not present in the data object 123

--- a/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_7_0_to_11_8_0.py
@@ -16,7 +16,7 @@ class Migrator(MigratorBase):
         If the data object has any other value for data_object_type; ignore it.
 
         >>> m = Migrator()
-        >>> m.validate_data_object_type({"id":123, "type":"nmdc:DataObject", "data_object_type":"Type"})
+        >>> m.validate_data_object_type({"id": 123, "type": "nmdc:DataObject", "data_object_type": "Type"})
         {'id': 123, 'type': 'nmdc:DataObject', 'data_object_type': 'Type'}
         >>> m.validate_data_object_type({"id":123, "type":"nmdc:DataObject"})
         Traceback (most recent call last):

--- a/src/data/invalid/DataObject-invalid_id-1.yaml
+++ b/src/data/invalid/DataObject-invalid_id-1.yaml
@@ -4,3 +4,4 @@ name: mapping_stats.txt
 description: Metagenome Contig Coverage Stats for gold:Gp0061273
 file_size_bytes: 32787380
 type: nmdc:DataObject
+data_object_type: Metagenome Raw Read 1

--- a/src/data/invalid/DataObject-invalid_id-2.yaml
+++ b/src/data/invalid/DataObject-invalid_id-2.yaml
@@ -4,3 +4,4 @@ name: mapping_stats.txt
 description: Metagenome Contig Coverage Stats for gold:Gp0061273
 file_size_bytes: 32787380
 type: nmdc:DataObject
+data_object_type: Metagenome Bins Info File

--- a/src/data/invalid/DataObject-invalid_was_generated_by.yaml
+++ b/src/data/invalid/DataObject-invalid_was_generated_by.yaml
@@ -5,3 +5,4 @@ description: Sequencing from project ABDC description
 file_size_bytes: 32787380
 type: nmdc:DataObject
 was_generated_by: nmdc:omprc-11-abd4sg.1
+data_object_type: Metagenome Raw Read 1

--- a/src/data/invalid/DataObject-no-data_object_type.yaml
+++ b/src/data/invalid/DataObject-no-data_object_type.yaml
@@ -1,0 +1,6 @@
+# This example is invalid because the data_object_type field is missing.
+id: nmdc:dobj-99-izwYW6
+type: nmdc:DataObject
+name: mapping_stats.txt
+description: Metagenome Contig Coverage Stats for gold:Gp0061273
+file_size_bytes: 32787380

--- a/src/data/invalid/DataObject-no-id.yaml
+++ b/src/data/invalid/DataObject-no-id.yaml
@@ -1,3 +1,4 @@
 description: "Crispr Terms for nmdc:ann0vx38"
 name: "Crispr Terms for nmdc:ann0vx38"
 type: nmdc:DataObject
+data_object_type: Crispr Terms

--- a/src/data/invalid/DataObject-no-name.yaml
+++ b/src/data/invalid/DataObject-no-name.yaml
@@ -1,3 +1,4 @@
 description: "Crispr Terms for nmdc:ann0vx38"
 id: nmdc:dobj-99-abc123
 type: nmdc:DataObject
+data_object_type: Crispr Terms

--- a/src/data/invalid/DataObject-no-type.yaml
+++ b/src/data/invalid/DataObject-no-type.yaml
@@ -1,3 +1,4 @@
 description: "Crispr Terms for nmdc:ann0vx38"
 id: nmdc:dobj-99-abc123
 name: "Crispr Terms for nmdc:ann0vx38"
+data_object_type: Crispr Terms

--- a/src/data/valid/DataObject-1.yaml
+++ b/src/data/valid/DataObject-1.yaml
@@ -3,3 +3,4 @@ type: nmdc:DataObject
 name: mapping_stats.txt
 description: Metagenome Contig Coverage Stats for gold:Gp0061273
 file_size_bytes: 32787380
+data_object_type: Metagenome Bins

--- a/src/data/valid/DataObject-2.yaml
+++ b/src/data/valid/DataObject-2.yaml
@@ -3,3 +3,4 @@ name: assembly_scaffolds.fna
 description: Assembled scaffold fasta for gold:Gp0061273
 file_size_bytes: 205297945
 type: nmdc:DataObject
+data_object_type: Metagenome Bins

--- a/src/data/valid/DataObject-3.yaml
+++ b/src/data/valid/DataObject-3.yaml
@@ -3,3 +3,4 @@ name: mapping_stats.txt
 description: Metagenome Contig Coverage Stats for gold:Gp0061273
 file_size_bytes: 32787380
 type: nmdc:DataObject
+data_object_type: Metagenome Bins

--- a/src/data/valid/DataObject-Crisper-Terms-data_object_type.yaml
+++ b/src/data/valid/DataObject-Crisper-Terms-data_object_type.yaml
@@ -6,3 +6,4 @@ md5_checksum: "22afa3d49b73eaec2e9787a6b88fbdc3"
 name: Crispr Terms
 type: nmdc:DataObject
 url: http://example.com
+data_object_type: CheckM Statistics

--- a/src/data/valid/DataObject-minimal.yaml
+++ b/src/data/valid/DataObject-minimal.yaml
@@ -2,3 +2,4 @@ description: "Crispr Terms for nmdc:ann0vx38"
 id: "nmdc:dobj-11-dtTMNb"
 name: Crispr Terms
 type: nmdc:DataObject
+data_object_type: Crispr Terms

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -3076,16 +3076,19 @@ data_object_set:
     name: 11340.8.202049.GTCTCCT-AAGGAGA.fastq.gz
     description: Raw sequencer read data
     file_size_bytes: 9208349052
+    data_object_type: Metagenome Raw Reads
   - id: nmdc:dobj-99-7zrm55
     type: nmdc:DataObject
     name: 11839.4.222578.GAGCTCA-TTGAGCT.fastq.gz
     description: Raw sequencer read data
     file_size_bytes: 34243309819
+    data_object_type: Metagenome Raw Reads
   - id: nmdc:dobj-99-sQQw0I
     type: nmdc:DataObject
     name: 12660.4.274923.GATCGTAC-GTACGATC.fastq.gz
     description: Raw sequencer read data
     file_size_bytes: 7580035314
+    data_object_type: Metagenome Raw Reads
   - id: nmdc:dobj-70-izwYW6
     type: nmdc:DataObject
     name: CoreMS.toml
@@ -3111,6 +3114,7 @@ data_object_set:
     type: nmdc:DataObject
     name: emsl_calibration_run.raw
     description: GCMS data file
+    data_object_type: GC-MS Raw Data
     data_category: instrument_data
     file_size_bytes: 9208349052
     url: https://emsl_site/emsl_calibration_run.raw

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -65,6 +65,7 @@ data_object_set:
     file_size_bytes: 9208349052
     in_manifest:
       - nmdc:manif-99-krhtest                                   #defined below
+    data_object_type: GC-MS Raw Data
   - id: nmdc:dobj-11-9n9n9n
     type: nmdc:DataObject
     data_category: instrument_data
@@ -74,3 +75,4 @@ data_object_set:
     file_size_bytes: 9208349052
     in_manifest:
       - nmdc:manif-99-krhtest                                   #defined below
+    data_object_type: GC-MS Raw Data

--- a/src/data/valid/Database-nmdc-example.yaml
+++ b/src/data/valid/Database-nmdc-example.yaml
@@ -282,13 +282,16 @@ data_object_set:
     description: Raw sequencer read data
     file_size_bytes: 9208349052
     type: nmdc:DataObject
+    data_object_type: Metagenome Raw Read 1
   - id: nmdc:dobj-99-7zrm55
     name: 11839.4.222578.GAGCTCA-TTGAGCT.fastq.gz
     description: Raw sequencer read data
     file_size_bytes: 34243309819
     type: nmdc:DataObject
+    data_object_type: Metagenome Raw Read 1
   - id: nmdc:dobj-99-sQQw0I
     name: 12660.4.274923.GATCGTAC-GTACGATC.fastq.gz
     description: Raw sequencer read data
     file_size_bytes: 7580035314
     type: nmdc:DataObject
+    data_object_type: Metagenome Raw Read 1

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -374,6 +374,8 @@ classes:
           syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
         range: DataEmitterProcess
+      data_object_type:
+        required: true
   DataEmitterProcess:
     class_uri: nmdc:DataEmitterProcess
     is_a: PlannedProcess


### PR DESCRIPTION
This MR will close #2431 

It will make the slot `data_object_type` required on `DataObject`s.  I've updated all valid and invalid tests accordingly and added an invalid test that is missing this field.

Note that _in theory_ this could make data that were compliant now not compliant; though our NMDC mongo data are fully populated with regards to this field (see https://github.com/microbiomedata/issues/issues/1175).  Therefore, the migrator implemented here simply raises an error if it encounters data that do not meet this expectation. 

