### PR TITLE
Update 11.7->11.8 migrator data_category_type mapping to include "rRNA Filtered Sequencing Reads"

### DIFF
--- a/nmdc_schema/migrators/assets/migrator_from_11_7_to_11_8/data_category_map.yaml
+++ b/nmdc_schema/migrators/assets/migrator_from_11_7_to_11_8/data_category_map.yaml
@@ -71,3 +71,4 @@ Contaminants Amino Acid FASTA: workflow_parameter_data
 GC-MS Raw Data: instrument_data
 GC-MS Metabolomics Results: processed_data
 Direct Infusion FT-ICR MS Analysis Results: processed_data
+rRNA Filtered Sequencing Reads: processed_data


### PR DESCRIPTION
Bug identified where a record has the category "rRNA Filtered Sequencing Reads" but this was not included in the mapping yaml file. Add this value to the yaml file. 