### PR TITLE
Add PVs to `ChemicalEntityEnum` and `StationaryPhaseEnum` for EMP500 mass spec material processing modeling

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -155,6 +155,8 @@ enums:
         meaning: CHEBI:62947
       ammonium_bicarbonate:
         meaning: CHEBI:184335
+      amitriptyline:
+        meaning: CHEBI:2666
       Arg-C:
         meaning: MS:1001303
         comments: >-
@@ -171,6 +173,8 @@ enums:
         comments: >-
           A serine protease that hydrolyzes peptide bonds at the C-terminus of tryptophan, leucine, tyrosine, 
           and phenylalanine.
+      ethanol:
+        meaning: CHEBI:16236
       formic_acid:
         meaning: CHEBI:30751
         comments: >-

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -196,14 +196,20 @@ enums:
         meaning: MS:1003093
         comments: >-
           A metalloendopeptidase that hydrolyzes peptide bonds at the C-terminus of lysine.
+      N-methyl-N-trimethylsilyltrifluoroacetamide:
+        meaning: CHEBI:85064
       methanol:
         meaning: CHEBI:17790
+      methoxyamine:
+        meaning: CHEBI:192842
       medronic_acid:
         meaning: CHEBI:43945
         comments: >-
           A 1,1-bis(phosphonic acid) consisting of methane substituted by two phosphonic acid groups, also known as methylenediphosphonic acid
       phosphoric_acid:
         meaning: CHEBI:26078
+      trimethylchlorosilane:
+        meaning: CHEBI:85069
       trypsin:
         meaning: MS:1001251
         comments: >-

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -951,7 +951,7 @@ enums:
       HILIC:
         description: Hydrophilic Interaction Chromatography (HILIC) stationary phase.
       HLB:
-        description: Hydrophilic-Lipophilic-Balance (HLB) solid phase extraction (SPE) plate.
+        description: Hydrophilic-Lipophilic-Balance (HLB) stationary phase.
       NH2:
         description: Amino (NH2) bonded stationary phase.
       Phenyl:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -950,6 +950,8 @@ enums:
         description: A stationary phase with diol (1,2-diol) functional groups.
       HILIC:
         description: Hydrophilic Interaction Chromatography (HILIC) stationary phase.
+      HLB:
+        description: Hydrophilic-Lipophilic-Balance (HLB) solid phase extraction (SPE) plate.
       NH2:
         description: Amino (NH2) bonded stationary phase.
       Phenyl:


### PR DESCRIPTION
Closes [#1322 in Issues repo](https://github.com/microbiomedata/issues/issues/1322). Adds PVs to `ChemicalEntityEnum` and `StationaryPhaseEnum` so  that [EMP500](https://github.com/biocore/emp/blob/master/protocols/MetabolomicsGC.md#derivatization-for-gc-ms-analysis) can have it's mass spec material processing correctly modeled.

Adds the following chemicals to `ChemicalEntityEnum`:
methoxyamine CHEBI:192842
N-methyl-N-trimethylsilyltrifluoroacetamide CHEBI:85064
trimethylchlorosilane CHEBI:85069

Also adds Hydrophilic-Lipophilic-Balance (HLB) as a PV in `StationaryPhaseEnum`