### PR TITLE
Add `protocol_for` and `analysis_type` slots to `Protocol`

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -1095,15 +1095,19 @@ enums:
     comments:
       - These are the non-abstract class descendants of PlannedProcess.
     permissible_values:
+      AnnotatingWorkflow:
       ChemicalConversionProcess:
       ChromatographicSeparationProcess:
       CollectingBiosamplesFromSite:
+      DataEmitterProcess:
+      DataGeneration:
       DissolvingProcess:
       Extraction:
       FiltrationProcess:
       LibraryPreparation:
       MagsAnalysis:
       MassSpectrometry:
+      MaterialProcessing:
       MetabolomicsAnalysis:
       MetagenomeAnnotation:
       MetagenomeAssembly:
@@ -1114,8 +1118,10 @@ enums:
       MixingProcess:
       NomAnalysis:
       NucleotideSequencing:
+      PlannedProcess:
       Pooling:
       ReadBasedTaxonomyAnalysis:
       ReadQcAnalysis:
       StorageProcess:
       SubSamplingProcess:
+      WorkflowExecution:

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -9,18 +9,14 @@ class TestEnums(unittest.TestCase):
     """Test suite for enum-related validations."""
 
     def test_ProtocolForEnum_should_have_PlannedProcess_permissible_values(self):
-        """Test that the permissible values of ProtocolForEnum are the non-abstract class
-        descendants of PlannedProcess."""
+        """Test that the permissible values of ProtocolForEnum are the class descendants of
+        PlannedProcess."""
         schema_view = SchemaView(SCHEMA_FILE)
 
 
-        non_abstract_planned_process_class_names = set()
-        for class_name in schema_view.class_descendants("PlannedProcess"):
-            class_def = schema_view.get_class(class_name, strict=True)
-            if not class_def.abstract:
-                non_abstract_planned_process_class_names.add(class_name)
+        planned_process_class_names = set(schema_view.class_descendants("PlannedProcess"))
 
         protocol_for_enum = schema_view.get_enum("ProtocolForEnum", strict=True)
         protocol_for_permissible_value_names = set(protocol_for_enum.permissible_values.keys())
 
-        self.assertEqual(protocol_for_permissible_value_names, non_abstract_planned_process_class_names)
+        self.assertEqual(protocol_for_permissible_value_names, planned_process_class_names)


### PR DESCRIPTION
Fixes #2635 

* Adds the existing `analysis_type` slot to `Protocol`.
* Defines a new slot named `protocol_for` and adds it to `Protocol`.
* Adds a new enum named `ProtocolForEnum` which is used as the range of `protocol_for`. The permissible values are the non-abstract class descendants of `PlannedProcess`.
* Adds a test which ensures that the permissible values of `ProtocolForEnum` stay in-sync with `PlannedProcess` class descendants. 