### PR TITLE
Fix order of poetry installation; use pipx for install

### DIFF
--- a/.github/workflows/artifact_upload.yaml
+++ b/.github/workflows/artifact_upload.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        uses: pipx install poetry
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -25,13 +25,13 @@ jobs:
       - name: Check out commit
         # Reference: https://github.com/actions/checkout
         uses: actions/checkout@v5
+      - name: Install Poetry
+        uses: pipx install poetry
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'poetry'
-      - name: Install Poetry
-        uses: snok/install-poetry@v1.3
       - name: Install Python dependencies (including "docs" extras)
         # Reference: https://python-poetry.org/docs/pyproject/#extras
         run: poetry install --extras docs

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -12,14 +12,14 @@ jobs:
         with:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
+      - name: Install Poetry.
+        uses: pipx install poetry
+
       - name: Set up Python 3.
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: 'poetry'
-
-      - name: Install Poetry.
-        uses: snok/install-poetry@v1.3
 
       - name: Install dependencies.
         run: poetry install

--- a/.github/workflows/migration.yaml
+++ b/.github/workflows/migration.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        uses: pipx install poetry
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -16,16 +16,16 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Install Poetry
+      run: |
+        pipx install poetry
+        pipx inject poetry "poetry-dynamic-versioning[plugin]"
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
         cache: 'poetry'
-
-    - name: Install Poetry
-      run: |
-        pipx install poetry
-        pipx inject poetry "poetry-dynamic-versioning[plugin]"
 
     - name: Install project dependencies
       run: poetry install --no-interaction


### PR DESCRIPTION
Previously we were inconsistent with how and when Poetry was installed in GitHub Actions workflows. These changes update the workflow definitions to ensure that:

* Poetry is installed before `actions/setup-python`
* Poetry is install via `pipx` (as recommended by the Poetry docs) instead of via a third party action