### PR TITLE
Add permissible value to `InstrumentModelEnum`

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -774,6 +774,11 @@ enums:
           - Orbitrap Q-Exactive HF
           - Orbitrap Q-Exactive HF-X
 
+      orbitrap_iqx_tribrid:
+        aliases:
+          - Orbitrap IQ-X Tribrid
+          - Thermo Orbitrap IQ-X Tribrid
+
       solarix_7T:
         aliases:
           - 7T Solarix


### PR DESCRIPTION
Closes #2588 by adding `orbitrap_iqx_tribrid` as a permissible value to `InstrumentModelEnum`