### PR TITLE
Enforce ExternalIdentifier range for external identifier mixins

### DIFF
--- a/src/schema/external_identifiers.yaml
+++ b/src/schema/external_identifiers.yaml
@@ -48,14 +48,17 @@ slots:
     mixin: true
     see_also:
       - https://gold.jgi.doe.gov/
+    is_a: external_database_identifiers
 
   emsl_identifiers:
     mixin: true
+    is_a: external_database_identifiers
 
   mgnify_identifiers:
     mixin: true
     see_also:
       - https://www.ebi.ac.uk/metagenomics/
+    is_a: external_database_identifiers
 
   insdc_identifiers:
     mixin: true
@@ -71,20 +74,24 @@ slots:
     see_also:
       - https://www.insdc.org/
       - https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html
+    is_a: external_database_identifiers
 
   neon_identifiers:
     mixin: true
     description: identifiers for entities according to NEON
+    is_a: external_database_identifiers
 
   jgi_portal_identifiers:
     mixin: true
     description: identifiers for entities according to JGI Portal
     see_also:
       - https://data.jgi.doe.gov/
+    is_a: external_database_identifiers
 
   gnps_identifiers:
     mixin: true
-
+    is_a: external_database_identifiers
+ 
   ## studies
 
   study_identifiers:


### PR DESCRIPTION
This PR updates the default range to ExternalIdentifiers for mixins in the external_identifiers.yaml by adding is_a: external_database_identifiers. Previously these mixins showed the default range of string.