### PR TITLE
Add `protocol_link` slot to `Configuration` class and corresponding example

### DIFF
--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -4638,6 +4638,10 @@ configuration_set:
       - ion_trap
     ionization_source: electrospray_ionization
     polarity_mode: positive
+    protocol_link:
+      type: nmdc:Protocol
+      url: http://example.com
+      name: EMSL Lipidomics Protocol
   - id: nmdc:mscon-99-oW43DzG2
     name: EMSL lipidomics mass spectrometry method, negative polarity
     description: Mass spectrometry method used by EMSL for lipidomics analysis, negative polarity

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -4638,10 +4638,6 @@ configuration_set:
       - ion_trap
     ionization_source: electrospray_ionization
     polarity_mode: positive
-    protocol_link:
-      type: nmdc:Protocol
-      url: http://example.com
-      name: EMSL Lipidomics Protocol
   - id: nmdc:mscon-99-oW43DzG2
     name: EMSL lipidomics mass spectrometry method, negative polarity
     description: Mass spectrometry method used by EMSL for lipidomics analysis, negative polarity

--- a/src/data/valid/Database-mass_spectrometry_gc.yaml
+++ b/src/data/valid/Database-mass_spectrometry_gc.yaml
@@ -56,6 +56,10 @@ configuration_set:
     mass_spectrum_collection_modes:
       - centroid
     polarity_mode: positive
+    protocol_link:
+      type: nmdc:Protocol
+      url: http://example.com
+      name: EMSL low resolution GCMS EI mass spectrometry protocol
 data_object_set:
   - id: nmdc:dobj-12-krhrtjw9
     type: nmdc:DataObject

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -246,6 +246,8 @@ classes:
     description: A set of parameters that define the actions of a process and is shared among multiple instances of the process.
     notes:
       - This class is intended to represent the parameters within a method file (or similar) that control a process.
+    slots:
+      - protocol_link
 
   MassSpectrometryConfiguration:
     is_a: Configuration


### PR DESCRIPTION
This MR adds `protocol_link` slot to `Configuration` class and adds a corresponding example.

Closes #2520.