### PR TITLE
Make some slots on MassSpectrometryConfiguration and ChromatographyConfiguration required and create a migrator

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/__init__.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/__init__.py
@@ -4,6 +4,8 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_1
 from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_2
 from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_3
+from nmdc_schema.migrators.partials.migrator_from_11_7_0_to_11_8_0 import migrator_from_11_7_0_to_11_8_0_part_4
+
 
 
 
@@ -27,5 +29,6 @@ def get_migrator_classes() -> List[Type[MigratorBase]]:
         migrator_from_11_7_0_to_11_8_0_part_1.Migrator,
         migrator_from_11_7_0_to_11_8_0_part_2.Migrator,
         migrator_from_11_7_0_to_11_8_0_part_3.Migrator,
+        migrator_from_11_7_0_to_11_8_0_part_4.Migrator,
     ]
 

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -29,7 +29,6 @@ class Migrator(MigratorBase):
         # get the eluent_introduction_category and has_mass_spectrometry_configuration fields
         if data_generation_record.get("type") == "nmdc:MassSpectrometry":
             eluent_introduction_category = data_generation_record.get("eluent_introduction_category")
-            
             if eluent_introduction_category is None:
                 raise ValueError(f"`eluent_introduction_category` is required and is not present in the data object {data_generation_record.get('id')}")
             

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_3.py
@@ -13,7 +13,7 @@ class Migrator(MigratorBase):
 
     def validate_mass_spec_slots(self, data_generation_record: dict) -> None:
         r"""
-        If the data object does not have eluent_introduction_category or has_mass_spectrometry_configuration AND those keys do not have a value, raise a ValueError.
+        If the data object is of type `nmdc:MassSpectrometry` and either (a) its `eluent_introduction_category` field is missing or consists of `None`, or (b) its `has_mass_spectrometry_configuration` field is missing or consists of `None`, raise a `ValueError`.
 
         >>> m = Migrator()
         >>> m.validate_mass_spec_slots({"id": 123, "type": "nmdc:MassSpectrometry", "eluent_introduction_category": "gas_chromatography", "has_mass_spectrometry_configuration": "nmdc:mscon-123"})

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
@@ -45,7 +45,6 @@ class Migrator(MigratorBase):
         # get the slots that are required for mass spectrometry configuration
         if configuration_record.get("type") == "nmdc:MassSpectrometryConfiguration":
             mass_spectrometry_acquisition_strategy = configuration_record.get("mass_spectrometry_acquisition_strategy")
-            
             if mass_spectrometry_acquisition_strategy is None:
                 raise ValueError(f"`mass_spectrometry_acquisition_strategy` is required and is not present in the configuration record {configuration_record.get('id')}")
             
@@ -56,12 +55,15 @@ class Migrator(MigratorBase):
             mass_analyzers = configuration_record.get("mass_analyzers")
             if mass_analyzers is None:
                 raise ValueError(f"`mass_analyzers` is required and is not present in the configuration record {configuration_record.get('id')}")
+
             ionization_source = configuration_record.get("ionization_source")
             if ionization_source is None:
                 raise ValueError(f"`ionization_source` is required and is not present in the configuration record {configuration_record.get('id')}")
+
             mass_spectrum_collection_modes = configuration_record.get("mass_spectrum_collection_modes")
             if mass_spectrum_collection_modes is None:
                 raise ValueError(f"`mass_spectrum_collection_modes` is required and is not present in the configuration record {configuration_record.get('id')}")
+
             polarity_mode = configuration_record.get("polarity_mode")
             if polarity_mode is None:
                 raise ValueError(f"`polarity_mode` is required and is not present in the configuration record {configuration_record.get('id')}")

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
@@ -42,31 +42,32 @@ class Migrator(MigratorBase):
         ...
         ValueError: `mass_spectrometry_acquisition_strategy` is required and is not present in the configuration record 123
         """
+        config_record_id = configuration_record.get("id")
         # get the slots that are required for mass spectrometry configuration
         if configuration_record.get("type") == "nmdc:MassSpectrometryConfiguration":
             mass_spectrometry_acquisition_strategy = configuration_record.get("mass_spectrometry_acquisition_strategy")
             if mass_spectrometry_acquisition_strategy is None:
-                raise ValueError(f"`mass_spectrometry_acquisition_strategy` is required and is not present in the configuration record {configuration_record.get('id')}")
+                raise ValueError(f"`mass_spectrometry_acquisition_strategy` is required and is not present in the configuration record {config_record_id}")
             
             resolution_categories = configuration_record.get("resolution_categories")
             if resolution_categories is None:
-                raise ValueError(f"`resolution_categories` is required and is not present in the configuration record {configuration_record.get('id')}")
+                raise ValueError(f"`resolution_categories` is required and is not present in the configuration record {config_record_id}")
             
             mass_analyzers = configuration_record.get("mass_analyzers")
             if mass_analyzers is None:
-                raise ValueError(f"`mass_analyzers` is required and is not present in the configuration record {configuration_record.get('id')}")
-
+                raise ValueError(f"`mass_analyzers` is required and is not present in the configuration record {config_record_id}")
+            
             ionization_source = configuration_record.get("ionization_source")
             if ionization_source is None:
-                raise ValueError(f"`ionization_source` is required and is not present in the configuration record {configuration_record.get('id')}")
-
+                raise ValueError(f"`ionization_source` is required and is not present in the configuration record {config_record_id}")
+            
             mass_spectrum_collection_modes = configuration_record.get("mass_spectrum_collection_modes")
             if mass_spectrum_collection_modes is None:
-                raise ValueError(f"`mass_spectrum_collection_modes` is required and is not present in the configuration record {configuration_record.get('id')}")
-
+                raise ValueError(f"`mass_spectrum_collection_modes` is required and is not present in the configuration record {config_record_id}")
+            
             polarity_mode = configuration_record.get("polarity_mode")
             if polarity_mode is None:
-                raise ValueError(f"`polarity_mode` is required and is not present in the configuration record {configuration_record.get('id')}")
+                raise ValueError(f"`polarity_mode` is required and is not present in the configuration record {config_record_id}")
     
     def validate_chrom_config_slots(self, configuration_record:dict) -> None:
         r"""
@@ -83,12 +84,13 @@ class Migrator(MigratorBase):
         ...
         ValueError: `chromatographic_category` is required and is not present in the configuration record 123
         """
+        config_record_id = configuration_record.get("id")
         if configuration_record.get("type") == "nmdc:ChromatographyConfiguration":
             chromatographic_category = configuration_record.get("chromatographic_category")
             if chromatographic_category is None:
-                raise ValueError(f"`chromatographic_category` is required and is not present in the configuration record {configuration_record.get('id')}")
+                raise ValueError(f"`chromatographic_category` is required and is not present in the configuration record {config_record_id}")
             
             stationary_phase = configuration_record.get("stationary_phase")
             if stationary_phase is None:
-                raise ValueError(f"`stationary_phase` is required and is not present in the configuration record {configuration_record.get('id')}")
+                raise ValueError(f"`stationary_phase` is required and is not present in the configuration record {config_record_id}")
             

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
@@ -70,7 +70,7 @@ class Migrator(MigratorBase):
     
     def validate_chrom_config_slots(self, configuration_record:dict) -> None:
         r"""
-        If the configuration record is of type ChromatographyConfiguration, does not chromatographic_category and stationary_phase, AND those keys do not have a value, raise a ValueError.
+        If the configuration record is of type `ChromatographyConfiguration` and either (a) its `chromatographic_category` field is missing or consists of `None`, or (b) its `stationary_phase` field is missing or consists of `None`, raise a `ValueError`.
 
         >>> m = Migrator()
         >>> m.validate_chrom_config_slots({"id": 123, "type": "nmdc:ChromatographyConfiguration", "chromatographic_category": "gas_chromatography", "stationary_phase": "C18"})

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
@@ -13,7 +13,7 @@ class Migrator(MigratorBase):
 
     def validate_mass_spec_config_slots(self, configuration_record: dict) -> None:
         r"""
-        If the configuration record is of type MassSpectrometryConfiguration, does not have mass_spectrometry_acquisition_strategy, resolution_categories, mass_analyzers, ionization_source, mass_spectrum_collection_modes, and polarity_mode AND those keys do not have a value, raise a ValueError.
+        If the configuration record is of type MassSpectrometryConfiguration, does not have mass_spectrometry_acquisition_strategy, resolution_categories, mass_analyzers, ionization_source, mass_spectrum_collection_modes, and polarity_mode OR any of those keys does not have a value, raise a ValueError.
 
         >>> m = Migrator()
         >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
@@ -1,0 +1,92 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.8.0.part_3"
+    _to_version = "11.8.0.part_4"
+
+    def upgrade(self) -> None:
+        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+        self.adapter.do_for_each_document("configuration_set", self.validate_mass_spec_config_slots)
+        self.adapter.do_for_each_document("configuration_set", self.validate_chrom_config_slots)
+
+    def validate_mass_spec_config_slots(self, configuration_record: dict) -> None:
+        r"""
+        If the configuration record is of type MassSpectrometryConfiguration, does not have mass_spectrometry_acquisition_strategy, resolution_categories, mass_analyzers, ionization_source, mass_spectrum_collection_modes, and polarity_mode AND those keys do not have a value, raise a ValueError.
+
+        >>> m = Migrator()
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid"))
+        Traceback (most recent call last):
+        ...
+        ValueError: `polarity_mode` is required and is not present in the configuration record 123
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "polarity_mode": "positive"})
+        Traceback (most recent call last):
+        ... 
+        ValueError: `mass_spectrum_collection_modes` is required and is not present in the configuration record 123
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `ionization_source` is required and is not present in the configuration record 123
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `mass_analyzers` is required and is not present in the configuration record 123
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `resolution_categories` is required and is not present in the configuration record 123
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `mass_spectrometry_acquisition_strategy` is required and is not present in the configuration record 123
+        """
+        # get the slots that are required for mass spectrometry configuration
+        if configuration_record.get("type") == "nmdc:MassSpectrometryConfiguration":
+            mass_spectrometry_acquisition_strategy = configuration_record.get("mass_spectrometry_acquisition_strategy")
+            
+            if mass_spectrometry_acquisition_strategy is None:
+                raise ValueError(f"`mass_spectrometry_acquisition_strategy` is required and is not present in the configuration record {configuration_record.get('id')}")
+            
+            resolution_categories = configuration_record.get("resolution_categories")
+            if resolution_categories is None:
+                raise ValueError(f"`resolution_categories` is required and is not present in the configuration record {configuration_record.get('id')}")
+            
+            mass_analyzers = configuration_record.get("mass_analyzers")
+            if mass_analyzers is None:
+                raise ValueError(f"`mass_analyzers` is required and is not present in the configuration record {configuration_record.get('id')}")
+            ionization_source = configuration_record.get("ionization_source")
+            if ionization_source is None:
+                raise ValueError(f"`ionization_source` is required and is not present in the configuration record {configuration_record.get('id')}")
+            mass_spectrum_collection_modes = configuration_record.get("mass_spectrum_collection_modes")
+            if mass_spectrum_collection_modes is None:
+                raise ValueError(f"`mass_spectrum_collection_modes` is required and is not present in the configuration record {configuration_record.get('id')}")
+            polarity_mode = configuration_record.get("polarity_mode")
+            if polarity_mode is None:
+                raise ValueError(f"`polarity_mode` is required and is not present in the configuration record {configuration_record.get('id')}")
+    
+    def validate_chrom_config_slots(self, configuration_record:dict) -> None:
+        r"""
+        If the configuration record is of type ChromatographyConfiguration, does not chromatographic_category and stationary_phase, AND those keys do not have a value, raise a ValueError.
+        
+        >>> m = Migrator()
+        >>> m.validate_chrom_config_slots({"id": 123, "type": "nmdc:ChromatographyConfiguration", "chromatographic_category": "gas_chromatography", "stationary_phase": "C18"})
+        >>> m.validate_chrom_config_slots({"id": 123, "type": "nmdc:ChromatographyConfiguration", "chromatographic_category": "gas_chromatography"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `stationary_phase` is required and is not present in the configuration record 123
+        >>> m.validate_chrom_config_slots({"id": 123, "type": "nmdc:ChromatographyConfiguration", "stationary_phase": "C18"})
+        Traceback (most recent call last):
+        ...
+        ValueError: `chromatographic_category` is required and is not present in the configuration record 123
+        """
+        if configuration_record.get("type") == "nmdc:ChromatographyConfiguration":
+            chromatographic_category = configuration_record.get("chromatographic_category")
+            if chromatographic_category is None:
+                raise ValueError(f"`chromatographic_category` is required and is not present in the configuration record {configuration_record.get('id')}")
+            
+            stationary_phase = configuration_record.get("stationary_phase")
+            if stationary_phase is None:
+                raise ValueError(f"`stationary_phase` is required and is not present in the configuration record {configuration_record.get('id')}")
+            

--- a/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_7_0_to_11_8_0/migrator_from_11_7_0_to_11_8_0_part_4.py
@@ -17,7 +17,7 @@ class Migrator(MigratorBase):
 
         >>> m = Migrator()
         >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid", "polarity_mode": "positive"})
-        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid"))
+        >>> m.validate_mass_spec_config_slots({"id": 123, "type": "nmdc:MassSpectrometryConfiguration", "mass_spectrometry_acquisition_strategy": "data_independent_acquisition", "resolution_categories": "high", "mass_analyzers": "ion_trap", "ionization_source": "electron_ionization", "mass_spectrum_collection_modes": "centroid"})
         Traceback (most recent call last):
         ...
         ValueError: `polarity_mode` is required and is not present in the configuration record 123
@@ -69,7 +69,7 @@ class Migrator(MigratorBase):
     def validate_chrom_config_slots(self, configuration_record:dict) -> None:
         r"""
         If the configuration record is of type ChromatographyConfiguration, does not chromatographic_category and stationary_phase, AND those keys do not have a value, raise a ValueError.
-        
+
         >>> m = Migrator()
         >>> m.validate_chrom_config_slots({"id": 123, "type": "nmdc:ChromatographyConfiguration", "chromatographic_category": "gas_chromatography", "stationary_phase": "C18"})
         >>> m.validate_chrom_config_slots({"id": 123, "type": "nmdc:ChromatographyConfiguration", "chromatographic_category": "gas_chromatography"})

--- a/src/data/invalid/ChromatograohyConfiguration-invalid-no_sp.yaml
+++ b/src/data/invalid/ChromatograohyConfiguration-invalid-no_sp.yaml
@@ -1,0 +1,6 @@
+# this is invalid because it is missing the required field `stationary_phase`
+id: nmdc:chrcon-99-oW43DzG0
+type: nmdc:ChromatographyConfiguration
+name: "EMSL GC method for small molecules"
+description: "EMSL's GC method for small molecule analysis"
+chromatographic_category: gas_chromatography

--- a/src/data/invalid/ChromatographyConfiguration-invalid-no_CC.yaml
+++ b/src/data/invalid/ChromatographyConfiguration-invalid-no_CC.yaml
@@ -1,0 +1,6 @@
+#this is invalid because it is missing the chromatographic_category field
+id: nmdc:chrcon-99-oW43DzG0
+type: nmdc:ChromatographyConfiguration
+name: "EMSL LC method for non-polar metabolites"
+description: "EMSL's LC method for non-polar metabolites"
+stationary_phase: C18

--- a/src/data/invalid/MassSpectrometryConfiguration-invalid-no_is.yaml
+++ b/src/data/invalid/MassSpectrometryConfiguration-invalid-no_is.yaml
@@ -1,0 +1,13 @@
+# this is invalid because it is missing the required field `ionization_source`
+id: nmdc:mscon-99-oW43DzG0
+name: EMSL_NOM_method1
+description: Mass Spectrometry method used by EMSL for NOM analysis
+type: nmdc:MassSpectrometryConfiguration
+mass_spectrometry_acquisition_strategy: full_scan_only
+resolution_categories:
+  - high
+mass_analyzers: 
+  - ion_cyclotron_resonance
+mass_spectrum_collection_modes: 
+  - full_profile
+polarity_mode: negative

--- a/src/data/invalid/MassSpectrometryConfiguration-invalid-no_ma.yaml
+++ b/src/data/invalid/MassSpectrometryConfiguration-invalid-no_ma.yaml
@@ -1,0 +1,12 @@
+# this is invalid because it is missing the required field `mass_analyzers`
+id: nmdc:mscon-99-oW43DzG0
+name: EMSL_NOM_method1
+description: Mass Spectrometry method used by EMSL for NOM analysis
+type: nmdc:MassSpectrometryConfiguration
+mass_spectrometry_acquisition_strategy: full_scan_only
+resolution_categories:
+  - high
+ionization_source: electrospray_ionization
+mass_spectrum_collection_modes: 
+  - full_profile
+polarity_mode: negative

--- a/src/data/invalid/MassSpectrometryConfiguration-invalid-no_msas.yaml
+++ b/src/data/invalid/MassSpectrometryConfiguration-invalid-no_msas.yaml
@@ -1,0 +1,13 @@
+# this file is invalid because it does not have a `mass_spectrometry_acquisition_strategy` field
+id: nmdc:mscon-99-oW43DzG0
+name: EMSL_NOM_method1
+description: Mass Spectrometry method used by EMSL for NOM analysis
+type: nmdc:MassSpectrometryConfiguration
+resolution_categories:
+  - high
+mass_analyzers: 
+  - ion_cyclotron_resonance
+ionization_source: electrospray_ionization
+mass_spectrum_collection_modes: 
+  - full_profile
+polarity_mode: negative

--- a/src/data/invalid/MassSpectrometryConfiguration-invalid-no_mscm.yaml
+++ b/src/data/invalid/MassSpectrometryConfiguration-invalid-no_mscm.yaml
@@ -1,0 +1,12 @@
+# this is invalid because it is missing the required field `mass_spectrum_collection_modes`
+id: nmdc:mscon-99-oW43DzG0
+name: EMSL_NOM_method1
+description: Mass Spectrometry method used by EMSL for NOM analysis
+type: nmdc:MassSpectrometryConfiguration
+mass_spectrometry_acquisition_strategy: full_scan_only
+resolution_categories:
+  - high
+mass_analyzers: 
+  - ion_cyclotron_resonance
+ionization_source: electrospray_ionization
+polarity_mode: negative

--- a/src/data/invalid/MassSpectrometryConfiguration-invalid-no_pm.yaml
+++ b/src/data/invalid/MassSpectrometryConfiguration-invalid-no_pm.yaml
@@ -1,0 +1,13 @@
+# this is invalid because it is missing the required field `polarity_mode`
+id: nmdc:mscon-99-oW43DzG0
+name: EMSL_NOM_method1
+description: Mass Spectrometry method used by EMSL for NOM analysis
+type: nmdc:MassSpectrometryConfiguration
+mass_spectrometry_acquisition_strategy: full_scan_only
+resolution_categories:
+  - high
+mass_analyzers: 
+  - ion_cyclotron_resonance
+ionization_source: electrospray_ionization
+mass_spectrum_collection_modes: 
+  - full_profile

--- a/src/data/invalid/MassSpectrometryConfiguration-invalid-no_rc.yaml
+++ b/src/data/invalid/MassSpectrometryConfiguration-invalid-no_rc.yaml
@@ -1,0 +1,12 @@
+# this is invalid because it is missing the required field `resolution_categories`
+id: nmdc:mscon-99-oW43DzG0
+name: EMSL_NOM_method1
+description: Mass Spectrometry method used by EMSL for NOM analysis
+type: nmdc:MassSpectrometryConfiguration
+mass_spectrometry_acquisition_strategy: full_scan_only
+mass_analyzers: 
+  - ion_cyclotron_resonance
+ionization_source: electrospray_ionization
+mass_spectrum_collection_modes: 
+  - full_profile
+polarity_mode: negative

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -47,6 +47,7 @@ configuration_set:
     type: nmdc:MassSpectrometryConfiguration
     name: "EMSL EI mass spectrometry method for small molecules"
     description: "Electron impact mass spectrometry method for small molecules"
+    mass_spectrometry_acquisition_strategy: data_dependent_acquisition
     ionization_source: electron_ionization
     mass_analyzers:
       - quadrupole

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -268,6 +268,18 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:mscon-{id_shoulder}-{id_blade}$"
           interpolated: true
+      mass_spectrometry_acquisition_strategy:
+        required: true
+      resolution_categories:
+        required: true
+      mass_analyzers:
+        required: true
+      ionization_source:
+        required: true
+      mass_spectrum_collection_modes:
+        required: true
+      polarity_mode:
+        required: true
   
   ChromatographyConfiguration:
     is_a: Configuration
@@ -289,6 +301,10 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:chrcon-{id_shoulder}-{id_blade}$"
           interpolated: true
+      chromatographic_category:
+        required: true
+      stationary_phase:
+        required: true
   
   Manifest:
     is_a: InformationObject


### PR DESCRIPTION
MERGE AFTER #2461
- On MassSpectrometryConfiguration type, made slots mass_spectrometry_acquisition_strategy, resolution_categories, mass_analyzers, ionization_source, mass_spectrum_collection_modes, and polarity_mode required
- On ChromatographyConfiguration type, made slots chromatographic_category and stationary_phase required
- Created a migrator to validate the data
- Tested the migrators locally against mongo db data

Closes #2457 
Closes #2456 