### PR TITLE
Change casing of GOLD structured alias for Illumina MiSeq

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -930,7 +930,7 @@ enums:
           - Illumina MiSeq
         meaning: OBI:0002003
         structured_aliases:
-          ILLUMINA_MI_SEQ:
+          Illumina MiSeq:
             contexts:
             -  https://gold.jgi.doe.gov/
             predicate: EXACT_SYNONYM


### PR DESCRIPTION
This PR updates the casing of instrument model structured aliases for GOLD to correspond with them cleaning up casing on their end.