### PR TITLE
Add `temperature` to `Extraction` class

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -447,6 +447,7 @@ classes:
       - extraction_targets
       - input_mass
       - volume
+      - temperature
     slot_usage:
       has_input:
         required: true


### PR DESCRIPTION
This PR adds the `temperature` slot to the `Extraction` class to accommodate modelling of lab processes in which an extraction was carried out at a specific temperature.

Only additive, will not make any existing data invalid, no migrator needed.