### PR TITLE
Rename migrator to follow naming convention

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_8_0_to_10_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_8_0_to_10_9_0.py
@@ -10,21 +10,21 @@ class Migrator(MigratorBase):
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
 
-        # Update each document in the `workflow_execution_set` collection so was_informed_by is multivalued.
-
+        # Update each document in the `workflow_execution_set` collection so its `was_informed_by` value is a list.
         self.adapter.process_each_document(
             "workflow_execution_set", [self.update_was_informed_by]
         )
 
     def update_was_informed_by(self, workflow_execution: dict) -> dict:
         r"""
-        Update was_informed_by to be multivalued.
+        Update the document's `was_informed_by` value to be a list (since the schema says the slot is now multivalued).
 
         >>> m = Migrator()
-        >>> m.update_was_informed_by({'id': 1, 'was_informed_by': 'nmdc:dgns-11-abdc4'})  # test: value not relevant
-        {'id': 1, 'was_informed_by': ['nmdc:dgns-11-abdc4']}
+        >>> m.update_was_informed_by({'id': 1, 'was_informed_by': 'nmdc:dgns-11-000001'})
+        {'id': 1, 'was_informed_by': ['nmdc:dgns-11-000001']}
         """
         self.logger.info(f"Processing WorkflowExecution: {workflow_execution['id']}")
 
-        workflow_execution["was_informed_by"] = [workflow_execution["was_informed_by"]]
+        original_was_informed_by_value = workflow_execution["was_informed_by"]
+        workflow_execution["was_informed_by"] = [original_was_informed_by_value]
         return workflow_execution

--- a/nmdc_schema/migrators/migrator_from_11_8_0_to_10_9_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_8_0_to_10_9_0.py
@@ -4,8 +4,8 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 class Migrator(MigratorBase):
     r"""Migrates a database between two schemas."""
 
-    _from_version = "11.8.0"  
-    _to_version = "11.9.0"  
+    _from_version = "11.8.0"
+    _to_version = "11.9.0"
 
     def upgrade(self) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""


### PR DESCRIPTION
On this branch, I updated the filename of a migrator so it would contain a schema version number instead of a partial schema version number combined with an `x` placeholder. While doing that, I also made some aesthetic changes to the migrator, itself, which don't affect its functionality.