### PR TITLE
Generate release artifacts for `nmdc-schema` version `11.9.1`

### DIFF
--- a/nmdc_schema/nmdc.py
+++ b/nmdc_schema/nmdc.py
@@ -1,5 +1,5 @@
 # Auto generated from nmdc.yaml by pythongen.py version: 0.0.1
-# Generation date: 2025-07-16T21:18:16
+# Generation date: 2025-07-17T02:25:52
 # Schema: NMDC
 #
 # id: https://w3id.org/nmdc/nmdc


### PR DESCRIPTION
On this branch, I went through the usual process of re-generating the "derived files" in preparation for creating a new GitHub Release of `nmdc-schema`. As I expected, the only thing that changed is the **timestamp** of when one of the files was re-generated. Since 11.9.0, the only thing that changes was migration code, which is not a factor to the "derived files."