### PR TITLE
Make `eluent_introduction_category` & `has_mass_spectrometry_configuration` slots on `MassSpectrometry` required and implement migrator 

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/__init__.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/__init__.py
@@ -3,6 +3,7 @@ from typing import List, Type
 from nmdc_schema.migrators.migrator_base import MigratorBase
 from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_1
 from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_2
+from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_3
 
 
 
@@ -25,4 +26,6 @@ def get_migrator_classes() -> List[Type[MigratorBase]]:
     return [
         migrator_from_11_7_0_to_11_8_0_part_1.Migrator,
         migrator_from_11_7_0_to_11_8_0_part_2.Migrator,
+        migrator_from_11_7_0_to_11_8_0_part_3.Migrator,
     ]
+

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -13,7 +13,7 @@ class Migrator(MigratorBase):
 
     def validate_mass_spec_slots(self, data_generation_record: dict) -> None:
         r"""
-        If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration AND those keys do not have a value, raise a ValueError.
+        If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration OR those keys do not have a value, raise a ValueError.
 
         >>> m = Migrator()
         >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -13,7 +13,7 @@ class Migrator(MigratorBase):
 
     def validate_mass_spec_slots(self, data_generation_record: dict) -> None:
         r"""
-        If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration, raise a ValueError.
+        If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration AND those keys do not have a value, raise a ValueError.
 
         >>> m = Migrator()
         >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -1,0 +1,23 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+from nmdc_schema.migrators.helpers import load_yaml_asset
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.8.0.part_2"
+    _to_version = "11.8.0.part_3"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        self.adapter.process_each_document("data_generation_set", [self.validate_mass_spec_slots])
+
+    def validate_mass_spec_slots(self, data_object: dict) -> dict:
+        r"""
+        If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration, raise a ValueError.
+        If the data object's eluent_introduction_category is liquid_chromatography, then ensure has_chromatography_configuration slot is present.
+
+        >>> m = Migrator()
+        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "liquid_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})
+        {'id': 123, 'type': 'nmdc:MassSpectrometry', 'eluent_introduction_category': 'liquid_chromatography', 'has_mass_spectrometry_configuration': 'nmdc:mscon-123'}
+        """
+        pass

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -9,15 +9,41 @@ class Migrator(MigratorBase):
 
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
-        self.adapter.process_each_document("data_generation_set", [self.validate_mass_spec_slots])
+        self.adapter.do_for_each_document("data_generation_set", [self.validate_mass_spec_slots])
 
-    def validate_mass_spec_slots(self, data_object: dict) -> dict:
+    def validate_mass_spec_slots(self, data_object: dict) -> None:
         r"""
         If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration, raise a ValueError.
         If the data object's eluent_introduction_category is liquid_chromatography, then ensure has_chromatography_configuration slot is present.
 
         >>> m = Migrator()
+        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})
+        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "liquid_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123", "has_chromatography_configuration": "nmdc:chromcon-123"})
+        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `has_mass_spectrometry_configuration` is required and is not present in the data object 123
+        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})
+        Traceback (most recent call last):
+        ... 
+        ValueError: `eluent_introduction_category` is required and is not present in the data object 123
         >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "liquid_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})
-        {'id': 123, 'type': 'nmdc:MassSpectrometry', 'eluent_introduction_category': 'liquid_chromatography', 'has_mass_spectrometry_configuration': 'nmdc:mscon-123'}
+        Traceback (most recent call last):
+        ...
+        ValueError: `has_chromatography_configuration` is required because `eluent_introduction_category` is `liquid_chromatography` and is not present in the data object 123
         """
-        pass
+        # get the eluent_introduction_category and has_mass_spectrometry_configuration fields
+        if data_object.get("type") == "nmdc:MassSpectrometry":
+            eluent_introduction_category = data_object.get("eluent_introduction_category")
+            
+            if eluent_introduction_category is None:
+                raise ValueError(f"`eluent_introduction_category` is required and is not present in the data object {data_object.get('id')}")
+            
+            elif eluent_introduction_category == "liquid_chromatography":
+                has_chrom_config = data_object.get("has_chromatography_configuration")
+                if has_chrom_config is None:
+                    raise ValueError(f"`has_chromatography_configuration` is required because `eluent_introduction_category` is `liquid_chromatography` and is not present in the data object {data_object.get('id')}")
+            
+            has_mass_spec_config = data_object.get("has_mass_spectrometry_configuration")
+            if has_mass_spec_config is None:
+                raise ValueError(f"`has_mass_spectrometry_configuration` is required and is not present in the data object {data_object.get('id')}")

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -9,7 +9,7 @@ class Migrator(MigratorBase):
 
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
-        self.adapter.do_for_each_document("data_generation_set", [self.validate_mass_spec_slots])
+        self.adapter.do_for_each_document("data_generation_set", self.validate_mass_spec_slots)
 
     def validate_mass_spec_slots(self, data_generation_record: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -11,14 +11,12 @@ class Migrator(MigratorBase):
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
         self.adapter.do_for_each_document("data_generation_set", [self.validate_mass_spec_slots])
 
-    def validate_mass_spec_slots(self, data_object: dict) -> None:
+    def validate_mass_spec_slots(self, data_generation_record: dict) -> None:
         r"""
         If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration, raise a ValueError.
-        If the data object's eluent_introduction_category is liquid_chromatography, then ensure has_chromatography_configuration slot is present.
 
         >>> m = Migrator()
         >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})
-        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "liquid_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123", "has_chromatography_configuration": "nmdc:chromcon-123"})
         >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography"})
         Traceback (most recent call last):
         ...
@@ -27,23 +25,14 @@ class Migrator(MigratorBase):
         Traceback (most recent call last):
         ... 
         ValueError: `eluent_introduction_category` is required and is not present in the data object 123
-        >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "liquid_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})
-        Traceback (most recent call last):
-        ...
-        ValueError: `has_chromatography_configuration` is required because `eluent_introduction_category` is `liquid_chromatography` and is not present in the data object 123
         """
         # get the eluent_introduction_category and has_mass_spectrometry_configuration fields
-        if data_object.get("type") == "nmdc:MassSpectrometry":
-            eluent_introduction_category = data_object.get("eluent_introduction_category")
+        if data_generation_record.get("type") == "nmdc:MassSpectrometry":
+            eluent_introduction_category = data_generation_record.get("eluent_introduction_category")
             
             if eluent_introduction_category is None:
-                raise ValueError(f"`eluent_introduction_category` is required and is not present in the data object {data_object.get('id')}")
+                raise ValueError(f"`eluent_introduction_category` is required and is not present in the data object {data_generation_record.get('id')}")
             
-            elif eluent_introduction_category == "liquid_chromatography":
-                has_chrom_config = data_object.get("has_chromatography_configuration")
-                if has_chrom_config is None:
-                    raise ValueError(f"`has_chromatography_configuration` is required because `eluent_introduction_category` is `liquid_chromatography` and is not present in the data object {data_object.get('id')}")
-            
-            has_mass_spec_config = data_object.get("has_mass_spectrometry_configuration")
+            has_mass_spec_config = data_generation_record.get("has_mass_spectrometry_configuration")
             if has_mass_spec_config is None:
-                raise ValueError(f"`has_mass_spectrometry_configuration` is required and is not present in the data object {data_object.get('id')}")
+                raise ValueError(f"`has_mass_spectrometry_configuration` is required and is not present in the data object {data_generation_record.get('id')}")

--- a/src/data/invalid/MassSpectrometry-incl-nucleotideseq-slots.yaml
+++ b/src/data/invalid/MassSpectrometry-incl-nucleotideseq-slots.yaml
@@ -12,3 +12,5 @@ associated_studies:
   - nmdc:sty-00-555xxx
 analyte_category: metabolome
 target_gene: cool_gene_name
+eluent_introduction_category: direct_infusion_syringe
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/invalid/MassSpectrometry-invalid-gc-without-config.yaml
+++ b/src/data/invalid/MassSpectrometry-invalid-gc-without-config.yaml
@@ -10,4 +10,4 @@ associated_studies:
 eluent_introduction_category: gas_chromatography
 #has_chromatography_configuration: nmdc:chrcon-00-1234
 generates_calibration: nmdc:calib-00-1234
-
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/invalid/MassSpectrometry-invalid-lc-without-config.yaml
+++ b/src/data/invalid/MassSpectrometry-invalid-lc-without-config.yaml
@@ -1,3 +1,4 @@
+# Invalid because it does not have has_chromatography_configuration when eluent_introduction_category is liquid_chromatography
 type: nmdc:MassSpectrometry
 id: nmdc:dgms-00-1234
 has_input:

--- a/src/data/invalid/MassSpectrometry-invalid-lc-without-config.yaml
+++ b/src/data/invalid/MassSpectrometry-invalid-lc-without-config.yaml
@@ -9,3 +9,4 @@ associated_studies:
 # If eluent_introduction_category is liquid_chromatography or gas_chromatography, then has_chromatography_configuration is required
 eluent_introduction_category: liquid_chromatography
 #has_chromatography_configuration: nmdc:chrcon-00-1234
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/invalid/MassSpectrometry-invalid_no_eic.yaml
+++ b/src/data/invalid/MassSpectrometry-invalid_no_eic.yaml
@@ -1,0 +1,10 @@
+# Invalid because it does not have eluent_introduction_category
+type: nmdc:MassSpectrometry
+id: nmdc:dgms-00-1234
+has_input:
+  - nmdc:procsm-00-1234
+analyte_category: metabolome
+associated_studies:
+  - nmdc:sty-00-1234
+generates_calibration: nmdc:calib-00-1234
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/invalid/MassSpectrometry-invalid_no_hms_config.yaml
+++ b/src/data/invalid/MassSpectrometry-invalid_no_hms_config.yaml
@@ -1,0 +1,10 @@
+# Invalid because it does not have has_mass_spectrometry_configuration
+type: nmdc:MassSpectrometry
+id: nmdc:dgms-00-1234
+has_input:
+  - nmdc:procsm-00-1234
+analyte_category: metabolome
+associated_studies:
+  - nmdc:sty-00-1234
+generates_calibration: nmdc:calib-00-1234
+eluent_introduction_category: gas_chromatography

--- a/src/data/invalid/MassSpectrometry-no-analyte_category.yaml
+++ b/src/data/invalid/MassSpectrometry-no-analyte_category.yaml
@@ -12,3 +12,5 @@ has_output:
   - nmdc:dobj-00-9n9n9n
 associated_studies:
   - nmdc:sty-00-555xxx
+eluent_introduction_category: direct_infusion_syringe
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/Database-MassSpectrometry-NucleotideSequencing.yaml
+++ b/src/data/valid/Database-MassSpectrometry-NucleotideSequencing.yaml
@@ -6,6 +6,8 @@ data_generation_set:
       - nmdc:sty-00-555xxx
     has_input:
       - nmdc:procsm-11-0wxpzf08
+    eluent_introduction_category: direct_infusion_syringe
+    has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11
   - id: nmdc:dgns-99-gKlQlF
     type: nmdc:NucleotideSequencing
     analyte_category: metagenome # allows metabolome
@@ -13,5 +15,4 @@ data_generation_set:
       - nmdc:sty-00-555xxx
     has_input:
       - nmdc:procsm-11-0wxpzf08
-    eluent_introduction_category: direct_infusion_syringe
-    has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11
+

--- a/src/data/valid/Database-MassSpectrometry-NucleotideSequencing.yaml
+++ b/src/data/valid/Database-MassSpectrometry-NucleotideSequencing.yaml
@@ -13,3 +13,5 @@ data_generation_set:
       - nmdc:sty-00-555xxx
     has_input:
       - nmdc:procsm-11-0wxpzf08
+    eluent_introduction_category: direct_infusion_syringe
+    has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/Database-MassSpectrometry-dgms-minimal.yaml
+++ b/src/data/valid/Database-MassSpectrometry-dgms-minimal.yaml
@@ -6,3 +6,5 @@ data_generation_set:
       - nmdc:sty-00-555xxx
     has_input:
       - nmdc:procsm-11-0wxpzf08
+    eluent_introduction_category: direct_infusion_syringe
+    has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/MassSpectrometry-dgms-minimal.yaml
+++ b/src/data/valid/MassSpectrometry-dgms-minimal.yaml
@@ -5,4 +5,6 @@ associated_studies:
   - nmdc:sty-00-555xxx
 has_input:
   - nmdc:procsm-11-0wxpzf08
+eluent_introduction_category: direct_infusion_syringe
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11
 

--- a/src/data/valid/MassSpectrometry-omprc-minimal.yaml
+++ b/src/data/valid/MassSpectrometry-omprc-minimal.yaml
@@ -5,4 +5,6 @@ associated_studies:
   - nmdc:sty-00-555xxx
 has_input:
   - nmdc:procsm-11-0wxpzf08
+eluent_introduction_category: direct_infusion_syringe
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11
 

--- a/src/data/valid/MassSpectrometry-valid-gc-with-config.yaml
+++ b/src/data/valid/MassSpectrometry-valid-gc-with-config.yaml
@@ -10,3 +10,4 @@ associated_studies:
 eluent_introduction_category: gas_chromatography
 has_chromatography_configuration: nmdc:chrcon-00-1234
 generates_calibration: nmdc:calib-00-1234
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/MassSpectrometry-valid-lc-with-config.yaml
+++ b/src/data/valid/MassSpectrometry-valid-lc-with-config.yaml
@@ -9,3 +9,4 @@ associated_studies:
 # If eluent_introduction_category is liquid_chromatography or gas_chromatography, then has_chromatography_configuration is required
 eluent_introduction_category: liquid_chromatography
 has_chromatography_configuration: nmdc:chrcon-00-1234
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/MassSpectrometry-valid-syringe-without-config.yaml
+++ b/src/data/valid/MassSpectrometry-valid-syringe-without-config.yaml
@@ -9,3 +9,4 @@ associated_studies:
 # If eluent_introduction_category is liquid_chromatography or gas_chromatography, then has_chromatography_configuration is required
 eluent_introduction_category: direct_infusion_syringe
 #has_chromatography_configuration: nmdc:chrcon-00-1234
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/MassSpectrometryConfiguration-NOM.yaml
+++ b/src/data/valid/MassSpectrometryConfiguration-NOM.yaml
@@ -11,5 +11,3 @@ ionization_source: electrospray_ionization
 mass_spectrum_collection_modes: 
   - full_profile
 polarity_mode: negative
-eluent_introduction_category: direct_infusion_syringe
-has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/data/valid/MassSpectrometryConfiguration-NOM.yaml
+++ b/src/data/valid/MassSpectrometryConfiguration-NOM.yaml
@@ -11,3 +11,5 @@ ionization_source: electrospray_ionization
 mass_spectrum_collection_modes: 
   - full_profile
 polarity_mode: negative
+eluent_introduction_category: direct_infusion_syringe
+has_mass_spectrometry_configuration: nmdc:mscon-11-e1vant11

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -198,7 +198,7 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:mscon-{id_shoulder}-{id_blade}$"
           interpolated: true
-          required: true
+        required: true
       analyte_category: 
         range: MassSpectrometryEnum
       eluent_introduction_category:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -207,7 +207,6 @@ classes:
       - title: generates_calibration_required_if_gc
         description: >-
           If eluent_introduction_category is gas_chromatography, then generates_calibration is required.
-          If eluent_introduction_category is liquid_chromatography, then has_chromatography_configuration is required.
         preconditions:
           slot_conditions:
             eluent_introduction_category:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -198,12 +198,16 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:mscon-{id_shoulder}-{id_blade}$"
           interpolated: true
+          required: true
       analyte_category: 
         range: MassSpectrometryEnum
+      eluent_introduction_category:
+        required: true
     rules:
       - title: generates_calibration_required_if_gc
         description: >-
           If eluent_introduction_category is gas_chromatography, then generates_calibration is required.
+          If eluent_introduction_category is liquid_chromatography, then has_chromatography_configuration is required.
         preconditions:
           slot_conditions:
             eluent_introduction_category:


### PR DESCRIPTION
- Make MassSpectromery's slots eluent_introduction_category, has_mass_spectrometry_configuration required
- create a migrator to that will raise an error if the slots do not exist. Data for these slots has already been back filled. 
- Tested the migrators locally against mongo db data

This MR will close #2455 