### PR TITLE
UCUM constraint implemented as LinkML annotation and Python script, with intentionally failing UCUM test

### DIFF
--- a/assets/yq-for-mixs_subset_modified.txt
+++ b/assets/yq-for-mixs_subset_modified.txt
@@ -253,3 +253,5 @@ make: *** [Makefile:102: gen-project] Error 1
 # issue https://github.com/microbiomedata/nmdc-schema/issues/2472
 # see also https://github.com/microbiomedata/nmdc-schema/issues/1368
 'del(.prefixes.MIXS_yaml)'
+
+'.slots.temp.annotations.nmdc_mongodb_ucum_symbol |= "Cel"'

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -9847,6 +9847,7 @@ slots:
       preferred_unit:
         tag: preferred_unit
         value: degree Celsius
+      nmdc_mongodb_ucum_symbol: Cel
     description: Temperature of the sample at the time of sampling.
     title: temperature
     examples:

--- a/tests/test_report_biosample_slots_with_ucum_constraint.py
+++ b/tests/test_report_biosample_slots_with_ucum_constraint.py
@@ -1,0 +1,68 @@
+import os
+import pprint
+import unittest
+
+import jsonasobj2
+from linkml.validator import validate
+from linkml_runtime import SchemaView
+
+
+def create_schema_view():
+    return SchemaView(SCHEMA_FILE)
+
+
+ROOT = os.path.join(os.path.dirname(__file__), '..')
+SCHEMA_DIR = os.path.join(ROOT, "nmdc_schema")
+
+SCHEMA_FILE = os.path.join(SCHEMA_DIR, 'nmdc_materialized_patterns.yaml')
+
+
+class TestReportBiosampleSlotsWithUCUM(unittest.TestCase):
+
+    def test_report_biosample_slots_with_ucum_constraint(self):
+        """
+        Test to ensure that the report_biosample_slots_with_ucum_constraint function
+        correctly identifies and reports biosample slots with UCUM constraints.
+        """
+
+        schema_view = create_schema_view()
+
+        print("\n")
+
+        otherwise_schema_valid_biosample_dict = {'associated_studies': ['nmdc:sty-00-abc123'],
+                                                 'env_broad_scale': {'term': {'id': 'ENVO:00002030',
+                                                                              'type': 'nmdc:OntologyClass'},
+                                                                     'type': 'nmdc:ControlledIdentifiedTermValue'},
+                                                 'env_local_scale': {'term': {'id': 'ENVO:00002169',
+                                                                              'type': 'nmdc:OntologyClass'},
+                                                                     'type': 'nmdc:ControlledIdentifiedTermValue'},
+                                                 'env_medium': {
+                                                     'term': {'id': 'ENVO:00005792', 'type': 'nmdc:OntologyClass'},
+                                                     'type': 'nmdc:ControlledIdentifiedTermValue'},
+                                                 'id': 'nmdc:bsm-99-dtTMNb',
+                                                 'temp': {'has_numeric_value': 20,
+                                                          'has_raw_value': '20.0 C',
+                                                          'has_unit': 'C',
+                                                          'type': 'nmdc:QuantityValue'},
+                                                 'type': 'nmdc:Biosample'}
+
+        report = validate(otherwise_schema_valid_biosample_dict, SCHEMA_FILE, "Biosample")
+
+        assert len(report.results) == 0, "Biosample should be valid but has errors: " + pprint.pformat(report)
+
+        biosample_ucum_annotations = {}
+
+        induced_biosample_attributes = schema_view.induced_class("Biosample").attributes
+
+        for k, v in induced_biosample_attributes.items():
+            if v.annotations:
+                annotations_dict = jsonasobj2.as_dict(v.annotations)
+                if "nmdc_mongodb_ucum_symbol" in annotations_dict and annotations_dict["nmdc_mongodb_ucum_symbol"]:
+                    biosample_ucum_annotations[k] = annotations_dict["nmdc_mongodb_ucum_symbol"]["value"]
+
+        assert biosample_ucum_annotations["temp"] == "Cel"
+
+        for k, v in biosample_ucum_annotations.items():
+            if k in otherwise_schema_valid_biosample_dict:
+                assert otherwise_schema_valid_biosample_dict[k]['has_unit'] == v, \
+                    f"Expected unit {v} for biosample slot '{k}', but found {otherwise_schema_valid_biosample_dict[k]['has_unit']}"


### PR DESCRIPTION
one strength of this specification-by-annotation is the ability to share one (merged) schema file, not a schema file and a separate TSV specification 