### PR TITLE
Add migrator assuring unit compliance with annotations and UnitEnum

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/__init__.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/__init__.py
@@ -4,6 +4,7 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 from nmdc_schema.migrators.partials.migrator_from_11_10_0_to_11_11_0 import (
     migrator_from_11_10_0_to_11_11_0_part_1,
     migrator_from_11_10_0_to_11_11_0_part_2,
+    migrator_from_11_10_0_to_11_11_0_part_3,
 )
 
 
@@ -25,4 +26,5 @@ def get_migrator_classes() -> List[Type[MigratorBase]]:
     return [
         migrator_from_11_10_0_to_11_11_0_part_1.Migrator,
         migrator_from_11_10_0_to_11_11_0_part_2.Migrator,
+        migrator_from_11_10_0_to_11_11_0_part_3.Migrator,
     ]

--- a/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_1.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_1.py
@@ -7,7 +7,7 @@ class Migrator(MigratorBase):
     _from_version = "11.10.0"
     _to_version = "11.11.0.part_1"
 
-    def upgrade(self) -> None:
+    def upgrade(self,commit_changes: bool = False) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
         self.adapter.do_for_each_document("biosample_set", self.check_for_fields)
 

--- a/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_3.py
@@ -73,14 +73,14 @@ class Migrator(MigratorBase):
         ...     "type": "nmdc:Biosample", 
         ...     "temp": {
         ...         "type": "nmdc:QuantityValue",
-        ...         "has_unit": "meter",  # Wrong unit type for temperature
+        ...         "has_unit": "m",  # Wrong unit type for temperature
         ...         "has_numeric_value": 25.0
         ...     }
         ... }
         >>> m.confirm_units_fit_unitenum_and_storage_units(invalid_biosample_storage)
         Traceback (most recent call last):
             ...
-        ValueError: Document test3 has invalid unit 'meter' for slot 'temp': Unit 'meter' not in allowed storage_units for slot 'temp'
+        ValueError: Document test3 has invalid unit 'm' for slot 'temp': Unit 'm' not in allowed storage_units ['Cel'] for slot 'temp'
 
         '''
         

--- a/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_3.py
@@ -8,21 +8,13 @@ sys.path.insert(0, str(project_root))
 
 from units.validate_production_units import ProductionUnitsValidator
 
-
-
-
-
-##TODO: CURRENTLY ONLY LOOKS AT BIOSAMPLE
-
-## IM HERE: trying to figure out why all these tests are passing when they shouldn't
-
-
-
-
-
-
 class Migrator(MigratorBase):
-    r'''Migrates a database between two schemas.'''
+    r'''
+    Migrates a database between two schemas.
+    TWO NOTES: 
+    - If there is no storage_unit on the slot, the only test is whether the value for `has_unit` is in the UnitEnum
+    - This assumes that all storage_unit restrictions are applied on the global level, it does not validate any changes made on slot_useage (same as python tests, example: does not test if temp on biosample has to be celsius but temp on conversion process is kelvin)
+    '''
 
     _from_version = '11.11.0.part_2'
     _to_version = '11.11.0.part_3'
@@ -101,9 +93,7 @@ class Migrator(MigratorBase):
                 continue
                 
             # Extract slot name from path using the imported method
-            slot_name = self.validator.extract_slot_from_path(path)
-            if not slot_name:
-                continue
+            slot_name = path[-1]
             
             # First validate against UnitEnum using the imported method
             if not self.validator.validate_has_unit_against_enum(has_unit):

--- a/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_3.py
@@ -1,0 +1,119 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+import sys
+from pathlib import Path
+
+# For importing ProductionUnitsValidator and materialized yaml
+project_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(project_root))
+
+from units.validate_production_units import ProductionUnitsValidator
+
+
+
+
+
+##TODO: CURRENTLY ONLY LOOKS AT BIOSAMPLE
+
+## IM HERE: trying to figure out why all these tests are passing when they shouldn't
+
+
+
+
+
+
+class Migrator(MigratorBase):
+    r'''Migrates a database between two schemas.'''
+
+    _from_version = '11.11.0.part_2'
+    _to_version = '11.11.0.part_3'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Initialize the validator with the schema file
+        schema_file = Path('nmdc_schema/nmdc_materialized_patterns.yaml')
+        self.validator = ProductionUnitsValidator(schema_file)
+
+    def upgrade(self,commit_changes: bool = False) -> None:
+        r'''
+        Migrates the database from conforming to the original schema, to conforming to the new schema.
+        '''
+        
+        self.adapter.do_for_each_document(
+            'biosample_set', self.confirm_units_fit_unitenum_and_storage_units
+        )
+
+    def confirm_units_fit_unitenum_and_storage_units(self, document: dict) -> None:
+        r'''
+        Raise an exception if the QuantityValue's has_unit slot is not valid against slot's storage_unit or UnitEnum constraints.
+
+        >>> m = Migrator()
+        
+        # Test: valid QuantityValue with proper units in biosample
+        >>> valid_biosample = {
+        ...     "id": "test1", 
+        ...     "type": "nmdc:Biosample",
+        ...     "temp": {
+        ...         "type": "nmdc:QuantityValue",
+        ...         "has_unit": "Cel",
+        ...         "has_numeric_value": 25.0
+        ...     }
+        ... }
+        >>> m.confirm_units_fit_unitenum_and_storage_units(valid_biosample)  # Should not raise
+        
+        # Test: invalid unit not in UnitEnum
+        >>> invalid_biosample_enum = {
+        ...     "id": "test2", 
+        ...     "type": "nmdc:Biosample",
+        ...     "temp": {
+        ...         "type": "nmdc:QuantityValue", 
+        ...         "has_unit": "invalid_unit",
+        ...         "has_numeric_value": 25.0
+        ...     }
+        ... }
+        >>> m.confirm_units_fit_unitenum_and_storage_units(invalid_biosample_enum)
+        Traceback (most recent call last):
+            ...
+        ValueError: Document test2 has invalid unit 'invalid_unit' for slot 'temp': Unit not in UnitEnum
+        
+        # Test: unit not allowed for specific slot's storage_units
+        >>> invalid_biosample_storage = {
+        ...     "id": "test3",
+        ...     "type": "nmdc:Biosample", 
+        ...     "temp": {
+        ...         "type": "nmdc:QuantityValue",
+        ...         "has_unit": "meter",  # Wrong unit type for temperature
+        ...         "has_numeric_value": 25.0
+        ...     }
+        ... }
+        >>> m.confirm_units_fit_unitenum_and_storage_units(invalid_biosample_storage)
+        Traceback (most recent call last):
+            ...
+        ValueError: Document test3 has invalid unit 'meter' for slot 'temp': Unit 'meter' not in allowed storage_units for slot 'temp'
+
+        '''
+        
+        document_id = document.get("id")
+        
+        # Find all QuantityValue objects in this document using the imported validator
+        for path, qv_data in self.validator.iter_quantity_values(document):
+            has_unit = qv_data.get('has_unit')
+            if not has_unit:
+                continue
+                
+            # Extract slot name from path using the imported method
+            slot_name = self.validator.extract_slot_from_path(path)
+            if not slot_name:
+                continue
+            
+            # First validate against UnitEnum using the imported method
+            if not self.validator.validate_has_unit_against_enum(has_unit):
+                raise ValueError(
+                    f"Document {document_id} has invalid unit '{has_unit}' for slot '{slot_name}': Unit not in UnitEnum"
+                )
+            
+            # Then validate against storage_units constraints using the imported method
+            is_valid, message = self.validator.validate_has_unit_against_slot(has_unit, slot_name)
+            if not is_valid:
+                raise ValueError(
+                    f"Document {document_id} has invalid unit '{has_unit}' for slot '{slot_name}': {message}"
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,5 @@ extend_exclude = [
     "nmdc_schema/nmdc-pydantic.py"
 ]
 
+[tool.deptry.per_rule_ignores]
+DEP003 = ["units"]

--- a/units/validate_production_units.py
+++ b/units/validate_production_units.py
@@ -115,9 +115,7 @@ class ProductionUnitsValidator:
         """Extract slot name from the path to QuantityValue."""
         # The slot is typically the second-to-last element in the path
         # e.g., ['biosample_set', '0', 'temp', 'has_numeric_value'] -> 'temp'
-        if len(path) >= 2:
-            return path[-2]
-        return None
+        return path[-1]
 
     def analyze_production_data(self, yaml_file: Path) -> Dict[str, Any]:
         """Analyze production data and return validation results."""


### PR DESCRIPTION
Closes #2637 
Add a migrator assuring data in MongoDB with a QuantityValue have units 1) from UnitEnum and 2) compliant with storage_unit annotation on slot in schema.


Adjustments Needed:
- [ ] update location for validate script import
- [ ] Merge main and make first migrator for new release
- [ ] Update migrator so it doesn't error for slots with an annotation of 'units_alignment_excuse' (value indicating the excuse reason)