### PR TITLE
Add `unique_keys` and and update description for `Instrument` for make:model restructuring

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -113,11 +113,17 @@ classes:
     title: Material Entity
   Instrument:
     class_uri: nmdc:Instrument
-    description: A material entity that is designed to perform a function in a scientific investigation, but is not a reagent.
+    description: A material entity that is designed to perform a function in a scientific investigation, but is not a reagent. This class models the make and model of the instrument, not the specific instance of the instrument.
     is_a: MaterialEntity
     slots:
       - vendor
       - model
+    unique_keys:
+      main:
+        description: A unique instrument is defined by its vendor and model.
+        unique_key_slots:
+          - vendor
+          - model
     aliases:
       - device
     exact_mappings:


### PR DESCRIPTION
Closes #2624.

We've decided to model the Instrument class at a vendor : model level. See superissue https://github.com/microbiomedata/nmdc-schema/issues/2394 for full discussion and record of our handling of existing data (done without a migrator).

This PR adds a unique_keys constraint to the `Instrument` class and updates the `description` of the class to indicate that the class is not intended to capture the specific instance of the class (that information has been moved to `DataGeneration`'s `instrument_instance_specifier` slot).