### PR TITLE
remove examples from sample_shipped description

### DIFF
--- a/src/schema/portal_user_facility.yaml
+++ b/src/schema/portal_user_facility.yaml
@@ -101,8 +101,7 @@ slots:
     rank: 1
     recommended: true
   sample_shipped:
-    description: The total amount or size (volume (ml), mass (g) or area (m2) ) of
-      sample sent to EMSL.
+    description: The total amount or size (volume, mass, or area) of sample sent to EMSL.
     title: sample shipped amount
     comments:
       - This field is only required when completing metadata for samples being submitted


### PR DESCRIPTION
Resolves part of https://github.com/microbiomedata/submission-schema/issues/210 

Remove units from description. Any unit is allowed by EMSL, and the units in the description is confusing.

Updating this slot here will result in an update with `submission-schema`