### PR TITLE
Deprecate `Metagenome Bins` FileTypeEnum permissible value

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -732,6 +732,10 @@ enums:
 
       Metagenome Bins:
         description: Metagenome bin contigs fasta
+        deprecated: Deprecated in favor of separate permissible values based on bin quality.
+        last_updated_on: 2025-07-14
+        deprecated_element_has_possible_replacement: 'Metagenome HQMQ Bins Compression File' or 'Metagenome LQ Bins Compression File'
+        modified_by: orcid:0000-0002-5004-3362
 
       Metagenome HQMQ Bins Compression File:
         description: Compressed file containing high quality and medium quality metagenome bins and associated files


### PR DESCRIPTION
This PR has the first stage of deprecation for `Metagenome Bins` as a FileTypeEnum permissible value.