### PR TITLE
Deprecate `Centrifuge Classification Report` FileTypeEnum permissible value

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -809,6 +809,10 @@ enums:
 
       Centrifuge Classification Report:
         description: Centrifuge output report file
+        deprecated: Deprecated in favor of 'Centrifuge output report file'.
+        last_updated_on: "2025-07-14"
+        modified_by: orcid:0000-0002-5004-3362
+        
 
       Centrifuge Taxonomic Classification:
         description: Centrifuge output read classification file


### PR DESCRIPTION
This PR deprecates`Centrifuge Classification Report`, a redundant FileTypeEnum permissible value.