### PR TITLE
3 required jgi fields are often left blank

### DIFF
--- a/src/schema/portal_jgi_metagenomics.yaml
+++ b/src/schema/portal_jgi_metagenomics.yaml
@@ -164,6 +164,9 @@ slots:
     string_serialization: '{text}'
     slot_group: JGI-Metagenomics
     recommended: true
+    deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02
+    modified_by: ORCID:0000-0002-8683-0050
   dna_seq_project_name:
     title: DNA seq project name
     comments:

--- a/src/schema/portal_jgi_metagenomics.yaml
+++ b/src/schema/portal_jgi_metagenomics.yaml
@@ -206,3 +206,6 @@ slots:
     string_serialization: '{text}'
     slot_group: JGI-Metagenomics
     recommended: true
+    deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02
+    modified_by: ORCID:0000-0002-8683-0050

--- a/src/schema/portal_jgi_metagenomics.yaml
+++ b/src/schema/portal_jgi_metagenomics.yaml
@@ -107,7 +107,6 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
     deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
-    last_updated_on: 2025-07-02
     modified_by: ORCID:0000-0002-8683-0050
   dna_samp_id:
     title: DNA sample ID
@@ -168,7 +167,6 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
     deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
-    last_updated_on: 2025-07-02
     modified_by: ORCID:0000-0002-8683-0050
   dna_seq_project_name:
     title: DNA seq project name
@@ -207,5 +205,4 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
     deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
-    last_updated_on: 2025-07-02
     modified_by: ORCID:0000-0002-8683-0050

--- a/src/schema/portal_jgi_metagenomics.yaml
+++ b/src/schema/portal_jgi_metagenomics.yaml
@@ -107,6 +107,7 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
     deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02T00:00:00
     modified_by: ORCID:0000-0002-8683-0050
   dna_samp_id:
     title: DNA sample ID
@@ -167,6 +168,7 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
     deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02T00:00:00
     modified_by: ORCID:0000-0002-8683-0050
   dna_seq_project_name:
     title: DNA seq project name
@@ -205,4 +207,5 @@ slots:
     slot_group: JGI-Metagenomics
     recommended: true
     deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02T00:00:00
     modified_by: ORCID:0000-0002-8683-0050

--- a/src/schema/portal_jgi_metagenomics.yaml
+++ b/src/schema/portal_jgi_metagenomics.yaml
@@ -106,6 +106,9 @@ slots:
     string_serialization: '{text}'
     slot_group: JGI-Metagenomics
     recommended: true
+    deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02
+    modified_by: ORCID:0000-0002-8683-0050
   dna_samp_id:
     title: DNA sample ID
     todos:

--- a/src/schema/portal_jgi_metatranscriptomics.yaml
+++ b/src/schema/portal_jgi_metatranscriptomics.yaml
@@ -38,6 +38,9 @@ slots:
     string_serialization: '{text}'
     slot_group: JGI-Metatranscriptomics
     recommended: true
+    deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02T00:00:00
+    modified_by: ORCID:0000-0002-8683-0050
   rna_absorb1:
     description: 260/280 measurement of RNA sample purity
     title: RNA absorbance 260/280
@@ -157,6 +160,9 @@ slots:
     string_serialization: '{text}'
     slot_group: JGI-Metatranscriptomics
     recommended: true
+    deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02T00:00:00
+    modified_by: ORCID:0000-0002-8683-0050
   rna_samp_id:
     title: RNA sample ID
     comments:
@@ -213,6 +219,9 @@ slots:
     string_serialization: '{text}'
     slot_group: JGI-Metatranscriptomics
     recommended: true
+    deprecated: "This slot is not always provided by JGI and does not need to be in the file that we send back to JGI. Not needed in UI"
+    last_updated_on: 2025-07-02T00:00:00
+    modified_by: ORCID:0000-0002-8683-0050
   rna_seq_project_name:
     title: RNA seq project name
     comments:


### PR DESCRIPTION
Closes #2512 

deprecate these slots for DNA and RNA