### PR TITLE
Add "Direct Infusion FT-ICR MS Analysis Results" to migrator_from_11_7_to_11_8_part_2 mapping

### DIFF
--- a/nmdc_schema/migrators/assets/migrator_from_11_7_to_11_8/data_category_map.yaml
+++ b/nmdc_schema/migrators/assets/migrator_from_11_7_to_11_8/data_category_map.yaml
@@ -70,3 +70,4 @@ Analysis Tool Parameter File: workflow_parameter_data
 Contaminants Amino Acid FASTA: workflow_parameter_data
 GC-MS Raw Data: instrument_data
 GC-MS Metabolomics Results: processed_data
+Direct Infusion FT-ICR MS Analysis Results: processed_data


### PR DESCRIPTION
From schema release 11.7 there is a new data_object_type. Add `Direct Infusion FT-ICR MS Analysis Results` to the migrator mapping. 