### PR TITLE
Fix `kwarg`-related issue preventing partial migrator from being run

### DIFF
--- a/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_1.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_10_0_to_11_11_0/migrator_from_11_10_0_to_11_11_0_part_1.py
@@ -7,11 +7,11 @@ class Migrator(MigratorBase):
     _from_version = "11.10.0"
     _to_version = "11.11.0.part_1"
 
-    def upgrade(self) -> None:
+    def upgrade(self, commit_changes: bool = True) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
         self.adapter.do_for_each_document("biosample_set", self.check_for_fields)
 
-    def check_for_fields(self, biosample: dict) -> dict:
+    def check_for_fields(self, biosample: dict) -> None:
         r"""
         Check each biosample record to ensure none of the removed slots are being used. 
         List of the slots that were removed:


### PR DESCRIPTION
On this branch, I added a missing parameter to a function's signature. Without that parameter, Python would raise this error:

```py
File ~/Documents/Code/nmdc/nmdc-runtime/.venv/lib/python3.13/site-packages/nmdc_schema/migrators/migrator_from_11_10_0_to_11_11_0.py:35, in Migrator.upgrade(self, commit_changes)
     30 self.logger.debug(
     31     f"Migrating from {migrator_class.get_origin_version()} "
     32     f"to {migrator_class.get_destination_version()}"
     33 )
     34 migrator = migrator_class(adapter=self.adapter, logger=self.logger)
---> [35](/path/to/migrator_from_11_10_0_to_11_11_0.py:35) migrator.upgrade(commit_changes=commit_changes)

TypeError: Migrator.upgrade() got an unexpected keyword argument 'commit_changes'
```