### PR TITLE
Update method signature to comply with base class

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_11_9_1_to_11_10_0/migrator_from_11_9_1_to_11_10_0_part_2.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_9_1_to_11_10_0/migrator_from_11_9_1_to_11_10_0_part_2.py
@@ -7,8 +7,17 @@ class Migrator(MigratorBase):
     _from_version = "11.10.0.part_1"
     _to_version = "11.10.0.part_2"
 
-    def upgrade(self) -> None:
-        r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""
+        Migrates the database from conforming to the original schema, to conforming to the new schema.
+        
+        Note: The `commit_changes` parameter is not used, but must be present in the
+              method signature to comply with the base class. This migrator does
+              not use transactions—all changes are committed immediately.
+
+        TODO: Address the fact that existing migrators' `upgrade` methods
+              no longer comply with the base class.
+        """
 
         self.adapter.process_each_document(
             "workflow_execution_set", [self.update_processing_metadata]


### PR DESCRIPTION
The `Migrator` base class was recently updated so that its `upgrade` method has a `commit_changes` parameter. One of the newly-implemented migrators did not have that parameter in its `upgrade` method, even though that class inherited from `Migrator`. As a result, when calling the `upgrade` method, Python raised a `TypeError` (as shown [here](https://github.com/microbiomedata/nmdc-runtime/pull/1127#issuecomment-3169672830)).

On this branch, I added the `commit_changes` parameter to the `upgrade` method, along with a `TODO` about existing migrators.