### PR TITLE
Dematerialize mixs.yaml generation: remove verbosity from induced schema

### DIFF
--- a/assets/other_mixs_yaml_files/mixs_template.yaml
+++ b/assets/other_mixs_yaml_files/mixs_template.yaml
@@ -1,13 +1,7 @@
 name: mixs-schema-subset
-title: MIxS Schema Subset for NMDC
 id: https://w3id.org/nmdc/mixs
 
-notes:
-  - removed several MIxS terms/slots that were sharing slot uris; commented out Biosample assignments
-  - note that the NMDC submission schema in sheets_and_friends takes its MIxS terms
-    from https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/model/schema/mixs.yaml
-    and then potentially modifies them. Ideally this file would contain MIxS terms, essentially ready-to-use
-  - multiple LinkML representations of MIxS are currently available and one will be blessed soon
+source: https://github.com/microbiomedata/mixs/tree/main/model/schema
 
 prefixes:
   nmdc: https://w3id.org/nmdc/

--- a/project.Makefile
+++ b/project.Makefile
@@ -90,7 +90,41 @@ shuttle-clean:
 
 
 src/schema/mixs.yaml: shuttle-clean local/mixs_regen/mixs_minus_1.yaml
-	mv $(word 2,$^) $@
+	# Remove all readonly metaslot assertions (these should only be set by schema loader)
+	# Schema-level: definition_uri, from_schema, imported_from, metamodel_version, source_file, source_file_date, source_file_size, generation_date
+	# Element-level: owner, domain_of, is_usage_slot, usage_slot_name
+	# Then apply ALL dematerialization transformations from SCHEMA_MATERIALIZATION_GUIDE.md:
+	# Step 2: Simplify annotations in classes
+	# Step 3: Simplify prefixes (ExpandedDict -> SimpleDict)
+	# Step 4: Simplify settings (ExpandedDict -> SimpleDict)
+	# Step 5: Simplify annotations in slots
+	# Step 6: Remove redundant class names
+	# Step 7: Remove redundant slot_usage names
+	# Step 8: Remove redundant enum names
+	# Step 9: Remove redundant permissible_values text
+	# Step 10: Remove domain (except MixsCompliantData)
+	# Step 11: Remove redundant slot names
+	# Step 13: Remove redundant subset names
+	# Additional: Remove redundant aliases when they duplicate title
+	yq eval 'del(.source_file, .definition_uri, .imported_from, .metamodel_version, .source_file_date, .source_file_size, .generation_date) | \
+		del(.. | select(has("from_schema")).from_schema) | \
+		del(.. | select(has("owner")).owner) | \
+		del(.. | select(has("domain_of")).domain_of) | \
+		del(.. | select(has("is_usage_slot")).is_usage_slot) | \
+		del(.. | select(has("usage_slot_name")).usage_slot_name) | \
+		(.classes[] | select(has("annotations")).annotations) |= map_values(.value) | \
+		.prefixes |= map_values(.prefix_reference) | \
+		(.settings // {}) |= map_values(.setting_value) | \
+		(.slots[] | select(has("annotations")).annotations) |= map_values(.value) | \
+		del(.classes.[].name) | \
+		del(.classes.[].slot_usage.[].name) | \
+		del(.enums.[].name) | \
+		del(.enums.[].permissible_values.[].text) | \
+		del(.slots[] | select(.domain != "MixsCompliantData") | .domain) | \
+		del(.slots.[].name) | \
+		del(.subsets.[].name) | \
+		del(.slots[] | select(.aliases and .title and (.aliases | length == 1) and .aliases[0] == .title) | .aliases)' \
+		$(word 2,$^) > $@
 	rm -rf local/mixs_regen/mixs_subset_modified.yaml.bak
 
 local/mixs_regen/mixs_subset.yaml: assets/import_mixs_slots_regardless.tsv
@@ -103,12 +137,15 @@ local/mixs_regen/mixs_subset_modified.yaml: local/mixs_regen/mixs_subset.yaml as
 	# switching to TextValue may not add any value. the other range changes do improve the structure of the data.
 	# ironically changing back to strings for the submission-schema, data harmonizer, submission portal etc.
 	# may switch source of truth to the MIxS 6.2.2 release candidate
-	sed 's/quantity value/QuantityValue/' $(word 1, $^) > $@
-	sed -i.bak 's/range: string/range: TextValue/' $@
-	sed -i.bak 's/range: text value/range: TextValue/' $@
 
+	# First, apply global string replacements using yq (replacing sed)
+	yq eval '(.. | select(. == "quantity value")) |= "QuantityValue" | \
+		(.. | select(tag == "!!str" and . == "string")) |= "TextValue" | \
+		(.. | select(tag == "!!str" and . == "text value")) |= "TextValue"' \
+		$(word 1, $^) > $@
+
+	# Then apply all slot-specific transformations from config file
 	grep "^'" $(word 2, $^) | while IFS= read -r line ; do echo $$line ; eval yq -i $$line $@ ; done
-	rm -rf $@.bak
 
 
 local/mixs_regen/mixs_subset_modified_inj_land_use.yaml: local/mixs_regen/mixs_subset_modified.yaml \
@@ -127,26 +164,17 @@ assets/other_mixs_yaml_files/TargetGeneEnum.yaml
 	yq -i '.slots.target_gene.range = "TargetGeneEnum"' $@
 
 
-local/mixs_regen/mixs_subset_modified_inj_env_broad_scale_alt_description.yaml: local/mixs_regen/mixs_subset_modified_inj_TargetGeneEnum.yaml \
+local/mixs_regen/mixs_subset_modified_inj_env_triad.yaml: local/mixs_regen/mixs_subset_modified_inj_TargetGeneEnum.yaml \
 assets/other_mixs_yaml_files/nmdc_mixs_env_triad_tooltips.yaml
-	yq eval-all \
-		'select(fileIndex==0).slots.env_broad_scale.annotations.tooltip = select(fileIndex==1).slots.env_broad_scale.annotations.tooltip | select(fileIndex==0)' \
+	# Inject all three environment triad tooltips in a single step
+	yq eval-all '\
+		select(fileIndex==0).slots.env_broad_scale.annotations.tooltip = select(fileIndex==1).slots.env_broad_scale.annotations.tooltip | \
+		select(fileIndex==0).slots.env_local_scale.annotations.tooltip = select(fileIndex==1).slots.env_local_scale.annotations.tooltip | \
+		select(fileIndex==0).slots.env_medium.annotations.tooltip = select(fileIndex==1).slots.env_medium.annotations.tooltip | \
+		select(fileIndex==0)' \
 		$^ | cat > $@
 
-local/mixs_regen/mixs_subset_modified_inj_env_local_scale_alt_description.yaml: local/mixs_regen/mixs_subset_modified_inj_env_broad_scale_alt_description.yaml \
-assets/other_mixs_yaml_files/nmdc_mixs_env_triad_tooltips.yaml
-	yq eval-all \
-		'select(fileIndex==0).slots.env_local_scale.annotations.tooltip = select(fileIndex==1).slots.env_local_scale.annotations.tooltip | select(fileIndex==0)' \
-		$^ | cat > $@
-
-local/mixs_regen/mixs_subset_modified_inj_env_medium_alt_description.yaml: local/mixs_regen/mixs_subset_modified_inj_env_local_scale_alt_description.yaml \
-assets/other_mixs_yaml_files/nmdc_mixs_env_triad_tooltips.yaml
-	yq eval-all \
-		'select(fileIndex==0).slots.env_medium.annotations.tooltip = select(fileIndex==1).slots.env_medium.annotations.tooltip | select(fileIndex==0)' \
-		$^ | cat > $@
-
-
-local/mixs_regen/mixs_minus_1.yaml: local/mixs_regen/mixs_subset_modified_inj_env_medium_alt_description.yaml \
+local/mixs_regen/mixs_minus_1.yaml: local/mixs_regen/mixs_subset_modified_inj_env_triad.yaml \
 assets/other_mixs_yaml_files/mixs_env_triad_field_slot.yaml
 	yq eval-all \
 		'select(fileIndex==0).slots.mixs_env_triad_field = select(fileIndex==1).slots.mixs_env_triad_field | select(fileIndex==0)' \

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1,33 +1,21 @@
 name: mixs-schema-subset
-title: MIxS Schema Subset for NMDC
-notes:
-  - removed several MIxS terms/slots that were sharing slot uris; commented out Biosample assignments
-  - note that the NMDC submission schema in sheets_and_friends takes its MIxS terms from https://raw.githubusercontent.com/GenomicsStandardsConsortium/mixs/main/model/schema/mixs.yaml and then potentially modifies them. Ideally this file would contain MIxS terms, essentially ready-to-use
-  - multiple LinkML representations of MIxS are currently available and one will be blessed soon
+source: https://github.com/microbiomedata/mixs/tree/main/model/schema
 id: https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/mixs.yaml
 imports:
   - linkml:types
   - attribute_values
 prefixes:
-  nmdc:
-    prefix_prefix: nmdc
-    prefix_reference: https://w3id.org/nmdc/
-  MIXS:
-    prefix_prefix: MIXS
-    prefix_reference: https://w3id.org/mixs/
-  linkml:
-    prefix_prefix: linkml
-    prefix_reference: https://w3id.org/linkml/
+  nmdc: https://w3id.org/nmdc/
+  MIXS: https://w3id.org/mixs/
+  linkml: https://w3id.org/linkml/
 default_prefix: MIXS
 enums:
   arch_struc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       building: {}
       shed: {}
       home: {}
   biol_stat_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       wild: {}
       natural: {}
@@ -38,14 +26,12 @@ enums:
       clonal selection: {}
       mutant: {}
   biotic_relationship_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       free living: {}
       parasite: {}
       commensal: {}
       symbiont: {}
   build_docs_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       building information model: {}
       commissioning report: {}
@@ -61,7 +47,6 @@ enums:
       ventilation system: {}
       windows: {}
   build_occup_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       office: {}
       market: {}
@@ -77,14 +62,12 @@ enums:
       airport: {}
       sports complex: {}
   building_setting_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       urban: {}
       suburban: {}
       exurban: {}
       rural: {}
   ceil_cond_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       new: {}
       visible wear: {}
@@ -92,7 +75,6 @@ enums:
       damaged: {}
       rupture: {}
   ceil_finish_mat_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       drywall: {}
       mineral fibre: {}
@@ -105,7 +87,6 @@ enums:
       mineral wool/calcium silicate: {}
       wood: {}
   ceil_texture_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       crows feet: {}
       crows-foot stomp: {}
@@ -121,7 +102,6 @@ enums:
       stomp knockdown: {}
       swirl: {}
   ceil_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       cathedral: {}
       dropped: {}
@@ -131,7 +111,6 @@ enums:
       cove: {}
       stretched: {}
   cur_land_use_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       badlands: {}
       cities: {}
@@ -257,7 +236,6 @@ enums:
         examples:
           - value: grapes
   depos_env_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Continental - Alluvial: {}
       Continental - Aeolian: {}
@@ -276,14 +254,12 @@ enums:
       Other - Volcanic: {}
       other: {}
   door_comp_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       metal covered: {}
       revolving: {}
       sliding: {}
       telescopic: {}
   door_cond_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       damaged: {}
       needs repair: {}
@@ -291,20 +267,17 @@ enums:
       rupture: {}
       visible wear: {}
   door_direct_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       inward: {}
       outward: {}
       sideways: {}
   door_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north: {}
       south: {}
       east: {}
       west: {}
   door_mat_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       aluminum: {}
       cellular PVC: {}
@@ -317,7 +290,6 @@ enums:
       wood: {}
       wood/plastic composite: {}
   door_move_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       collapsible: {}
       folding: {}
@@ -326,13 +298,11 @@ enums:
       sliding: {}
       swinging: {}
   door_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       composite: {}
       metal: {}
       wooden: {}
   door_type_metal_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       collapsible: {}
       corrugated steel: {}
@@ -340,7 +310,6 @@ enums:
       rolling shutters: {}
       steel plate: {}
   door_type_wood_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       bettened and ledged: {}
       battened: {}
@@ -353,7 +322,6 @@ enums:
       louvered: {}
       wire gauged: {}
   drainage_class_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       very poorly: {}
       poorly: {}
@@ -362,7 +330,6 @@ enums:
       well: {}
       excessively drained: {}
   drawings_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       operation: {}
       as built: {}
@@ -373,7 +340,6 @@ enums:
       diagram: {}
       sketch: {}
   ext_wall_orient_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north: {}
       south: {}
@@ -384,7 +350,6 @@ enums:
       southwest: {}
       northwest: {}
   ext_window_orient_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north: {}
       south: {}
@@ -395,7 +360,6 @@ enums:
       southwest: {}
       northwest: {}
   fao_class_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Acrisols: {}
       Andosols: {}
@@ -424,7 +388,6 @@ enums:
       Vertisols: {}
       Yermosols: {}
   filter_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       particulate air filter: {}
       chemical air filter: {}
@@ -433,7 +396,6 @@ enums:
       electrostatic: {}
       gas-phase or ultraviolet air treatments: {}
   floor_cond_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       new: {}
       visible wear: {}
@@ -441,7 +403,6 @@ enums:
       damaged: {}
       rupture: {}
   floor_finish_mat_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       tile: {}
       wood strip or parquet: {}
@@ -462,7 +423,6 @@ enums:
       paint: {}
       none or unfinished: {}
   floor_struc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       balcony: {}
       floating floor: {}
@@ -472,7 +432,6 @@ enums:
       wood-framed: {}
       concrete: {}
   floor_water_mold_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       mold odor: {}
       wet floor: {}
@@ -484,7 +443,6 @@ enums:
       bulging walls: {}
       condensation: {}
   freq_clean_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Daily: {}
       Weekly: {}
@@ -493,13 +451,11 @@ enums:
       Annually: {}
       other: {}
   furniture_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       cabinet: {}
       chair: {}
       desks: {}
   gender_restroom_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       all gender: {}
       female: {}
@@ -508,21 +464,18 @@ enums:
       male and female: {}
       unisex: {}
   growth_habit_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       erect: {}
       semi-erect: {}
       spreading: {}
       prostrate: {}
   handidness_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       ambidexterity: {}
       left handedness: {}
       mixed-handedness: {}
       right handedness: {}
   hc_produced_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Oil: {}
       Gas-Condensate: {}
@@ -531,7 +484,6 @@ enums:
       Coalbed Methane: {}
       other: {}
   hcr_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Oil Reservoir: {}
       Gas Reservoir: {}
@@ -542,7 +494,6 @@ enums:
       Tight Gas Reservoir: {}
       other: {}
   hcr_geol_age_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Archean: {}
       Cambrian: {}
@@ -563,7 +514,6 @@ enums:
       Triassic: {}
       other: {}
   heat_cool_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       radiant system: {}
       heat pump: {}
@@ -571,14 +521,12 @@ enums:
       steam forced heat: {}
       wood stove: {}
   heat_deliv_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north: {}
       south: {}
       east: {}
       west: {}
   host_sex_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       female: {}
       hermaphrodite: {}
@@ -589,7 +537,6 @@ enums:
       transgender (male to female): {}
       undeclared: {}
   indoor_space_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       bedroom: {}
       office: {}
@@ -600,7 +547,6 @@ enums:
       hallway: {}
       elevator: {}
   indoor_surf_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       cabinet: {}
       ceiling: {}
@@ -611,7 +557,6 @@ enums:
       window: {}
       wall: {}
   int_wall_cond_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       new: {}
       visible wear: {}
@@ -619,7 +564,6 @@ enums:
       damaged: {}
       rupture: {}
   light_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       natural light: {}
       electric light: {}
@@ -627,7 +571,6 @@ enums:
       flourescent lights: {}
       none: {}
   lithology_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Basement: {}
       Chalk: {}
@@ -643,7 +586,6 @@ enums:
       Volcanic: {}
       other: {}
   mech_struc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       subway: {}
       coach: {}
@@ -655,26 +597,22 @@ enums:
       car: {}
       bus: {}
   occup_document_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       automated count: {}
       estimate: {}
       manual count: {}
       videos: {}
   organism_count_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       ATP: {}
       MPN: {}
       other: {}
   oxy_stat_samp_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       aerobic: {}
       anaerobic: {}
       other: {}
   plant_growth_med_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       other artificial liquid medium: {}
       other artificial solid medium: {}
@@ -686,7 +624,6 @@ enums:
       vermiculite: {}
       water: {}
   plant_sex_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Androdioecious: {}
       Androecious: {}
@@ -718,7 +655,6 @@ enums:
       Trioecious: {}
       Unisexual: {}
   profile_position_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       summit: {}
       shoulder: {}
@@ -726,20 +662,17 @@ enums:
       footslope: {}
       toeslope: {}
   quad_pos_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       North side: {}
       West side: {}
       South side: {}
       East side: {}
   rel_samp_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       edge of car: {}
       center of car: {}
       under a seat: {}
   room_condt_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       new: {}
       visible wear: {}
@@ -748,7 +681,6 @@ enums:
       rupture: {}
       visible signs of mold/mildew: {}
   room_connected_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       attic: {}
       bathroom: {}
@@ -762,13 +694,11 @@ enums:
       office: {}
       stairwell: {}
   room_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       corner room: {}
       interior room: {}
       exterior wall: {}
   room_samp_pos_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north corner: {}
       south corner: {}
@@ -780,7 +710,6 @@ enums:
       southwest corner: {}
       center: {}
   room_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       attic: {}
       bathroom: {}
@@ -808,7 +737,6 @@ enums:
       cafe: {}
       warehouse: {}
   samp_capt_status_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       active surveillance in response to an outbreak: {}
       active surveillance not initiated by an outbreak: {}
@@ -816,7 +744,6 @@ enums:
       market sample: {}
       other: {}
   samp_collect_point_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       well: {}
       test well: {}
@@ -826,7 +753,6 @@ enums:
       storage tank: {}
       other: {}
   samp_dis_stage_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       dissemination: {}
       growth and reproduction: {}
@@ -835,14 +761,12 @@ enums:
       penetration: {}
       other: {}
   samp_floor_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       1st floor: {}
       2nd floor: {}
       basement: {}
       lobby: {}
   samp_md_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       DF: {}
       RT: {}
@@ -850,7 +774,6 @@ enums:
       MSL: {}
       other: {}
   samp_subtype_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       oil phase: {}
       water phase: {}
@@ -858,7 +781,6 @@ enums:
       not applicable: {}
       other: {}
   samp_weather_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       clear sky: {}
       cloudy: {}
@@ -870,21 +792,18 @@ enums:
       sunny: {}
       windy: {}
   season_use_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Spring: {}
       Summer: {}
       Fall: {}
       Winter: {}
   sediment_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       biogenous: {}
       cosmogenous: {}
       hydrogenous: {}
       lithogenous: {}
   shading_device_cond_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       damaged: {}
       needs repair: {}
@@ -892,7 +811,6 @@ enums:
       rupture: {}
       visible wear: {}
   shading_device_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       bahama shutters: {}
       exterior roll blind: {}
@@ -907,7 +825,6 @@ enums:
       trellis: {}
       venetian awning: {}
   soil_horizon_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       O horizon: {}
       A horizon: {}
@@ -918,7 +835,6 @@ enums:
       Permafrost: {}
       M horizon: {}
   specific_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       operation: {}
       as built: {}
@@ -927,7 +843,6 @@ enums:
       design: {}
       photos: {}
   sr_dep_env_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Lacustine: {}
       Fluvioldeltaic: {}
@@ -935,7 +850,6 @@ enums:
       Marine: {}
       other: {}
   sr_geol_age_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Archean: {}
       Cambrian: {}
@@ -956,7 +870,6 @@ enums:
       Triassic: {}
       other: {}
   sr_kerog_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Type I: {}
       Type II: {}
@@ -964,7 +877,6 @@ enums:
       Type IV: {}
       other: {}
   sr_lithology_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Clastic: {}
       Carbonate: {}
@@ -972,13 +884,11 @@ enums:
       Biosilicieous: {}
       other: {}
   substructure_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       crawlspace: {}
       slab on grade: {}
       basement: {}
   surf_air_cont_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       dust: {}
       organic matter: {}
@@ -989,7 +899,6 @@ enums:
       nutrients: {}
       biocides: {}
   surf_material_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       adobe: {}
       carpet: {}
@@ -1007,14 +916,12 @@ enums:
       vinyl: {}
       wood: {}
   tidal_stage_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       low tide: {}
       ebb tide: {}
       flood tide: {}
       high tide: {}
   tillage_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       drill: {}
       cutting disc: {}
@@ -1026,13 +933,11 @@ enums:
       mouldboard: {}
       disc plough: {}
   train_line_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       red: {}
       green: {}
       orange: {}
   train_stat_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       south station above ground: {}
       south station underground: {}
@@ -1040,13 +945,11 @@ enums:
       forest hills: {}
       riverside: {}
   train_stop_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       end: {}
       mid: {}
       downtown: {}
   vis_media_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       photos: {}
       videos: {}
@@ -1056,7 +959,6 @@ enums:
       equipment: {}
       3D scans: {}
   wall_const_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       frame construction: {}
       joisted masonry: {}
@@ -1065,7 +967,6 @@ enums:
       modified fire resistive: {}
       fire resistive: {}
   wall_finish_mat_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       plaster: {}
       gypsum plaster: {}
@@ -1079,14 +980,12 @@ enums:
       metal: {}
       masonry: {}
   wall_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north: {}
       south: {}
       east: {}
       west: {}
   wall_surf_treatment_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       painted: {}
       wall paper: {}
@@ -1095,7 +994,6 @@ enums:
       stucco: {}
       fabric: {}
   wall_texture_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       crows feet: {}
       crows-foot stomp: {}
@@ -1112,7 +1010,6 @@ enums:
       stomp knockdown: {}
       swirl: {}
   water_feat_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       fountain: {}
       pool: {}
@@ -1120,7 +1017,6 @@ enums:
       stream: {}
       waterfall: {}
   weekday_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       Monday: {}
       Tuesday: {}
@@ -1130,7 +1026,6 @@ enums:
       Saturday: {}
       Sunday: {}
   window_cond_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       damaged: {}
       needs repair: {}
@@ -1138,26 +1033,22 @@ enums:
       rupture: {}
       visible wear: {}
   window_cover_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       blinds: {}
       curtains: {}
       none: {}
   window_horiz_pos_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       left: {}
       middle: {}
       right: {}
   window_loc_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       north: {}
       south: {}
       east: {}
       west: {}
   window_mat_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       clad: {}
       fiberglass: {}
@@ -1165,13 +1056,11 @@ enums:
       vinyl: {}
       wood: {}
   window_type_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       single-hung sash window: {}
       horizontal sash window: {}
       fixed window: {}
   window_vert_pos_enum:
-    from_schema: http://w3id.org/mixs/terms
     permissible_values:
       bottom: {}
       middle: {}
@@ -1203,63 +1092,38 @@ enums:
 slots:
   abs_air_humidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per gram, kilogram per kilogram, kilogram, pound
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[lb_av]|g/g|kg|kg/kg'
+      expected_value: measurement value
+      preferred_unit: gram per gram, kilogram per kilogram, kilogram, pound
+      occurrence: '1'
+      storage_units: '[lb_av]|g/g|kg|kg/kg'
     description: Actual mass of water vapor - mh20 - present in the air water vapor mixture
     title: absolute air humidity
     examples:
       - value: 9 g/g
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - absolute air humidity
     is_a: core field
     slot_uri: MIXS:0000122
     range: QuantityValue
     multivalued: false
   add_recov_method:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration;timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration;timestamp
+      occurrence: '1'
     description: Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed for increase of hydrocarbon recovery from resource and start date for each one of them. If "other" is specified, please propose entry in "additional info" field
     title: secondary and tertiary recovery methods and start date
     examples:
       - value: Polymer Addition;2018-06-21T14:30Z
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - secondary and tertiary recovery methods and start date
     is_a: core field
     slot_uri: MIXS:0001009
     range: TextValue
     multivalued: false
   additional_info:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: text
+      occurrence: '1'
     description: Information that doesn't fit anywhere else. Can also be used to propose new entries for fields with controlled vocabulary
     title: additional info
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - additional info
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000300
@@ -1267,19 +1131,12 @@ slots:
     multivalued: false
   address:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The street name and building number where the sampling occurred.
     title: address
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - address
     is_a: core field
     string_serialization: '{integer}{text}'
     slot_uri: MIXS:0000218
@@ -1287,19 +1144,12 @@ slots:
     multivalued: false
   adj_room:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: room name;room number
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: room name;room number
+      occurrence: '1'
     description: List of rooms (room number, room name) immediately adjacent to the sampling room
     title: adjacent rooms
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - adjacent rooms
     is_a: core field
     string_serialization: '{text};{integer}'
     slot_uri: MIXS:0000219
@@ -1307,19 +1157,12 @@ slots:
     multivalued: false
   aero_struc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Aerospace structures typically consist of thin plates with stiffeners for the external surfaces, bulkheads and frames to support the shape and fasteners such as welds, rivets, screws and bolts to hold the components together
     title: aerospace structure
     examples:
       - value: plane
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - aerospace structure
     is_a: core field
     string_serialization: '[plane|glider]'
     slot_uri: MIXS:0000773
@@ -1327,22 +1170,13 @@ slots:
     multivalued: false
   agrochem_addition:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: agrochemical name;agrochemical amount;timestamp
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: agrochemical name;agrochemical amount;timestamp
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Addition of fertilizers, pesticides, etc. - amount and time of applications
     title: history/agrochemical additions
     examples:
       - value: roundup;5 milligram per liter;2018-06-21
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/agrochemical additions
     is_a: core field
     string_serialization: '{text};{float} {unit};{timestamp}'
     slot_uri: MIXS:0000639
@@ -1351,22 +1185,13 @@ slots:
     inlined_as_list: true
   air_PM_concen:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: particulate matter name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micrograms per cubic meter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: particulate matter name;measurement value
+      preferred_unit: micrograms per cubic meter
+      occurrence: m
     description: Concentration of substances that remain suspended in the air, and comprise mixtures of organic and inorganic substances (PM10 and PM2.5); can report multiple PM's by entering numeric values preceded by name of PM
     title: air particulate matter concentration
     examples:
       - value: PM2.5;10 microgram per cubic meter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - air particulate matter concentration
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000108
@@ -1375,47 +1200,27 @@ slots:
     inlined_as_list: true
   air_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: Temperature of the air at the time of sampling
     title: air temperature
     examples:
       - value: 20 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - air temperature
     is_a: core field
     slot_uri: MIXS:0000124
     range: QuantityValue
     multivalued: false
   air_temp_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: temperature value;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: temperature value;treatment interval and duration
+      preferred_unit: meter
+      occurrence: m
     description: Information about treatment involving an exposure to varying temperatures; should include the temperature, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include different temperature regimens
     title: air temperature regimen
     examples:
       - value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - air temperature regimen
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000551
@@ -1424,44 +1229,26 @@ slots:
     inlined_as_list: true
   al_sat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percentage
+      occurrence: '1'
+      storage_units: '%'
     description: Aluminum saturation (esp. For tropical soils)
     title: extreme_unusual_properties/Al saturation
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - extreme_unusual_properties/Al saturation
     is_a: core field
     slot_uri: MIXS:0000607
     range: QuantityValue
     multivalued: false
   al_sat_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or URL
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or URL
+      occurrence: '1'
     description: Reference or method used in determining Al saturation
     title: extreme_unusual_properties/Al saturation method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - extreme_unusual_properties/Al saturation method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000324
@@ -1469,44 +1256,26 @@ slots:
     multivalued: false
   alkalinity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milliequivalent per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: meq/L|mg/L
+      expected_value: measurement value
+      preferred_unit: milliequivalent per liter, milligram per liter
+      occurrence: '1'
+      storage_units: meq/L|mg/L
     description: Alkalinity, the ability of a solution to neutralize acids to the equivalence point of carbonate or bicarbonate
     title: alkalinity
     examples:
       - value: 50 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - alkalinity
     is_a: core field
     slot_uri: MIXS:0000421
     range: QuantityValue
     multivalued: false
   alkalinity_method:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: description of method
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: description of method
+      occurrence: '1'
     description: Method used for alkalinity measurement
     title: alkalinity method
     examples:
       - value: titration
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - alkalinity method
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000298
@@ -1514,138 +1283,80 @@ slots:
     multivalued: false
   alkyl_diethers:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: mole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mol/L
+      expected_value: measurement value
+      preferred_unit: mole per liter
+      occurrence: '1'
+      storage_units: mol/L
     description: Concentration of alkyl diethers
     title: alkyl diethers
     examples:
       - value: 0.005 mol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - alkyl diethers
     is_a: core field
     slot_uri: MIXS:0000490
     range: QuantityValue
     multivalued: false
   alt:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      storage_units:
-        tag: storage_units
-        value: m
+      expected_value: measurement value
+      storage_units: m
     description: Altitude is a term used to identify heights of objects such as airplanes, space shuttles, rockets, atmospheric balloons and heights of places such as atmospheric layers and clouds. It is used to measure the height of an object which is above the earth's surface. In this context, the altitude measurement is the vertical distance between the earth's surface above sea level and the sampled position in the air
     title: altitude
     examples:
       - value: 100 m
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - altitude
     is_a: environment field
     slot_uri: MIXS:0000094
     range: QuantityValue
     multivalued: false
   aminopept_act:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: mole per liter per hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mol/L/h
+      expected_value: measurement value
+      preferred_unit: mole per liter per hour
+      occurrence: '1'
+      storage_units: mol/L/h
     description: Measurement of aminopeptidase activity
     title: aminopeptidase activity
     examples:
       - value: 0.269 mol/L/h
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - aminopeptidase activity
     is_a: core field
     slot_uri: MIXS:0000172
     range: QuantityValue
     multivalued: false
   ammonium:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L'
     description: Concentration of ammonium in the sample
     title: ammonium
     examples:
       - value: 1.5 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ammonium
     is_a: core field
     slot_uri: MIXS:0000427
     range: QuantityValue
     multivalued: false
   amount_light:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: lux, lumens per square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: lm/m2|lx
+      expected_value: measurement value
+      preferred_unit: lux, lumens per square meter
+      occurrence: '1'
+      storage_units: lm/m2|lx
     description: The unit of illuminance and luminous emittance, measuring luminous flux per unit area
     title: amount of light
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - amount of light
     is_a: core field
     slot_uri: MIXS:0000140
     range: QuantityValue
     multivalued: false
   ances_data:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: free text
+      occurrence: '1'
     description: Information about either pedigree or other ancestral information description (e.g. parental variety in case of mutant or selection), e.g. A/3*B (meaning [(A x B) x B] x B)
     title: ancestral data
     examples:
       - value: A/3*B
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ancestral data
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000247
@@ -1653,72 +1364,41 @@ slots:
     multivalued: false
   annual_precpt:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mm
+      expected_value: measurement value
+      preferred_unit: millimeter
+      occurrence: '1'
+      storage_units: mm
     description: The average of all annual precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps.
     title: mean annual precipitation
     examples:
       - value: 225 mm
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mean annual precipitation
     is_a: core field
     slot_uri: MIXS:0000644
     range: QuantityValue
     multivalued: false
   annual_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: Mean annual temperature
     title: mean annual temperature
     examples:
       - value: 12.5 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mean annual temperature
     is_a: core field
     slot_uri: MIXS:0000642
     range: QuantityValue
     multivalued: false
   antibiotic_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: antibiotic name;antibiotic amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: antibiotic name;antibiotic amount;treatment interval and duration
+      preferred_unit: milligram
+      occurrence: m
     description: Information about treatment involving antibiotic administration; should include the name of antibiotic, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple antibiotic regimens
     title: antibiotic regimen
     examples:
       - value: penicillin;5 milligram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - antibiotic regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000553
@@ -1727,66 +1407,39 @@ slots:
     inlined_as_list: true
   api:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degrees API
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: non_ucum_unit
+      expected_value: measurement value
+      preferred_unit: degrees API
+      occurrence: '1'
+      units_alignment_excuse: non_ucum_unit
     description: 'API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g. 31.1¬∞ API)'
     title: API gravity
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - API gravity
     is_a: core field
     slot_uri: MIXS:0000157
     range: QuantityValue
     multivalued: false
   arch_struc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: An architectural structure is a human-made, free-standing, immobile outdoor construction
     title: architectural structure
     examples:
       - value: shed
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - architectural structure
     is_a: core field
     slot_uri: MIXS:0000774
     range: arch_struc_enum
     multivalued: false
   aromatics_pc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percent
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;measurement value
+      preferred_unit: percent
+      occurrence: '1'
     description: 'Saturate, Aromatic, Resin and Asphaltene¬†(SARA) is an analysis method that divides¬†crude oil¬†components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: aromatics wt%
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - aromatics wt%
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000133
@@ -1794,22 +1447,13 @@ slots:
     multivalued: false
   asphaltenes_pc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percent
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;measurement value
+      preferred_unit: percent
+      occurrence: '1'
     description: 'Saturate, Aromatic, Resin and Asphaltene¬†(SARA) is an analysis method that divides¬†crude oil¬†components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: asphaltenes wt%
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - asphaltenes wt%
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000135
@@ -1817,19 +1461,12 @@ slots:
     multivalued: false
   atmospheric_data:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: atmospheric data name;measurement value
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: atmospheric data name;measurement value
+      occurrence: m
     description: Measurement of atmospheric data; can include multiple data
     title: atmospheric data
     examples:
       - value: wind speed;9 knots
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - atmospheric data
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0001097
@@ -1838,188 +1475,108 @@ slots:
     inlined_as_list: true
   avg_dew_point:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: The average of dew point measures taken at the beginning of every hour over a 24 hour period on the sampling day
     title: average dew point
     examples:
       - value: 25.5 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - average dew point
     is_a: core field
     slot_uri: MIXS:0000141
     range: QuantityValue
     multivalued: false
   avg_occup:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: Daily average occupancy of room. Indicate the number of person(s) daily occupying the sampling room.
     title: average daily occupancy
     examples:
       - value: '2'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - average daily occupancy
     is_a: core field
     slot_uri: MIXS:0000775
     range: TextValue
     multivalued: false
   avg_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: The average of temperatures taken at the beginning of every hour over a 24 hour period on the sampling day
     title: average temperature
     examples:
       - value: 12.5 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - average temperature
     is_a: core field
     slot_uri: MIXS:0000142
     range: QuantityValue
     multivalued: false
   bac_prod:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per cubic meter per day
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/m3/d
+      expected_value: measurement value
+      preferred_unit: milligram per cubic meter per day
+      occurrence: '1'
+      storage_units: mg/m3/d
     description: Bacterial production in the water column measured by isotope uptake
     title: bacterial production
     examples:
       - value: 5 mg/m3/d
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bacterial production
     is_a: core field
     slot_uri: MIXS:0000683
     range: QuantityValue
     multivalued: false
   bac_resp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per cubic meter per day, micromole oxygen per liter per hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/m3/d|umol/L/h
+      expected_value: measurement value
+      preferred_unit: milligram per cubic meter per day, micromole oxygen per liter per hour
+      occurrence: '1'
+      storage_units: mg/m3/d|umol/L/h
     description: Measurement of bacterial respiration in the water column
     title: bacterial respiration
     examples:
       - value: 300 umol/L/h
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bacterial respiration
     is_a: core field
     slot_uri: MIXS:0000684
     range: QuantityValue
     multivalued: false
   bacteria_carb_prod:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: nanogram per hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ng/h
+      expected_value: measurement value
+      preferred_unit: nanogram per hour
+      occurrence: '1'
+      storage_units: ng/h
     description: Measurement of bacterial carbon production
     title: bacterial carbon production
     examples:
       - value: 50 ng/h
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bacterial carbon production
     is_a: core field
     slot_uri: MIXS:0000173
     range: QuantityValue
     multivalued: false
   barometric_press:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millibar
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mbar
+      expected_value: measurement value
+      preferred_unit: millibar
+      occurrence: '1'
+      storage_units: mbar
     description: Force per unit area exerted against a surface by the weight of air above that surface
     title: barometric pressure
     examples:
       - value: 1013 mbar
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - barometric pressure
     is_a: core field
     slot_uri: MIXS:0000096
     range: QuantityValue
     multivalued: false
   basin:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name
+      occurrence: '1'
     description: Name of the basin (e.g. Campos)
     title: basin name
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - basin name
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000290
@@ -2027,107 +1584,64 @@ slots:
     multivalued: false
   bathroom_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of bathrooms in the building
     title: bathroom count
     examples:
       - value: '1'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bathroom count
     is_a: core field
     slot_uri: MIXS:0000776
     range: TextValue
     multivalued: false
   bedroom_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of bedrooms in the building
     title: bedroom count
     examples:
       - value: '2'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bedroom count
     is_a: core field
     slot_uri: MIXS:0000777
     range: TextValue
     multivalued: false
   benzene:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of benzene in the sample
     title: benzene
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - benzene
     is_a: core field
     slot_uri: MIXS:0000153
     range: QuantityValue
     multivalued: false
   biochem_oxygen_dem:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: Amount of dissolved oxygen needed by aerobic biological organisms in a body of water to break down organic material present in a given water sample at certain temperature over a specific time period
     title: biochemical oxygen demand
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - biochemical oxygen demand
     is_a: core field
     slot_uri: MIXS:0000653
     range: QuantityValue
     multivalued: false
   biocide:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;name;timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;name;timestamp
+      occurrence: '1'
     description: List of biocides (commercial name of product and supplier) and date of administration
     title: biocide administration
     examples:
       - value: ALPHA 1427;Baker Hughes;2008-01-23
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - biocide administration
     is_a: core field
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001011
@@ -2135,22 +1649,13 @@ slots:
     multivalued: false
   biocide_admin_method:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;frequency;duration;duration
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value;frequency;duration;duration
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Method of biocide administration (dose, frequency, duration, time elapsed between last biociding and sampling) (e.g. 150 mg/l; weekly; 4 hr; 3 days)
     title: biocide administration method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - biocide administration method
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration}'
     slot_uri: MIXS:0000456
@@ -2158,41 +1663,25 @@ slots:
     multivalued: false
   biol_stat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The level of genome modification.
     title: biological status
     examples:
       - value: natural
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - biological status
     is_a: core field
     slot_uri: MIXS:0000858
     range: biol_stat_enum
     multivalued: false
   biomass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: biomass type;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: ton, kilogram, gram
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: biomass type;measurement value
+      preferred_unit: ton, kilogram, gram
+      occurrence: m
     description: Amount of biomass; should include the name for the part of biomass measured, e.g. Microbial, total. Can include multiple measurements
     title: biomass
     examples:
       - value: total;20 gram
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - biomass
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000174
@@ -2201,19 +1690,12 @@ slots:
     inlined_as_list: true
   biotic_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: free text
+      occurrence: '1'
     description: Information about treatment(s) involving use of biotic factors, such as bacteria, viruses or fungi.
     title: biotic regimen
     examples:
       - value: sample inoculated with Rhizobium spp. Culture
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - biotic regimen
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0001038
@@ -2221,217 +1703,129 @@ slots:
     multivalued: false
   biotic_relationship:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
+      expected_value: enumeration
     description: Description of relationship(s) between the subject organism and other organism(s) it is associated with. E.g., parasite on species X; mutualist with species Y. The target organism is the subject of the relationship, and the other organism(s) is the object
     title: observed biotic relationship
     examples:
       - value: free living
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - observed biotic relationship
     is_a: nucleic acid sequence source field
     slot_uri: MIXS:0000028
     range: biotic_relationship_enum
     multivalued: false
   bishomohopanol:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, microgram per gram
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|ug/g
+      expected_value: measurement value
+      preferred_unit: microgram per liter, microgram per gram
+      occurrence: '1'
+      storage_units: ug/L|ug/g
     description: Concentration of bishomohopanol
     title: bishomohopanol
     examples:
       - value: 14 ug/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bishomohopanol
     is_a: core field
     slot_uri: MIXS:0000175
     range: QuantityValue
     multivalued: false
   blood_press_diast:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millimeter mercury
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mm[Hg]
+      expected_value: measurement value
+      preferred_unit: millimeter mercury
+      occurrence: '1'
+      storage_units: mm[Hg]
     description: Resting diastolic blood pressure, measured as mm mercury
     title: host blood pressure diastolic
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host blood pressure diastolic
     is_a: core field
     slot_uri: MIXS:0000258
     range: QuantityValue
     multivalued: false
   blood_press_syst:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millimeter mercury
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mm[Hg]
+      expected_value: measurement value
+      preferred_unit: millimeter mercury
+      occurrence: '1'
+      storage_units: mm[Hg]
     description: Resting systolic blood pressure, measured as mm mercury
     title: host blood pressure systolic
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host blood pressure systolic
     is_a: core field
     slot_uri: MIXS:0000259
     range: QuantityValue
     multivalued: false
   bromide:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]'
+      expected_value: measurement value
+      preferred_unit: parts per million
+      occurrence: '1'
+      storage_units: '[ppm]'
     description: Concentration of bromide
     title: bromide
     examples:
       - value: 0.05 [ppm]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - bromide
     is_a: core field
     slot_uri: MIXS:0000176
     range: QuantityValue
     multivalued: false
   build_docs:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The building design, construction and operation documents
     title: design, construction, and operation documents
     examples:
       - value: maintenance plans
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - design, construction, and operation documents
     is_a: core field
     slot_uri: MIXS:0000787
     range: build_docs_enum
     multivalued: false
   build_occup_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: The primary function for which a building or discrete part of a building is intended to be used
     title: building occupancy type
     examples:
       - value: market
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - building occupancy type
     is_a: core field
     slot_uri: MIXS:0000761
     range: build_occup_type_enum
     multivalued: true
   building_setting:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: A location (geography) where a building is set
     title: building setting
     examples:
       - value: rural
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - building setting
     is_a: core field
     slot_uri: MIXS:0000768
     range: building_setting_enum
     multivalued: false
   built_struc_age:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: year
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: a
+      expected_value: value
+      preferred_unit: year
+      occurrence: '1'
+      storage_units: a
     description: The age of the built structure since construction
     title: built structure age
     examples:
       - value: 15 a
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - built structure age
     is_a: core field
     slot_uri: MIXS:0000145
     range: QuantityValue
     multivalued: false
   built_struc_set:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The characterization of the location of the built structure as high or low human density
     title: built structure setting
     examples:
       - value: rural
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - built structure setting
     is_a: core field
     string_serialization: '[urban|rural]'
     slot_uri: MIXS:0000778
@@ -2439,19 +1833,12 @@ slots:
     multivalued: false
   built_struc_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: free text
+      occurrence: '1'
     description: A physical structure that is a body or assemblage of bodies in space to form a system capable of supporting loads
     title: built structure type
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - built structure type
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000721
@@ -2459,179 +1846,105 @@ slots:
     multivalued: false
   calcium:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, micromole per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L|mg/kg'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, micromole per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L|mg/kg'
     description: Concentration of calcium in the sample
     title: calcium
     examples:
       - value: 0.2 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - calcium
     is_a: core field
     slot_uri: MIXS:0000432
     range: QuantityValue
     multivalued: false
   carb_dioxide:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|umol/L'
     description: Carbon dioxide (gas) amount or concentration at the time of sampling
     title: carbon dioxide
     examples:
       - value: 410 [ppm]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - carbon dioxide
     is_a: core field
     slot_uri: MIXS:0000097
     range: QuantityValue
     multivalued: false
   carb_monoxide:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|umol/L'
     description: Carbon monoxide (gas) amount or concentration at the time of sampling
     title: carbon monoxide
     examples:
       - value: 0.1 [ppm]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - carbon monoxide
     is_a: core field
     slot_uri: MIXS:0000098
     range: QuantityValue
     multivalued: false
   carb_nitro_ratio:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: Ratio of amount or concentrations of carbon to nitrogen
     title: carbon/nitrogen ratio
     examples:
       - value: '0.417361111'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - carbon/nitrogen ratio
     is_a: core field
     slot_uri: MIXS:0000310
     range: QuantityValue
     multivalued: false
   ceil_area:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m2
+      expected_value: measurement value
+      preferred_unit: square meter
+      occurrence: '1'
+      storage_units: m2
     description: The area of the ceiling space within the room
     title: ceiling area
     examples:
       - value: 25 m2
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling area
     is_a: core field
     slot_uri: MIXS:0000148
     range: QuantityValue
     multivalued: false
   ceil_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The physical condition of the ceiling at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas
     title: ceiling condition
     examples:
       - value: damaged
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling condition
     is_a: core field
     slot_uri: MIXS:0000779
     range: ceil_cond_enum
     multivalued: false
   ceil_finish_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of material used to finish a ceiling
     title: ceiling finish material
     examples:
       - value: stucco
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling finish material
     is_a: core field
     slot_uri: MIXS:0000780
     range: ceil_finish_mat_enum
     multivalued: false
   ceil_struc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The construction format of the ceiling
     title: ceiling structure
     examples:
       - value: concrete
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling structure
     is_a: core field
     string_serialization: '[wood frame|concrete]'
     slot_uri: MIXS:0000782
@@ -2639,82 +1952,50 @@ slots:
     multivalued: false
   ceil_texture:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The feel, appearance, or consistency of a ceiling surface
     title: ceiling texture
     examples:
       - value: popcorn
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling texture
     is_a: core field
     slot_uri: MIXS:0000783
     range: ceil_texture_enum
     multivalued: false
   ceil_thermal_mass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: joule per degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: J/K
+      expected_value: measurement value
+      preferred_unit: joule per degree Celsius
+      occurrence: '1'
+      storage_units: J/K
     description: The ability of the ceiling to provide inertia against temperature fluctuations. Generally this means concrete that is exposed. A metal deck that supports a concrete slab will act thermally as long as it is exposed to room air flow
     title: ceiling thermal mass
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling thermal mass
     is_a: core field
     slot_uri: MIXS:0000143
     range: QuantityValue
     multivalued: false
   ceil_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of ceiling according to the ceiling's appearance or construction
     title: ceiling type
     examples:
       - value: coffered
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling type
     is_a: core field
     slot_uri: MIXS:0000784
     range: ceil_type_enum
     multivalued: false
   ceil_water_mold:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Signs of the presence of mold or mildew on the ceiling
     title: ceiling signs of water/mold
     examples:
       - value: presence of mold visible
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ceiling signs of water/mold
     is_a: core field
     string_serialization: '[presence of mold visible|no presence of mold visible]'
     slot_uri: MIXS:0000781
@@ -2722,19 +2003,12 @@ slots:
     multivalued: false
   chem_administration:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: CHEBI;timestamp
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: CHEBI;timestamp
+      occurrence: m
     description: List of chemical compounds administered to the host or site where sampling occurred, and when (e.g. Antibiotics, n fertilizer, air filter); can include multiple compounds. For chemical entities of biological interest ontology (chebi) (v 163), http://purl.bioontology.org/ontology/chebi
     title: chemical administration
     examples:
       - value: agar [CHEBI:2509];2018-05-11T20:00Z
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chemical administration
     is_a: core field
     string_serialization: '{termLabel} {[termID]};{timestamp}'
     slot_uri: MIXS:0000751
@@ -2743,22 +2017,13 @@ slots:
     inlined_as_list: true
   chem_mutagen:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: mutagen name;mutagen amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: mutagen name;mutagen amount;treatment interval and duration
+      preferred_unit: milligram per liter
+      occurrence: m
     description: Treatment involving use of mutagens; should include the name of mutagen, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple mutagen regimens
     title: chemical mutagen
     examples:
       - value: nitrous acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chemical mutagen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000555
@@ -2767,47 +2032,27 @@ slots:
     inlined_as_list: true
   chem_oxygen_dem:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: A measure of the capacity of water to consume oxygen during the decomposition of organic matter and the oxidation of inorganic chemicals such as ammonia and nitrite
     title: chemical oxygen demand
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chemical oxygen demand
     is_a: core field
     slot_uri: MIXS:0000656
     range: QuantityValue
     multivalued: false
   chem_treat_method:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;frequency;duration;duration
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value;frequency;duration;duration
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Method of chemical administration(dose, frequency, duration, time elapsed between administration and sampling) (e.g. 50 mg/l; twice a week; 1 hr; 0 days)
     title: chemical treatment method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chemical treatment method
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration};{duration};{duration}'
     slot_uri: MIXS:0000457
@@ -2815,19 +2060,12 @@ slots:
     multivalued: false
   chem_treatment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;name;timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;name;timestamp
+      occurrence: '1'
     description: List of chemical compounds administered upstream the sampling location where sampling occurred (e.g. Glycols, H2S scavenger, corrosion and scale inhibitors, demulsifiers, and other production chemicals etc.). The commercial name of the product and name of the supplier should be provided. The date of administration should also be included
     title: chemical treatment
     examples:
       - value: ACCENT 1125;DOW;2010-11-17
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chemical treatment
     is_a: core field
     string_serialization: '{text};{text};{timestamp}'
     slot_uri: MIXS:0001012
@@ -2835,16 +2073,11 @@ slots:
     multivalued: false
   chimera_check:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name and version of software, parameters used
+      expected_value: name and version of software, parameters used
     description: Tool(s) used for chimera checking, including version number and parameters, to discover and remove chimeric sequences. A chimeric sequence is comprised of two or more phylogenetically distinct parent sequences.
     title: chimera check software
     examples:
       - value: uchime;v4.1;default parameters
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chimera check software
     is_a: sequencing field
     string_serialization: '{software};{version};{parameters}'
     slot_uri: MIXS:0000052
@@ -2852,69 +2085,40 @@ slots:
     multivalued: false
   chloride:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of chloride in the sample
     title: chloride
     examples:
       - value: 5000 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chloride
     is_a: core field
     slot_uri: MIXS:0000429
     range: QuantityValue
     multivalued: false
   chlorophyll:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per cubic meter, microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/m3|ug/L
+      expected_value: measurement value
+      preferred_unit: milligram per cubic meter, microgram per liter
+      occurrence: '1'
+      storage_units: mg/m3|ug/L
     description: Concentration of chlorophyll
     title: chlorophyll
     examples:
       - value: 5 mg/m3
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - chlorophyll
     is_a: core field
     slot_uri: MIXS:0000177
     range: QuantityValue
     multivalued: false
   climate_environment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: climate name;treatment interval and duration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: climate name;treatment interval and duration
+      occurrence: m
     description: Treatment involving an exposure to a particular climate; treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple climates
     title: climate environment
     examples:
       - value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - climate environment
     is_a: core field
     string_serialization: '{text};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0001040
@@ -2923,79 +2127,49 @@ slots:
     inlined_as_list: true
   collection_date:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: date and time
+      expected_value: date and time
     description: 'The time of sampling, either as an instance (single point in time) or interval. In case no exact time is available, the date/time can be right truncated i.e. all of these are valid times: 2008-01-23T19:23:10+00:00; 2008-01-23T19:23:10; 2008-01-23; 2008-01; 2008; Except: 2008-01; 2008 all are ISO8601 compliant'
     title: collection date
     examples:
       - value: 2018-05-11T10:00:00+01:00; 2018-05-11
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - collection date
     is_a: environment field
     slot_uri: MIXS:0000011
     range: TimestampValue
     multivalued: false
   conduc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milliSiemens per centimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mS/cm|uS/cm
+      expected_value: measurement value
+      preferred_unit: milliSiemens per centimeter
+      occurrence: '1'
+      storage_units: mS/cm|uS/cm
     description: Electrical conductivity of water
     title: conductivity
     examples:
       - value: 10 uS/cm
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - conductivity
     is_a: core field
     slot_uri: MIXS:0000692
     range: QuantityValue
     multivalued: false
   cool_syst_id:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: unique identifier
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: unique identifier
+      occurrence: '1'
     description: The cooling system identifier
     title: cooling system identifier
     examples:
       - value: '12345'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - cooling system identifier
     is_a: core field
     slot_uri: MIXS:0000785
     range: TextValue
     multivalued: false
   crop_rotation:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: crop rotation status;schedule
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: crop rotation status;schedule
+      occurrence: '1'
     description: Whether or not crop is rotated, and if yes, rotation schedule
     title: history/crop rotation
     examples:
       - value: yes;R2/2017-01-01/2018-12-31/P6M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/crop rotation
     is_a: core field
     string_serialization: '{boolean};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000318
@@ -3003,19 +2177,12 @@ slots:
     multivalued: false
   cult_root_med:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name, PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name, PMID,DOI or url
+      occurrence: '1'
     description: Name or reference for the hydroponic or in vitro culture rooting medium; can be the name of a commonly used medium or reference to a specific medium, e.g. Murashige and Skoog medium. If the medium has not been formally published, use the rooting medium descriptors.
     title: culture rooting medium
     examples:
       - value: http://himedialabs.com/TD/PT158.pdf
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - culture rooting medium
     is_a: core field
     string_serialization: '{text}|{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0001041
@@ -3023,38 +2190,24 @@ slots:
     multivalued: false
   cur_land_use:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Present state of sample site
     title: current land use
     examples:
       - value: conifers
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - current land use
     is_a: core field
     slot_uri: MIXS:0001080
     range: cur_land_use_enum
     multivalued: false
   cur_vegetation:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: current vegetation type
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: current vegetation type
+      occurrence: '1'
     description: Vegetation classification from one or more standard classification systems, or agricultural crop
     title: current vegetation
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - current vegetation
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000312
@@ -3062,19 +2215,12 @@ slots:
     multivalued: false
   cur_vegetation_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in vegetation classification
     title: current vegetation method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - current vegetation method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000314
@@ -3082,129 +2228,77 @@ slots:
     multivalued: false
   date_last_rain:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: timestamp
+      occurrence: '1'
     description: The date of the last time it rained
     title: date last rain
     examples:
       - value: 2018-05-11:T14:30Z
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - date last rain
     is_a: core field
     slot_uri: MIXS:0000786
     range: TimestampValue
     multivalued: false
   density:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per cubic meter, gram per cubic centimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: g/cm3|g/m3|kg/m3
+      expected_value: measurement value
+      preferred_unit: gram per cubic meter, gram per cubic centimeter
+      occurrence: '1'
+      storage_units: g/cm3|g/m3|kg/m3
     description: Density of the sample, which is its mass per unit volume (aka volumetric mass density)
     title: density
     examples:
       - value: 1000 kg/m3
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - density
     is_a: core field
     slot_uri: MIXS:0000435
     range: QuantityValue
     multivalued: false
   depos_env:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Main depositional environment (https://en.wikipedia.org/wiki/Depositional_environment). If "other" is specified, please propose entry in "additional info" field
     title: depositional environment
     examples:
       - value: Continental - Alluvial
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - depositional environment
     is_a: core field
     slot_uri: MIXS:0000992
     range: depos_env_enum
     multivalued: false
   depth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      storage_units:
-        tag: storage_units
-        value: m
+      expected_value: measurement value
+      storage_units: m
     description: The vertical distance below local surface, e.g. for sediment or soil samples depth is measured from sediment or soil surface, respectively. Depth can be reported as an interval for subsurface samples.
     title: depth
     examples:
       - value: 10 m
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - depth
     is_a: environment field
     slot_uri: MIXS:0000018
     range: QuantityValue
     multivalued: false
   dew_point:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: The temperature to which a given parcel of humid air must be cooled, at constant barometric pressure, for water vapor to condense into water.
     title: dew point
     examples:
       - value: 22 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dew point
     is_a: core field
     slot_uri: MIXS:0000129
     range: QuantityValue
     multivalued: false
   diether_lipids:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: diether lipid name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: nanogram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: diether lipid name;measurement value
+      preferred_unit: nanogram per liter
+      occurrence: m
     description: Concentration of diether lipids; can include multiple types of diether lipids
     title: diether lipids
     examples:
       - value: 0.2 nanogram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - diether lipids
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000178
@@ -3213,465 +2307,274 @@ slots:
     inlined_as_list: true
   diss_carb_dioxide:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|umol/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|umol/L
     description: Concentration of dissolved carbon dioxide in the sample or liquid portion of the sample
     title: dissolved carbon dioxide
     examples:
       - value: 5 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved carbon dioxide
     is_a: core field
     slot_uri: MIXS:0000436
     range: QuantityValue
     multivalued: false
   diss_hydrogen:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      storage_units: umol/L
     description: Concentration of dissolved hydrogen
     title: dissolved hydrogen
     examples:
       - value: 0.3 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved hydrogen
     is_a: core field
     slot_uri: MIXS:0000179
     range: QuantityValue
     multivalued: false
   diss_inorg_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|ug/L|umol/kg'
+      expected_value: measurement value
+      preferred_unit: microgram per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|ug/L|umol/kg'
     description: Dissolved inorganic carbon concentration in the sample, typically measured after filtering the sample using a 0.45 micrometer filter
     title: dissolved inorganic carbon
     examples:
       - value: 2059 umol/kg
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved inorganic carbon
     is_a: core field
     slot_uri: MIXS:0000434
     range: QuantityValue
     multivalued: false
   diss_inorg_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|umol/L|mg/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter, micromole per liter
+      occurrence: '1'
+      storage_units: ug/L|umol/L|mg/L
     description: Concentration of dissolved inorganic nitrogen
     title: dissolved inorganic nitrogen
     examples:
       - value: 761 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved inorganic nitrogen
     is_a: core field
     slot_uri: MIXS:0000698
     range: QuantityValue
     multivalued: false
   diss_inorg_phosp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|ug/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: microgram per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|ug/L|umol/L'
     description: Concentration of dissolved inorganic phosphorus in the sample
     title: dissolved inorganic phosphorus
     examples:
       - value: 56.5 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved inorganic phosphorus
     is_a: core field
     slot_uri: MIXS:0000106
     range: QuantityValue
     multivalued: false
   diss_iron:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: Concentration of dissolved iron in the sample
     title: dissolved iron
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved iron
     is_a: core field
     slot_uri: MIXS:0000139
     range: QuantityValue
     multivalued: false
   diss_org_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|umol/L|ug/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|umol/L|ug/L
     description: Concentration of dissolved organic carbon in the sample, liquid portion of the sample, or aqueous phase of the fluid
     title: dissolved organic carbon
     examples:
       - value: 197 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved organic carbon
     is_a: core field
     slot_uri: MIXS:0000433
     range: QuantityValue
     multivalued: false
   diss_org_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|ug/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|ug/L
     description: Dissolved organic nitrogen concentration measured as; total dissolved nitrogen - NH4 - NO3 - NO2
     title: dissolved organic nitrogen
     examples:
       - value: 0.05 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved organic nitrogen
     is_a: core field
     slot_uri: MIXS:0000162
     range: QuantityValue
     multivalued: false
   diss_oxygen:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per kilogram, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|umol/kg|umol/L
+      expected_value: measurement value
+      preferred_unit: micromole per kilogram, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|umol/kg|umol/L
     description: Concentration of dissolved oxygen
     title: dissolved oxygen
     examples:
       - value: 175 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved oxygen
     is_a: core field
     slot_uri: MIXS:0000119
     range: QuantityValue
     multivalued: false
   diss_oxygen_fluid:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per kilogram, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|umol/kg
+      expected_value: measurement value
+      preferred_unit: micromole per kilogram, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|umol/kg
     description: Concentration of dissolved oxygen in the oil field produced fluids as it contributes to oxgen-corrosion and microbial activity (e.g. Mic).
     title: dissolved oxygen in fluids
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - dissolved oxygen in fluids
     is_a: core field
     slot_uri: MIXS:0000438
     range: QuantityValue
     multivalued: false
   door_comp_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The composite type of the door
     title: door type, composite
     examples:
       - value: revolving
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door type, composite
     is_a: core field
     slot_uri: MIXS:0000795
     range: door_comp_type_enum
     multivalued: false
   door_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The phsical condition of the door
     title: door condition
     examples:
       - value: new
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door condition
     is_a: core field
     slot_uri: MIXS:0000788
     range: door_cond_enum
     multivalued: false
   door_direct:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The direction the door opens
     title: door direction of opening
     examples:
       - value: inward
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door direction of opening
     is_a: core field
     slot_uri: MIXS:0000789
     range: door_direct_enum
     multivalued: false
   door_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The relative location of the door in the room
     title: door location
     examples:
       - value: north
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door location
     is_a: core field
     slot_uri: MIXS:0000790
     range: door_loc_enum
     multivalued: false
   door_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The material the door is composed of
     title: door material
     examples:
       - value: wood
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door material
     is_a: core field
     slot_uri: MIXS:0000791
     range: door_mat_enum
     multivalued: false
   door_move:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of movement of the door
     title: door movement
     examples:
       - value: swinging
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door movement
     is_a: core field
     slot_uri: MIXS:0000792
     range: door_move_enum
     multivalued: false
   door_size:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m2
+      expected_value: measurement value
+      preferred_unit: square meter
+      occurrence: '1'
+      storage_units: m2
     description: The size of the door
     title: door area or size
     examples:
       - value: 2.5 m2
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door area or size
     is_a: core field
     slot_uri: MIXS:0000158
     range: QuantityValue
     multivalued: false
   door_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of door material
     title: door type
     examples:
       - value: wooden
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door type
     is_a: core field
     slot_uri: MIXS:0000794
     range: door_type_enum
     multivalued: false
   door_type_metal:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of metal door
     title: door type, metal
     examples:
       - value: hollow
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door type, metal
     is_a: core field
     slot_uri: MIXS:0000796
     range: door_type_metal_enum
     multivalued: false
   door_type_wood:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of wood door
     title: door type, wood
     examples:
       - value: battened
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door type, wood
     is_a: core field
     slot_uri: MIXS:0000797
     range: door_type_wood_enum
     multivalued: false
   door_water_mold:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Signs of the presence of mold or mildew on a door
     title: door signs of water/mold
     examples:
       - value: presence of mold visible
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - door signs of water/mold
     is_a: core field
     string_serialization: '[presence of mold visible|no presence of mold visible]'
     slot_uri: MIXS:0000793
@@ -3679,145 +2582,88 @@ slots:
     multivalued: false
   down_par:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microEinstein per square meter per second, microEinstein per square centimeter per second
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/m2/s
+      expected_value: measurement value
+      preferred_unit: microEinstein per square meter per second, microEinstein per square centimeter per second
+      occurrence: '1'
+      storage_units: umol/m2/s
     description: Visible waveband radiance and irradiance measurements in the water column
     title: downward PAR
     examples:
       - value: 28.71 umol/m2/s
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - downward PAR
     is_a: core field
     slot_uri: MIXS:0000703
     range: QuantityValue
     multivalued: false
   drainage_class:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Drainage classification from a standard system such as the USDA system
     title: drainage classification
     examples:
       - value: well
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - drainage classification
     is_a: core field
     slot_uri: MIXS:0001085
     range: drainage_class_enum
     multivalued: false
   drawings:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The buildings architectural drawings; if design is chosen, indicate phase-conceptual, schematic, design development, and construction documents
     title: drawings
     examples:
       - value: sketch
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - drawings
     is_a: core field
     slot_uri: MIXS:0000798
     range: drawings_enum
     multivalued: false
   efficiency_percent:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: mixs_inconsistent
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      units_alignment_excuse: mixs_inconsistent
     description: Percentage of volatile solids removed from the anaerobic digestor
     title: efficiency percent
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - efficiency percent
     is_a: core field
     slot_uri: MIXS:0000657
     range: QuantityValue
     multivalued: false
   elev:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
+      expected_value: measurement value
     description: Elevation of the sampling site is its height above a fixed reference point, most commonly the mean sea level. Elevation is mainly used when referring to points on the earth's surface, while altitude is used for points above the surface, such as an aircraft in flight or a spacecraft in orbit.
     title: elevation
     examples:
       - value: 100 meter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - elevation
     is_a: environment field
     slot_uri: MIXS:0000093
     range: float
     multivalued: false
   elevator:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of elevators within the built structure
     title: elevator count
     examples:
       - value: '2'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - elevator count
     is_a: core field
     slot_uri: MIXS:0000799
     range: TextValue
     multivalued: false
   emulsions:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: emulsion name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: emulsion name;measurement value
+      preferred_unit: gram per liter
+      occurrence: m
     description: Amount or concentration of substances such as paints, adhesives, mayonnaise, hair colorants, emulsified oils, etc.; can include multiple emulsion types
     title: emulsions
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - emulsions
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000660
@@ -3826,15 +2672,10 @@ slots:
     inlined_as_list: true
   env_broad_scale:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: The major environment type(s) where the sample was collected. Recommend subclasses of biome [ENVO:00000428]. Multiple terms can be separated by one or more pipes.
+      expected_value: The major environment type(s) where the sample was collected. Recommend subclasses of biome [ENVO:00000428]. Multiple terms can be separated by one or more pipes.
       tooltip: The biome or major environmental system where the sample or specimen originated. Choose values from subclasses of the 'biome' class [ENVO:00000428] in the Environment Ontology (ENVO). For host-associated or plant-associated samples, use terms from the UBERON or Plant Ontology to describe the broad anatomical or morphological context
     description: 'Report the major environmental system the sample or specimen came from. The system(s) identified should have a coarse spatial grain, to provide the general environmental context of where the sampling was done (e.g. in the desert or a rainforest). We recommend using subclasses of EnvO’s biome class:  http://purl.obolibrary.org/obo/ENVO_00000428. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS'
     title: broad-scale environmental context
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - broad-scale environmental context
     is_a: mixs_env_triad_field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000012
@@ -3844,15 +2685,10 @@ slots:
       - value: oceanic epipelagic zone biome [ENVO:01000035]
   env_local_scale:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: Environmental entities having causal influences upon the entity at time of sampling.
+      expected_value: Environmental entities having causal influences upon the entity at time of sampling.
       tooltip: The specific environmental entities or features near the sample or specimen that significantly influence its characteristics or composition. These entities are typically smaller in scale than the broad environmental context. Values for this field should be countable, material nouns and must be chosen from subclasses of BFO:0000040 (material entity) that appear in the Environment Ontology (ENVO). For host-associated or plant-associated samples, use terms from the UBERON or Plant Ontology to describe specific anatomical structures or plant parts.
     description: 'Report the entity or entities which are in the sample or specimen’s local vicinity and which you believe have significant causal influences on your sample or specimen. We recommend using EnvO terms which are of smaller spatial grain than your entry for env_broad_scale. Terms, such as anatomical sites, from other OBO Library ontologies which interoperate with EnvO (e.g. UBERON) are accepted in this field. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS.'
     title: local environmental context
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - local environmental context
     is_a: mixs_env_triad_field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000013
@@ -3862,15 +2698,10 @@ slots:
       - value: litter layer [ENVO:01000338]
   env_medium:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: The material displaced by the entity at time of sampling. Recommend subclasses of environmental material [ENVO:00010483].
+      expected_value: The material displaced by the entity at time of sampling. Recommend subclasses of environmental material [ENVO:00010483].
       tooltip: The predominant environmental material or substrate that directly surrounds or hosts the sample or specimen at the time of sampling. Choose values from subclasses of the 'environmental material' class [ENVO:00010483] in the Environment Ontology (ENVO). Values for this field should be measurable or mass material nouns, representing continuous environmental materials. For host-associated or plant-associated samples, use terms from the UBERON or Plant Ontology to indicate a tissue, organ, or plant structure
     description: 'Report the environmental material(s) immediately surrounding the sample or specimen at the time of sampling. We recommend using subclasses of ''environmental material'' (http://purl.obolibrary.org/obo/ENVO_00010483). EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS . Terms from other OBO ontologies are permissible as long as they reference mass/volume nouns (e.g. air, water, blood) and not discrete, countable entities (e.g. a tree, a leaf, a table top).'
     title: environmental medium
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - environmental medium
     is_a: mixs_env_triad_field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000014
@@ -3880,107 +2711,64 @@ slots:
       - value: soil [ENVO:00001998]
   escalator:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of escalators within the built structure
     title: escalator count
     examples:
       - value: '4'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - escalator count
     is_a: core field
     slot_uri: MIXS:0000800
     range: TextValue
     multivalued: false
   ethylbenzene:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of ethylbenzene in the sample
     title: ethylbenzene
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ethylbenzene
     is_a: core field
     slot_uri: MIXS:0000155
     range: QuantityValue
     multivalued: false
   exp_duct:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m2
+      expected_value: measurement value
+      preferred_unit: square meter
+      occurrence: '1'
+      storage_units: m2
     description: The amount of exposed ductwork in the room
     title: exposed ductwork
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - exposed ductwork
     is_a: core field
     slot_uri: MIXS:0000144
     range: QuantityValue
     multivalued: false
   exp_pipe:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: pending_analysis
+      expected_value: measurement value
+      occurrence: '1'
+      units_alignment_excuse: pending_analysis
     description: The number of exposed pipes in the room
     title: exposed pipes
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - exposed pipes
     is_a: core field
     slot_uri: MIXS:0000220
     range: QuantityValue
     multivalued: false
   experimental_factor:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: text or EFO and/or OBI
+      expected_value: text or EFO and/or OBI
     description: Experimental factors are essentially the variable aspects of an experiment design which can be used to describe an experiment, or set of experiments, in an increasingly detailed manner. This field accepts ontology terms from Experimental Factor Ontology (EFO) and/or Ontology for Biomedical Investigations (OBI). For a browser of EFO (v 2.95) terms, please see http://purl.bioontology.org/ontology/EFO; for a browser of OBI (v 2018-02-12) terms please see http://purl.bioontology.org/ontology/OBI
     title: experimental factor
     examples:
       - value: time series design [EFO:EFO_0001779]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - experimental factor
     is_a: investigation field
     string_serialization: '{termLabel} {[termID]}|{text}'
     slot_uri: MIXS:0000008
@@ -3988,117 +2776,73 @@ slots:
     multivalued: false
   ext_door:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of exterior doors in the built structure
     title: exterior door count
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - exterior door count
     is_a: core field
     slot_uri: MIXS:0000170
     range: TextValue
     multivalued: false
   ext_wall_orient:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The orientation of the exterior wall
     title: orientations of exterior wall
     examples:
       - value: northwest
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - orientations of exterior wall
     is_a: core field
     slot_uri: MIXS:0000817
     range: ext_wall_orient_enum
     multivalued: false
   ext_window_orient:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The compass direction the exterior window of the room is facing
     title: orientations of exterior window
     examples:
       - value: southwest
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - orientations of exterior window
     is_a: core field
     slot_uri: MIXS:0000818
     range: ext_window_orient_enum
     multivalued: false
   extreme_event:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: date
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: date
+      occurrence: '1'
     description: Unusual physical events that may have affected microbial populations
     title: history/extreme events
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/extreme events
     is_a: core field
     slot_uri: MIXS:0000320
     range: string
     multivalued: false
   fao_class:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Soil classification from the FAO World Reference Database for Soil Resources. The list can be found at http://www.fao.org/nr/land/sols/soil/wrb-soil-maps/reference-groups
     title: soil_taxonomic/FAO classification
     examples:
       - value: Luvisols
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil_taxonomic/FAO classification
     is_a: core field
     slot_uri: MIXS:0001083
     range: fao_class_enum
     multivalued: false
   fertilizer_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: fertilizer name;fertilizer amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: fertilizer name;fertilizer amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving the use of fertilizers; should include the name of fertilizer, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple fertilizer regimens
     title: fertilizer regimen
     examples:
       - value: urea;0.6 milligram per liter;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - fertilizer regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000556
@@ -4107,19 +2851,12 @@ slots:
     inlined_as_list: true
   field:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name
+      occurrence: '1'
     description: Name of the hydrocarbon field (e.g. Albacora)
     title: field name
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - field name
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000291
@@ -4127,57 +2864,36 @@ slots:
     multivalued: false
   filter_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: A device which removes solid particulates or airborne molecular contaminants
     title: filter type
     examples:
       - value: HEPA
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - filter type
     is_a: core field
     slot_uri: MIXS:0000765
     range: filter_type_enum
     multivalued: true
   fire:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: date
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: date
+      occurrence: '1'
     description: Historical and/or physical evidence of fire
     title: history/fire
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/fire
     is_a: core field
     slot_uri: MIXS:0001086
     range: string
     multivalued: false
   fireplace_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: A firebox with chimney
     title: fireplace type
     examples:
       - value: wood burning
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - fireplace type
     is_a: core field
     string_serialization: '[gas burning|wood burning]'
     slot_uri: MIXS:0000802
@@ -4185,280 +2901,167 @@ slots:
     multivalued: false
   flooding:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: date
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: date
+      occurrence: '1'
     description: Historical and/or physical evidence of flooding
     title: history/flooding
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/flooding
     is_a: core field
     slot_uri: MIXS:0000319
     range: string
     multivalued: false
   floor_age:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: years, weeks, days
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: a|d|wk
+      expected_value: value
+      preferred_unit: years, weeks, days
+      occurrence: '1'
+      storage_units: a|d|wk
     description: The time period since installment of the carpet or flooring
     title: floor age
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor age
     is_a: core field
     slot_uri: MIXS:0000164
     range: QuantityValue
     multivalued: false
   floor_area:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m2
+      expected_value: measurement value
+      preferred_unit: square meter
+      occurrence: '1'
+      storage_units: m2
     description: The area of the floor space within the room
     title: floor area
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor area
     is_a: core field
     slot_uri: MIXS:0000165
     range: QuantityValue
     multivalued: false
   floor_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The physical condition of the floor at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas
     title: floor condition
     examples:
       - value: new
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor condition
     is_a: core field
     slot_uri: MIXS:0000803
     range: floor_cond_enum
     multivalued: false
   floor_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of floors in the building, including basements and mechanical penthouse
     title: floor count
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor count
     is_a: core field
     slot_uri: MIXS:0000225
     range: TextValue
     multivalued: false
   floor_finish_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The floor covering type; the finished surface that is walked on
     title: floor finish material
     examples:
       - value: carpet
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor finish material
     is_a: core field
     slot_uri: MIXS:0000804
     range: floor_finish_mat_enum
     multivalued: false
   floor_struc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Refers to the structural elements and subfloor upon which the finish flooring is installed
     title: floor structure
     examples:
       - value: concrete
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor structure
     is_a: core field
     slot_uri: MIXS:0000806
     range: floor_struc_enum
     multivalued: false
   floor_thermal_mass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: joule per degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: J/K
+      expected_value: measurement value
+      preferred_unit: joule per degree Celsius
+      occurrence: '1'
+      storage_units: J/K
     description: The ability of the floor to provide inertia against temperature fluctuations
     title: floor thermal mass
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor thermal mass
     is_a: core field
     slot_uri: MIXS:0000166
     range: QuantityValue
     multivalued: false
   floor_water_mold:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Signs of the presence of mold or mildew in a room
     title: floor signs of water/mold
     examples:
       - value: ceiling discoloration
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - floor signs of water/mold
     is_a: core field
     slot_uri: MIXS:0000805
     range: floor_water_mold_enum
     multivalued: false
   fluor:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram chlorophyll a per cubic meter, volts
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/m3|V
+      expected_value: measurement value
+      preferred_unit: milligram chlorophyll a per cubic meter, volts
+      occurrence: '1'
+      storage_units: mg/m3|V
     description: Raw or converted fluorescence of water
     title: fluorescence
     examples:
       - value: 2.5 V
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - fluorescence
     is_a: core field
     slot_uri: MIXS:0000704
     range: QuantityValue
     multivalued: false
   freq_clean:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration or {text}
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: 1/d
+      expected_value: enumeration or {text}
+      occurrence: '1'
+      storage_units: 1/d
     description: The number of times the sample location is cleaned. Frequency of cleaning might be on a Daily basis, Weekly, Monthly, Quarterly or Annually.
     title: frequency of cleaning
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - frequency of cleaning
     is_a: core field
     slot_uri: MIXS:0000226
     range: QuantityValue
     multivalued: false
   freq_cook:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: 1/d
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: 1/d
     description: The number of times a meal is cooked per week
     title: frequency of cooking
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - frequency of cooking
     is_a: core field
     slot_uri: MIXS:0000227
     range: QuantityValue
     multivalued: false
   fungicide_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: fungicide name;fungicide amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: fungicide name;fungicide amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving use of fungicides; should include the name of fungicide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple fungicide regimens
     title: fungicide regimen
     examples:
       - value: bifonazole;1 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - fungicide regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000557
@@ -4467,41 +3070,25 @@ slots:
     inlined_as_list: true
   furniture:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The types of furniture present in the sampled room
     title: furniture
     examples:
       - value: chair
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - furniture
     is_a: core field
     slot_uri: MIXS:0000807
     range: furniture_enum
     multivalued: false
   gaseous_environment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gaseous compound name;gaseous compound amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: gaseous compound name;gaseous compound amount;treatment interval and duration
+      preferred_unit: micromole per liter
+      occurrence: m
     description: Use of conditions with differing gaseous environments; should include the name of gaseous compound, amount administered, treatment duration, interval and total experimental duration; can include multiple gaseous environment regimens
     title: gaseous environment
     examples:
       - value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - gaseous environment
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000558
@@ -4510,22 +3097,13 @@ slots:
     inlined_as_list: true
   gaseous_substances:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gaseous substance name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: gaseous substance name;measurement value
+      preferred_unit: micromole per liter
+      occurrence: m
     description: Amount or concentration of substances such as hydrogen sulfide, carbon dioxide, methane, etc.; can include multiple substances
     title: gaseous substances
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - gaseous substances
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000661
@@ -4534,38 +3112,24 @@ slots:
     inlined_as_list: true
   gender_restroom:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The gender type of the restroom
     title: gender of restroom
     examples:
       - value: male
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - gender of restroom
     is_a: core field
     slot_uri: MIXS:0000808
     range: gender_restroom_enum
     multivalued: false
   genetic_mod:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI,url or free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI,url or free text
+      occurrence: '1'
     description: Genetic modifications of the genome of an organism, which may occur naturally by spontaneous mutation, or be introduced by some experimental means, e.g. specification of a transgene or the gene knocked-out or details of transient transfection
     title: genetic modification
     examples:
       - value: aox1A transgenic
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - genetic modification
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}|{text}'
     slot_uri: MIXS:0000859
@@ -4573,16 +3137,11 @@ slots:
     multivalued: false
   geo_loc_name:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: 'country or sea name (INSDC or GAZ): region(GAZ), specific location name'
+      expected_value: 'country or sea name (INSDC or GAZ): region(GAZ), specific location name'
     description: The geographical origin of the sample as defined by the country or sea name followed by specific region name. Country or sea names should be chosen from the INSDC country list (http://insdc.org/country.html), or the GAZ ontology (http://purl.bioontology.org/ontology/GAZ)
     title: geographic location (country and/or sea,region)
     examples:
       - value: 'USA: Maryland, Bethesda'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - geographic location (country and/or sea,region)
     is_a: environment field
     string_serialization: '{term}: {term}, {text}'
     slot_uri: MIXS:0000010
@@ -4590,44 +3149,26 @@ slots:
     multivalued: false
   glucosidase_act:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: mol per liter per hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mol/L/h
+      expected_value: measurement value
+      preferred_unit: mol per liter per hour
+      occurrence: '1'
+      storage_units: mol/L/h
     description: Measurement of glucosidase activity
     title: glucosidase activity
     examples:
       - value: 5 mol/L/h
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - glucosidase activity
     is_a: core field
     slot_uri: MIXS:0000137
     range: QuantityValue
     multivalued: false
   gravidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gravidity status;timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: gravidity status;timestamp
+      occurrence: '1'
     description: Whether or not subject is gravid, and if yes date due or date post-conception, specifying which is used
     title: gravidity
     examples:
       - value: yes;due date:2018-05-11
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - gravidity
     is_a: core field
     string_serialization: '{boolean};{timestamp}'
     slot_uri: MIXS:0000875
@@ -4635,22 +3176,13 @@ slots:
     multivalued: false
   gravity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gravity factor value;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: meter per square second, g
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: gravity factor value;treatment interval and duration
+      preferred_unit: meter per square second, g
+      occurrence: m
     description: Information about treatment involving use of gravity factor to study various types of responses in presence, absence or modified levels of gravity; treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple treatments
     title: gravity
     examples:
       - value: 12 g;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - gravity
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000559
@@ -4659,19 +3191,12 @@ slots:
     inlined_as_list: true
   growth_facil:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: free text or CO
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: free text or CO
+      occurrence: '1'
     description: 'Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
     title: growth facility
     examples:
       - value: Growth chamber [CO_715:0000189]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - growth facility
     is_a: core field
     string_serialization: '{text}|{termLabel} {[termID]}'
     slot_uri: MIXS:0001043
@@ -4679,41 +3204,25 @@ slots:
     multivalued: false
   growth_habit:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Characteristic shape, appearance or growth form of a plant species
     title: growth habit
     examples:
       - value: spreading
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - growth habit
     is_a: core field
     slot_uri: MIXS:0001044
     range: growth_habit_enum
     multivalued: false
   growth_hormone_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: growth hormone name;growth hormone amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: growth hormone name;growth hormone amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving use of growth hormones; should include the name of growth hormone, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple growth hormone regimens
     title: growth hormone regimen
     examples:
       - value: abscisic acid;0.5 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - growth hormone regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000560
@@ -4722,142 +3231,87 @@ slots:
     inlined_as_list: true
   hall_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The total count of hallways and cooridors in the built structure
     title: hallway/corridor count
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - hallway/corridor count
     is_a: core field
     slot_uri: MIXS:0000228
     range: TextValue
     multivalued: false
   handidness:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The handidness of the individual sampled
     title: handidness
     examples:
       - value: right handedness
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - handidness
     is_a: core field
     slot_uri: MIXS:0000809
     range: handidness_enum
     multivalued: false
   hc_produced:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Main hydrocarbon type produced from resource (i.e. Oil, gas, condensate, etc). If "other" is specified, please propose entry in "additional info" field
     title: hydrocarbon type produced
     examples:
       - value: Gas
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - hydrocarbon type produced
     is_a: core field
     slot_uri: MIXS:0000989
     range: hc_produced_enum
     multivalued: false
   hcr:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Main Hydrocarbon Resource type. The term "Hydrocarbon Resource" HCR defined as a natural environmental feature containing large amounts of hydrocarbons at high concentrations potentially suitable for commercial exploitation. This term should not be confused with the Hydrocarbon Occurrence term which also includes hydrocarbon-rich environments with currently limited commercial interest such as seeps, outcrops, gas hydrates etc. If "other" is specified, please propose entry in "additional info" field
     title: hydrocarbon resource type
     examples:
       - value: Oil Sand
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - hydrocarbon resource type
     is_a: core field
     slot_uri: MIXS:0000988
     range: hcr_enum
     multivalued: false
   hcr_fw_salinity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: Original formation water salinity (prior to secondary recovery e.g. Waterflooding) expressed as TDS
     title: formation water salinity
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - formation water salinity
     is_a: core field
     slot_uri: MIXS:0000406
     range: QuantityValue
     multivalued: false
   hcr_geol_age:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: 'Geological age of hydrocarbon resource (Additional info: https://en.wikipedia.org/wiki/Period_(geology)). If "other" is specified, please propose entry in "additional info" field'
     title: hydrocarbon resource geological age
     examples:
       - value: Silurian
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - hydrocarbon resource geological age
     is_a: core field
     slot_uri: MIXS:0000993
     range: hcr_geol_age_enum
     multivalued: false
   hcr_pressure:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value range
-      preferred_unit:
-        tag: preferred_unit
-        value: atmosphere, kilopascal
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value range
+      preferred_unit: atmosphere, kilopascal
+      occurrence: '1'
     description: Original pressure of the hydrocarbon resource
     title: hydrocarbon resource original pressure
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - hydrocarbon resource original pressure
     is_a: core field
     string_serialization: '{float} - {float} {unit}'
     slot_uri: MIXS:0000395
@@ -4865,22 +3319,13 @@ slots:
     multivalued: false
   hcr_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value range
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value range
+      preferred_unit: degree Celsius
+      occurrence: '1'
     description: Original temperature of the hydrocarbon resource
     title: hydrocarbon resource original temperature
     examples:
       - value: 150-295 degree Celsius
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - hydrocarbon resource original temperature
     is_a: core field
     string_serialization: '{float} - {float} {unit}'
     slot_uri: MIXS:0000393
@@ -4888,57 +3333,36 @@ slots:
     multivalued: false
   heat_cool_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: Methods of conditioning or heating a room or building
     title: heating and cooling system type
     examples:
       - value: heat pump
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - heating and cooling system type
     is_a: core field
     slot_uri: MIXS:0000766
     range: heat_cool_type_enum
     multivalued: true
   heat_deliv_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The location of heat delivery within the room
     title: heating delivery locations
     examples:
       - value: north
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - heating delivery locations
     is_a: core field
     slot_uri: MIXS:0000810
     range: heat_deliv_loc_enum
     multivalued: false
   heat_sys_deliv_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The method by which the heat is delivered through the system
     title: heating system delivery method
     examples:
       - value: radiant
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - heating system delivery method
     is_a: core field
     string_serialization: '[conductive|radiant]'
     slot_uri: MIXS:0000812
@@ -4946,41 +3370,25 @@ slots:
     multivalued: false
   heat_system_id:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: unique identifier
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: unique identifier
+      occurrence: '1'
     description: The heating system identifier
     title: heating system identifier
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - heating system identifier
     is_a: core field
     slot_uri: MIXS:0000833
     range: TextValue
     multivalued: false
   heavy_metals:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: heavy metal name;measurement value unit
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per gram
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: heavy metal name;measurement value unit
+      preferred_unit: microgram per gram
+      occurrence: m
     description: Heavy metals present in the sequenced sample and their concentrations. For multiple heavy metals and concentrations, add multiple copies of this field.
     title: extreme_unusual_properties/heavy metals
     examples:
       - value: mercury;0.09 micrograms per gram
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - extreme_unusual_properties/heavy metals
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000652
@@ -4989,19 +3397,12 @@ slots:
     inlined_as_list: true
   heavy_metals_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining heavy metals
     title: extreme_unusual_properties/heavy metals method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - extreme_unusual_properties/heavy metals method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000343
@@ -5010,47 +3411,27 @@ slots:
     inlined_as_list: true
   height_carper_fiber:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: centimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: cm
+      expected_value: value
+      preferred_unit: centimeter
+      occurrence: '1'
+      storage_units: cm
     description: The average carpet fiber height in the indoor environment
     title: height carpet fiber mat
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - height carpet fiber mat
     is_a: core field
     slot_uri: MIXS:0000167
     range: QuantityValue
     multivalued: false
   herbicide_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: herbicide name;herbicide amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: herbicide name;herbicide amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving use of herbicides; information about treatment involving use of growth hormones; should include the name of herbicide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
     title: herbicide regimen
     examples:
       - value: atrazine;10 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - herbicide regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000561
@@ -5059,19 +3440,12 @@ slots:
     inlined_as_list: true
   horizon_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining the horizon
     title: soil horizon method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil horizon method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000321
@@ -5079,44 +3453,26 @@ slots:
     multivalued: false
   host_age:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: year, day, hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: a|d|h
+      expected_value: value
+      preferred_unit: year, day, hour
+      occurrence: '1'
+      storage_units: a|d|h
     description: Age of host at the time of sampling; relevant scale depends on species and study, e.g. Could be seconds for amoebae or centuries for trees
     title: host age
     examples:
       - value: 10 d
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host age
     is_a: core field
     slot_uri: MIXS:0000255
     range: QuantityValue
     multivalued: false
   host_body_habitat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: free text
+      occurrence: '1'
     description: Original body habitat where the sample was obtained from
     title: host body habitat
     examples:
       - value: nasopharynx
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host body habitat
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000866
@@ -5124,17 +3480,10 @@ slots:
     multivalued: false
   host_body_product:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: FMA or UBERON
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: FMA or UBERON
+      occurrence: '1'
     description: Substance produced by the body, e.g. Stool, mucus, where the sample was obtained from. For foundational model of anatomy ontology (fma) or Uber-anatomy ontology (UBERON) terms, please see https://www.ebi.ac.uk/ols/ontologies/fma or https://www.ebi.ac.uk/ols/ontologies/uberon
     title: host body product
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host body product
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000888
@@ -5144,19 +3493,12 @@ slots:
       - value: mucus [UBERON:0000912]
   host_body_site:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: FMA or UBERON
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: FMA or UBERON
+      occurrence: '1'
     description: Name of body site where the sample was obtained from, such as a specific organ or tissue (tongue, lung etc...). For foundational model of anatomy ontology (fma) (v 4.11.0) or Uber-anatomy ontology (UBERON) (v releases/2014-06-15) terms, please see http://purl.bioontology.org/ontology/FMA or http://purl.bioontology.org/ontology/UBERON
     title: host body site
     examples:
       - value: gill [UBERON:0002535]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host body site
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000867
@@ -5164,44 +3506,26 @@ slots:
     multivalued: false
   host_body_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: Core body temperature of the host when sample was collected
     title: host body temperature
     examples:
       - value: 15 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host body temperature
     is_a: core field
     slot_uri: MIXS:0000274
     range: QuantityValue
     multivalued: false
   host_color:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: color
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: color
+      occurrence: '1'
     description: The color of host
     title: host color
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host color
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000260
@@ -5209,19 +3533,12 @@ slots:
     multivalued: false
   host_common_name:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: common name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: common name
+      occurrence: '1'
     description: Common name of the host.
     title: host common name
     examples:
       - value: human
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host common name
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000248
@@ -5229,19 +3546,12 @@ slots:
     multivalued: false
   host_diet:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: diet type
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: diet type
+      occurrence: m
     description: Type of diet depending on the host, for animals omnivore, herbivore etc., for humans high-fat, meditteranean etc.; can include multiple diet types
     title: host diet
     examples:
       - value: herbivore
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host diet
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000869
@@ -5250,16 +3560,11 @@ slots:
     inlined_as_list: true
   host_disease_stat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: disease name or Disease Ontology term
+      expected_value: disease name or Disease Ontology term
     description: List of diseases with which the host has been diagnosed; can include multiple diagnoses. The value of the field depends on host; for humans the terms should be chosen from the DO (Human Disease Ontology) at https://www.disease-ontology.org, non-human host diseases are free text
     title: host disease status
     examples:
       - value: rabies [DOID:11260]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host disease status
     is_a: nucleic acid sequence source field
     string_serialization: '{termLabel} {[termID]}|{text}'
     slot_uri: MIXS:0000031
@@ -5267,44 +3572,26 @@ slots:
     multivalued: false
   host_dry_mass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: kilogram, gram
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: g|kg
+      expected_value: measurement value
+      preferred_unit: kilogram, gram
+      occurrence: '1'
+      storage_units: g|kg
     description: Measurement of dry mass
     title: host dry mass
     examples:
       - value: 500 g
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host dry mass
     is_a: core field
     slot_uri: MIXS:0000257
     range: QuantityValue
     multivalued: false
   host_family_relation:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: relationship type;arbitrary identifier
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: relationship type;arbitrary identifier
+      occurrence: m
     description: Familial relationships to other hosts in the same study; can include multiple relationships
     title: host family relationship
     examples:
       - value: offspring;Mussel25
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host family relationship
     is_a: core field
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0000872
@@ -5312,19 +3599,12 @@ slots:
     multivalued: true
   host_genotype:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: genotype
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: genotype
+      occurrence: '1'
     description: Observed genotype
     title: host genotype
     examples:
       - value: C57BL/6
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host genotype
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000365
@@ -5332,19 +3612,12 @@ slots:
     multivalued: false
   host_growth_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI,url or free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI,url or free text
+      occurrence: '1'
     description: Literature reference giving growth conditions of the host
     title: host growth conditions
     examples:
       - value: https://academic.oup.com/icesjms/article/68/2/349/617247
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host growth conditions
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}|{text}'
     slot_uri: MIXS:0000871
@@ -5352,44 +3625,26 @@ slots:
     multivalued: false
   host_height:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: centimeter, millimeter, meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: cm|m|mm
+      expected_value: measurement value
+      preferred_unit: centimeter, millimeter, meter
+      occurrence: '1'
+      storage_units: cm|m|mm
     description: The height of subject
     title: host height
     examples:
       - value: 0.1 m
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host height
     is_a: core field
     slot_uri: MIXS:0000264
     range: QuantityValue
     multivalued: false
   host_last_meal:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: content;duration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: content;duration
+      occurrence: m
     description: Content of last meal and time since feeding; can include multiple values
     title: host last meal
     examples:
       - value: corn feed;P2H
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host last meal
     is_a: core field
     string_serialization: '{text};{duration}'
     slot_uri: MIXS:0000870
@@ -5398,44 +3653,26 @@ slots:
     inlined_as_list: true
   host_length:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: centimeter, millimeter, meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: cm|m|mm
+      expected_value: measurement value
+      preferred_unit: centimeter, millimeter, meter
+      occurrence: '1'
+      storage_units: cm|m|mm
     description: The length of subject
     title: host length
     examples:
       - value: 1 m
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host length
     is_a: core field
     slot_uri: MIXS:0000256
     range: QuantityValue
     multivalued: false
   host_life_stage:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: stage
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: stage
+      occurrence: '1'
     description: Description of life stage of host
     title: host life stage
     examples:
       - value: adult
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host life stage
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000251
@@ -5443,19 +3680,12 @@ slots:
     multivalued: false
   host_phenotype:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PATO or HP
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PATO or HP
+      occurrence: '1'
     description: Phenotype of human or other host. For phenotypic quality ontology (pato) (v 2018-03-27) terms, please see http://purl.bioontology.org/ontology/pato. For Human Phenotype Ontology (HP) (v 2018-06-13) please see http://purl.bioontology.org/ontology/HP
     title: host phenotype
     examples:
       - value: elongated [PATO:0001154]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host phenotype
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000874
@@ -5463,38 +3693,24 @@ slots:
     multivalued: false
   host_sex:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Gender or physical sex of the host.
     title: host sex
     examples:
       - value: non-binary
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host sex
     is_a: core field
     slot_uri: MIXS:0000811
     range: host_sex_enum
     multivalued: false
   host_shape:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: shape
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: shape
+      occurrence: '1'
     description: Morphological shape of host
     title: host shape
     examples:
       - value: round
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host shape
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000261
@@ -5502,19 +3718,12 @@ slots:
     multivalued: false
   host_subject_id:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: unique identifier
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: unique identifier
+      occurrence: '1'
     description: A unique identifier by which each subject can be referred to, de-identified.
     title: host subject id
     examples:
       - value: MPI123
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host subject id
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000861
@@ -5522,19 +3731,12 @@ slots:
     multivalued: false
   host_subspecf_genlin:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies, e.g. serovar, biotype, ecotype, variety, cultivar.
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: Genetic lineage below lowest rank of NCBI taxonomy, which is subspecies, e.g. serovar, biotype, ecotype, variety, cultivar.
+      occurrence: m
     description: Information about the genetic distinctness of the host organism below the subspecies level e.g., serovar, serotype, biotype, ecotype, variety, cultivar, or any relevant genetic typing schemes like Group I plasmid. Subspecies should not be recorded in this term, but in the NCBI taxonomy. Supply both the lineage name and the lineage rank separated by a colon, e.g., biovar:abc123.
     title: host subspecific genetic lineage
     examples:
       - value: 'serovar:Newport, variety:glabrum, cultivar: Red Delicious'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host subspecific genetic lineage
     is_a: core field
     string_serialization: '{rank name}:{text}'
     slot_uri: MIXS:0001318
@@ -5542,19 +3744,12 @@ slots:
     multivalued: true
   host_substrate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: substrate name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: substrate name
+      occurrence: '1'
     description: The growth substrate of the host.
     title: host substrate
     examples:
       - value: rock
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host substrate
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000252
@@ -5562,19 +3757,12 @@ slots:
     multivalued: false
   host_symbiont:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: species name or common name
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: species name or common name
+      occurrence: m
     description: The taxonomic name of the organism(s) found living in mutualistic, commensalistic, or parasitic symbiosis with the specific host.
     title: observed host symbionts
     examples:
       - value: flukeworms
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - observed host symbionts
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0001298
@@ -5582,17 +3770,10 @@ slots:
     multivalued: true
   host_taxid:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: NCBI taxon identifier
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: NCBI taxon identifier
+      occurrence: '1'
     description: NCBI taxon id of the host, e.g. 9606
     title: host taxid
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host taxid
     is_a: core field
     slot_uri: MIXS:0000250
     range: ControlledIdentifiedTermValue
@@ -5601,97 +3782,55 @@ slots:
       - Homo sapiens [NCBITaxon:9606] would be a reasonable has_raw_value
   host_tot_mass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: kilogram, gram
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: g|kg
+      expected_value: measurement value
+      preferred_unit: kilogram, gram
+      occurrence: '1'
+      storage_units: g|kg
     description: Total mass of the host at collection, the unit depends on host
     title: host total mass
     examples:
       - value: 2500 g
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host total mass
     is_a: core field
     slot_uri: MIXS:0000263
     range: QuantityValue
     multivalued: false
   host_wet_mass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: kilogram, gram
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: g|kg
+      expected_value: measurement value
+      preferred_unit: kilogram, gram
+      occurrence: '1'
+      storage_units: g|kg
     description: Measurement of wet mass
     title: host wet mass
     examples:
       - value: 1500 g
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - host wet mass
     is_a: core field
     slot_uri: MIXS:0000567
     range: QuantityValue
     multivalued: false
   humidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per cubic meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: g/m3|%
+      expected_value: measurement value
+      preferred_unit: gram per cubic meter
+      occurrence: '1'
+      storage_units: g/m3|%
     description: Amount of water vapour in the air, at the time of sampling
     title: humidity
     examples:
       - value: 25 g/m3
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - humidity
     is_a: core field
     slot_uri: MIXS:0000100
     range: QuantityValue
     multivalued: false
   humidity_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: humidity value;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per cubic meter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: humidity value;treatment interval and duration
+      preferred_unit: gram per cubic meter
+      occurrence: m
     description: Information about treatment involving an exposure to varying degree of humidity; information about treatment involving use of growth hormones; should include amount of humidity administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
     title: humidity regimen
     examples:
       - value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - humidity regimen
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000568
@@ -5700,85 +3839,51 @@ slots:
     inlined_as_list: true
   indoor_space:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: A distinguishable space within a structure, the purpose for which discrete areas of a building is used
     title: indoor space
     examples:
       - value: foyer
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - indoor space
     is_a: core field
     slot_uri: MIXS:0000763
     range: indoor_space_enum
     multivalued: false
   indoor_surf:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Type of indoor surface
     title: indoor surface
     examples:
       - value: wall
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - indoor surface
     is_a: core field
     slot_uri: MIXS:0000764
     range: indoor_surf_enum
     multivalued: false
   indust_eff_percent:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percentage
+      occurrence: '1'
+      storage_units: '%'
     description: Percentage of industrial effluents received by wastewater treatment plant
     title: industrial effluent percent
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - industrial effluent percent
     is_a: core field
     slot_uri: MIXS:0000662
     range: QuantityValue
     multivalued: false
   inorg_particles:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: inorganic particle name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: inorganic particle name;measurement value
+      preferred_unit: mole per liter, milligram per liter
+      occurrence: m
     description: Concentration of particles such as sand, grit, metal particles, ceramics, etc.; can include multiple particles
     title: inorganic particles
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - inorganic particles
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000664
@@ -5787,123 +3892,75 @@ slots:
     inlined_as_list: true
   inside_lux:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: kilowatt per square metre
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: mixs_inconsistent
+      expected_value: measurement value
+      preferred_unit: kilowatt per square metre
+      occurrence: '1'
+      units_alignment_excuse: mixs_inconsistent
     description: The recorded value at sampling time (power density)
     title: inside lux light
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - inside lux light
     is_a: core field
     slot_uri: MIXS:0000168
     range: QuantityValue
     multivalued: false
   int_wall_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The physical condition of the wall at the time of sampling; photos or video preferred; use drawings to indicate location of damaged areas
     title: interior wall condition
     examples:
       - value: damaged
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - interior wall condition
     is_a: core field
     slot_uri: MIXS:0000813
     range: int_wall_cond_enum
     multivalued: false
   iw_bt_date_well:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: timestamp
+      occurrence: '1'
     description: Injection water breakthrough date per well following a secondary and/or tertiary recovery
     title: injection water breakthrough date of specific well
     examples:
       - value: '2018-05-11'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - injection water breakthrough date of specific well
     is_a: core field
     slot_uri: MIXS:0001010
     range: TimestampValue
     multivalued: false
   iwf:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percent
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percent
+      occurrence: '1'
+      storage_units: '%'
     description: Proportion of the produced fluids derived from injected water at the time of sampling. (e.g. 87%)
     title: injection water fraction
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - injection water fraction
     is_a: core field
     slot_uri: MIXS:0000455
     range: QuantityValue
     multivalued: false
   last_clean:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: timestamp
+      occurrence: '1'
     description: The last time the floor was cleaned (swept, mopped, vacuumed)
     title: last time swept/mopped/vacuumed
     examples:
       - value: 2018-05-11:T14:30Z
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - last time swept/mopped/vacuumed
     is_a: core field
     slot_uri: MIXS:0000814
     range: TimestampValue
     multivalued: false
   lat_lon:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: decimal degrees,  limit to 8 decimal points
+      expected_value: decimal degrees,  limit to 8 decimal points
     description: The geographical origin of the sample as defined by latitude and longitude. The values should be reported in decimal degrees and in WGS84 system
     title: geographic location (latitude and longitude)
     examples:
       - value: 50.586825 6.408977
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - geographic location (latitude and longitude)
     is_a: environment field
     string_serialization: '{float} {float}'
     slot_uri: MIXS:0000009
@@ -5911,47 +3968,27 @@ slots:
     multivalued: false
   light_intensity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: lux
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: lx
+      expected_value: measurement value
+      preferred_unit: lux
+      occurrence: '1'
+      storage_units: lx
     description: Measurement of light intensity
     title: light intensity
     examples:
       - value: 0.3 lx
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - light intensity
     is_a: core field
     slot_uri: MIXS:0000706
     range: QuantityValue
     multivalued: false
   light_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: exposure type;light intensity;light quality
-      preferred_unit:
-        tag: preferred_unit
-        value: lux; micrometer, nanometer, angstrom
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: exposure type;light intensity;light quality
+      preferred_unit: lux; micrometer, nanometer, angstrom
+      occurrence: '1'
     description: Information about treatment(s) involving exposure to light, including both light intensity and quality.
     title: light regimen
     examples:
       - value: incandescant light;10 lux;450 nanometer
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - light regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000569
@@ -5959,38 +3996,24 @@ slots:
     multivalued: false
   light_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: Application of light to achieve some practical or aesthetic effect. Lighting includes the use of both artificial light sources such as lamps and light fixtures, as well as natural illumination by capturing daylight. Can also include absence of light
     title: light type
     examples:
       - value: desk lamp
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - light type
     is_a: core field
     slot_uri: MIXS:0000769
     range: light_type_enum
     multivalued: true
   link_addit_analys:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Link to additional analysis results performed on the sample
     title: links to additional analysis
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - links to additional analysis
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000340
@@ -5998,19 +4021,12 @@ slots:
     multivalued: false
   link_class_info:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Link to digitized soil maps or other soil classification information
     title: link to classification information
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - link to classification information
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000329
@@ -6018,19 +4034,12 @@ slots:
     multivalued: false
   link_climate_info:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Link to climate resource
     title: link to climate information
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - link to climate information
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000328
@@ -6038,38 +4047,24 @@ slots:
     multivalued: false
   lithology:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: 'Hydrocarbon resource main lithology (Additional information: http://petrowiki.org/Lithology_and_rock_type_determination). If "other" is specified, please propose entry in "additional info" field'
     title: lithology
     examples:
       - value: Volcanic
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - lithology
     is_a: core field
     slot_uri: MIXS:0000990
     range: lithology_enum
     multivalued: false
   local_class:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: local classification name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: local classification name
+      occurrence: '1'
     description: Soil classification based on local soil classification system
     title: soil_taxonomic/local classification
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil_taxonomic/local classification
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000330
@@ -6077,19 +4072,12 @@ slots:
     multivalued: false
   local_class_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining the local soil classification
     title: soil_taxonomic/local classification method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil_taxonomic/local classification method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000331
@@ -6097,135 +4085,79 @@ slots:
     multivalued: false
   magnesium:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: mole per liter, milligram per liter, parts per million, micromole per kilogram
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|mol/L|umol/kg|mg/kg'
+      expected_value: measurement value
+      preferred_unit: mole per liter, milligram per liter, parts per million, micromole per kilogram
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|mol/L|umol/kg|mg/kg'
     description: Concentration of magnesium in the sample
     title: magnesium
     examples:
       - value: 52.8 umol/kg
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - magnesium
     is_a: core field
     slot_uri: MIXS:0000431
     range: QuantityValue
     multivalued: false
   max_occup:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: The maximum amount of people allowed in the indoor environment
     title: maximum occupancy
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - maximum occupancy
     is_a: core field
     slot_uri: MIXS:0000229
     range: QuantityValue
     multivalued: false
   mean_frict_vel:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter per second
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m/s
+      expected_value: measurement value
+      preferred_unit: meter per second
+      occurrence: '1'
+      storage_units: m/s
     description: Measurement of mean friction velocity
     title: mean friction velocity
     examples:
       - value: 0.5 m/s
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mean friction velocity
     is_a: core field
     slot_uri: MIXS:0000498
     range: QuantityValue
     multivalued: false
   mean_peak_frict_vel:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter per second
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m/s
+      expected_value: measurement value
+      preferred_unit: meter per second
+      occurrence: '1'
+      storage_units: m/s
     description: Measurement of mean peak friction velocity
     title: mean peak friction velocity
     examples:
       - value: 1 m/s
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mean peak friction velocity
     is_a: core field
     slot_uri: MIXS:0000502
     range: QuantityValue
     multivalued: false
   mech_struc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: 'mechanical structure: a moving structure'
     title: mechanical structure
     examples:
       - value: elevator
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mechanical structure
     is_a: core field
     slot_uri: MIXS:0000815
     range: mech_struc_enum
     multivalued: false
   mechanical_damage:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: damage type;body site
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: damage type;body site
+      occurrence: m
     description: Information about any mechanical damage exerted on the plant; can include multiple damages and sites
     title: mechanical damage
     examples:
       - value: pruning;bark
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mechanical damage
     is_a: core field
     string_serialization: '{text};{text}'
     slot_uri: MIXS:0001052
@@ -6234,44 +4166,26 @@ slots:
     inlined_as_list: true
   methane:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, parts per billion, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppb]|[ppm]|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, parts per billion, parts per million
+      occurrence: '1'
+      storage_units: '[ppb]|[ppm]|umol/L'
     description: Methane (gas) amount or concentration at the time of sampling
     title: methane
     examples:
       - value: 1800 [ppb]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - methane
     is_a: core field
     slot_uri: MIXS:0000101
     range: QuantityValue
     multivalued: false
   micro_biomass_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining microbial biomass
     title: microbial biomass method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - microbial biomass method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000339
@@ -6279,47 +4193,27 @@ slots:
     multivalued: false
   microbial_biomass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: ton, kilogram, gram per kilogram soil
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: complex_unit
+      expected_value: measurement value
+      preferred_unit: ton, kilogram, gram per kilogram soil
+      occurrence: '1'
+      units_alignment_excuse: complex_unit
     description: The part of the organic matter in the soil that constitutes living microorganisms smaller than 5-10 micrometer. If you keep this, you would need to have correction factors used for conversion to the final units
     title: microbial biomass
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - microbial biomass
     is_a: core field
     slot_uri: MIXS:0000650
     range: QuantityValue
     multivalued: false
   mineral_nutr_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: mineral nutrient name;mineral nutrient amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: mineral nutrient name;mineral nutrient amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving the use of mineral supplements; should include the name of mineral nutrient, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple mineral nutrient regimens
     title: mineral nutrient regimen
     examples:
       - value: potassium;15 gram;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mineral nutrient regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000570
@@ -6328,19 +4222,12 @@ slots:
     inlined_as_list: true
   misc_param:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: parameter name;measurement value
-      occurrence:
-        tag: occurrence
-        value: m
-    description: Structured miscellaneous property assertions for this Biosample. Use when a value cannot cleanly fit an existing, policy-governed slot.
+      expected_value: parameter name;measurement value
+      occurrence: m
+    description: Structured miscellaneous property assertions. Use when a value cannot cleanly fit an existing, policy-governed slot.
     title: miscellaneous parameter
     examples:
       - value: Bicarbonate ion concentration;2075 micromole per kilogram
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - miscellaneous parameter
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000752
@@ -6351,22 +4238,13 @@ slots:
     inlined_as_list: true
   n_alkanes:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: n-alkane name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: n-alkane name;measurement value
+      preferred_unit: micromole per liter
+      occurrence: m
     description: Concentration of n-alkanes; can include multiple n-alkanes
     title: n-alkanes
     examples:
       - value: n-hexadecane;100 milligram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - n-alkanes
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000503
@@ -6375,97 +4253,55 @@ slots:
     inlined_as_list: true
   nitrate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L'
     description: Concentration of nitrate in the sample
     title: nitrate
     examples:
       - value: 65 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - nitrate
     is_a: core field
     slot_uri: MIXS:0000425
     range: QuantityValue
     multivalued: false
   nitrite:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L'
     description: Concentration of nitrite in the sample
     title: nitrite
     examples:
       - value: 0.5 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - nitrite
     is_a: core field
     slot_uri: MIXS:0000426
     range: QuantityValue
     multivalued: false
   nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/L|%
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      storage_units: umol/L|%
     description: Concentration of nitrogen (total)
     title: nitrogen
     examples:
       - value: 4.2 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - nitrogen
     is_a: core field
     slot_uri: MIXS:0000504
     range: QuantityValue
     multivalued: false
   non_min_nutr_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: non-mineral nutrient name;non-mineral nutrient amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: non-mineral nutrient name;non-mineral nutrient amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving the exposure of plant to non-mineral nutrient such as oxygen, hydrogen or carbon; should include the name of non-mineral nutrient, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple non-mineral nutrient regimens
     title: non-mineral nutrient regimen
     examples:
       - value: carbon dioxide;10 mole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - non-mineral nutrient regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000571
@@ -6473,16 +4309,11 @@ slots:
     multivalued: true
   nucl_acid_amp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID, DOI or URL
+      expected_value: PMID, DOI or URL
     description: A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the enzymatic amplification (PCR, TMA, NASBA) of specific nucleic acids
     title: nucleic acid amplification
     examples:
       - value: https://phylogenomics.me/protocols/16s-pcr-protocol/
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - nucleic acid amplification
     is_a: sequencing field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000038
@@ -6490,16 +4321,11 @@ slots:
     multivalued: false
   nucl_acid_ext:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID, DOI or URL
+      expected_value: PMID, DOI or URL
     description: A link to a literature reference, electronic resource or a standard operating procedure (SOP), that describes the material separation to recover the nucleic acid fraction from a sample
     title: nucleic acid extraction
     examples:
       - value: https://mobio.com/media/wysiwyg/pdfs/protocols/12888.pdf
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - nucleic acid extraction
     is_a: sequencing field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000037
@@ -6507,176 +4333,104 @@ slots:
     multivalued: false
   number_pets:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: The number of pets residing in the sampled space
     title: number of pets
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - number of pets
     is_a: core field
     slot_uri: MIXS:0000231
     range: QuantityValue
     multivalued: false
   number_plants:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: The number of plant(s) in the sampling space
     title: number of houseplants
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - number of houseplants
     is_a: core field
     slot_uri: MIXS:0000230
     range: QuantityValue
     multivalued: false
   number_resident:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: The number of individuals currently occupying in the sampling location
     title: number of residents
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - number of residents
     is_a: core field
     slot_uri: MIXS:0000232
     range: QuantityValue
     multivalued: false
   occup_density_samp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: pending_analysis
+      expected_value: measurement value
+      occurrence: '1'
+      units_alignment_excuse: pending_analysis
     description: Average number of occupants at time of sampling per square footage
     title: occupant density at sampling
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - occupant density at sampling
     is_a: core field
     slot_uri: MIXS:0000217
     range: QuantityValue
     multivalued: false
   occup_document:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of documentation of occupancy
     title: occupancy documentation
     examples:
       - value: estimate
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - occupancy documentation
     is_a: core field
     slot_uri: MIXS:0000816
     range: occup_document_enum
     multivalued: false
   occup_samp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: Number of occupants present at time of sample within the given space
     title: occupancy at sampling
     examples:
       - value: '10'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - occupancy at sampling
     is_a: core field
     slot_uri: MIXS:0000772
     range: QuantityValue
     multivalued: false
   org_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/L|%|mg/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      storage_units: umol/L|%|mg/L
     description: Concentration of organic carbon
     title: organic carbon
     examples:
       - value: 0.015 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - organic carbon
     is_a: core field
     slot_uri: MIXS:0000508
     range: QuantityValue
     multivalued: false
   org_count_qpcr_info:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes; total cycles
-      preferred_unit:
-        tag: preferred_unit
-        value: number of cells per gram (or ml or cm^2)
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: gene name;FWD:forward primer sequence;REV:reverse primer sequence;initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes; total cycles
+      preferred_unit: number of cells per gram (or ml or cm^2)
+      occurrence: '1'
     description: 'If qpcr was used for the cell count, the target gene name, the primer sequence and the cycling conditions should also be provided. (Example: 16S rrna; FWD:ACGTAGCTATGACGT REV:GTGCTAGTCGAGTAC; initial denaturation:90C_5min; denaturation:90C_2min; annealing:52C_30 sec; elongation:72C_30 sec; 90 C for 1 min; final elongation:72C_5min; 30 cycles)'
     title: organism count qPCR information
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - organism count qPCR information
     is_a: core field
     string_serialization: '{text};FWD:{dna};REV:{dna};initial denaturation:degrees_minutes;denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes; total cycles'
     slot_uri: MIXS:0000099
@@ -6684,72 +4438,41 @@ slots:
     multivalued: false
   org_matter:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter
+      occurrence: '1'
+      storage_units: ug/L
     description: Concentration of organic matter
     title: organic matter
     examples:
       - value: 200 ug/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - organic matter
     is_a: core field
     slot_uri: MIXS:0000204
     range: QuantityValue
     multivalued: false
   org_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter
+      occurrence: '1'
+      storage_units: ug/L
     description: Concentration of organic nitrogen
     title: organic nitrogen
     examples:
       - value: 4 ug/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - organic nitrogen
     is_a: core field
     slot_uri: MIXS:0000205
     range: QuantityValue
     multivalued: false
   org_particles:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: particle name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: particle name;measurement value
+      preferred_unit: gram per liter
+      occurrence: m
     description: Concentration of particles such as faeces, hairs, food, vomit, paper fibers, plant material, humus, etc.
     title: organic particles
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - organic particles
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000665
@@ -6758,25 +4481,14 @@ slots:
     inlined_as_list: true
   organism_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: organism name;measurement value;enumeration
-      preferred_unit:
-        tag: preferred_unit
-        value: number of cells per cubic meter, number of cells per milliliter, number of cells per cubic centimeter
-      occurrence:
-        tag: occurrence
-        value: m
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: organism name;measurement value;enumeration
+      preferred_unit: number of cells per cubic meter, number of cells per milliliter, number of cells per cubic centimeter
+      occurrence: m
+      storage_units: "1"
     description: 'Total cell count of any organism (or group of organisms) per gram, volume or area of sample, should include name of organism followed by count. The method that was used for the enumeration (e.g. qPCR, atp, mpn, etc.) Should also be provided. (example: total prokaryotes; 3.5e7 cells per ml; qpcr)'
     title: organism count
     examples:
       - value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - organism count
     is_a: core field
     slot_uri: MIXS:0000103
     range: QuantityValue
@@ -6784,141 +4496,81 @@ slots:
     inlined_as_list: true
   owc_tvdss:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m
+      expected_value: measurement value
+      preferred_unit: meter
+      occurrence: '1'
+      storage_units: m
     description: Depth of the original oil water contact (OWC) zone (average) (m TVDSS)
     title: oil water contact depth
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - oil water contact depth
     is_a: core field
     slot_uri: MIXS:0000405
     range: QuantityValue
     multivalued: false
   oxy_stat_samp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Oxygenation status of sample
     title: oxygenation status of sample
     examples:
       - value: aerobic
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - oxygenation status of sample
     is_a: core field
     slot_uri: MIXS:0000753
     range: oxy_stat_samp_enum
     multivalued: false
   oxygen:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Oxygen (gas) amount or concentration at the time of sampling
     title: oxygen
     examples:
       - value: 600 [ppm]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - oxygen
     is_a: core field
     slot_uri: MIXS:0000104
     range: QuantityValue
     multivalued: false
   part_org_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|mg/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter
+      occurrence: '1'
+      storage_units: ug/L|mg/L
     description: Concentration of particulate organic carbon
     title: particulate organic carbon
     examples:
       - value: 0.02 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - particulate organic carbon
     is_a: core field
     slot_uri: MIXS:0000515
     range: QuantityValue
     multivalued: false
   part_org_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|umol/L|mg/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter, micromole per liter
+      occurrence: '1'
+      storage_units: ug/L|umol/L|mg/L
     description: Concentration of particulate organic nitrogen
     title: particulate organic nitrogen
     examples:
       - value: 0.3 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - particulate organic nitrogen
     is_a: core field
     slot_uri: MIXS:0000719
     range: QuantityValue
     multivalued: false
   particle_class:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: particle name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micrometer
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: particle name;measurement value
+      preferred_unit: micrometer
+      occurrence: m
     description: Particles are classified, based on their size, into six general categories:clay, silt, sand, gravel, cobbles, and boulders; should include amount of particle preceded by the name of the particle type; can include multiple values
     title: particle classification
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - particle classification
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000206
@@ -6927,16 +4579,11 @@ slots:
     inlined_as_list: true
   pcr_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles
+      expected_value: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles
     description: Description of reaction conditions and components of PCR in the form of 'initial denaturation:94degC_1.5min; annealing=...'
     title: pcr conditions
     examples:
       - value: initial denaturation:94_3;annealing:50_1;elongation:72_1.5;final elongation:72_10;35
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pcr conditions
     is_a: sequencing field
     string_serialization: initial denaturation:degrees_minutes;annealing:degrees_minutes;elongation:degrees_minutes;final elongation:degrees_minutes;total cycles
     slot_uri: MIXS:0000049
@@ -6944,16 +4591,11 @@ slots:
     multivalued: false
   pcr_primers:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: 'FWD: forward primer sequence;REV:reverse primer sequence'
+      expected_value: 'FWD: forward primer sequence;REV:reverse primer sequence'
     description: PCR primers that were used to amplify the sequence of the targeted gene, locus or subfragment. This field should contain all the primers used for a single PCR reaction if multiple forward or reverse primers are present in a single PCR reaction. The primer sequence should be reported in uppercase letters
     title: pcr primers
     examples:
       - value: FWD:GTGCCAGCMGCCGCGGTAA;REV:GGACTACHVGGGTWTCTAAT
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pcr primers
     is_a: sequencing field
     string_serialization: FWD:{dna};REV:{dna}
     slot_uri: MIXS:0000046
@@ -6961,22 +4603,13 @@ slots:
     multivalued: false
   permeability:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value range
-      preferred_unit:
-        tag: preferred_unit
-        value: mD
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value range
+      preferred_unit: mD
+      occurrence: '1'
     description: 'Measure of the ability of a hydrocarbon resource to allow fluids to pass through it. (Additional information: https://en.wikipedia.org/wiki/Permeability_(earth_sciences))'
     title: permeability
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - permeability
     is_a: core field
     string_serialization: '{integer} - {integer} {unit}'
     slot_uri: MIXS:0000404
@@ -6984,19 +4617,12 @@ slots:
     multivalued: false
   perturbation:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: perturbation type name;perturbation interval and duration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: perturbation type name;perturbation interval and duration
+      occurrence: m
     description: Type of perturbation, e.g. chemical administration, physical disturbance, etc., coupled with perturbation regimen including how many times the perturbation was repeated, how long each perturbation lasted, and the start and end time of the entire perturbation period; can include multiple perturbation types
     title: perturbation
     examples:
       - value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - perturbation
     is_a: core field
     string_serialization: '{text};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000754
@@ -7005,22 +4631,13 @@ slots:
     inlined_as_list: true
   pesticide_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: pesticide name;pesticide amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: pesticide name;pesticide amount;treatment interval and duration
+      preferred_unit: gram, mole per liter, milligram per liter
+      occurrence: m
     description: Information about treatment involving use of insecticides; should include the name of pesticide, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple pesticide regimens
     title: pesticide regimen
     examples:
       - value: pyrethrum;0.6 milligram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pesticide regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000573
@@ -7029,63 +4646,38 @@ slots:
     inlined_as_list: true
   petroleum_hydrocarb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      storage_units: umol/L
     description: Concentration of petroleum hydrocarbon
     title: petroleum hydrocarbon
     examples:
       - value: 0.05 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - petroleum hydrocarbon
     is_a: core field
     slot_uri: MIXS:0000516
     range: QuantityValue
     multivalued: false
   ph:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      occurrence: '1'
     description: Ph measurement of the sample, or liquid portion of sample, or aqueous phase of the fluid
     title: pH
     examples:
       - value: '7.2'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pH
     is_a: core field
     slot_uri: MIXS:0001001
     range: double
     multivalued: false
   ph_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining ph
     title: pH method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pH method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0001106
@@ -7093,19 +4685,12 @@ slots:
     multivalued: false
   ph_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;treatment interval and duration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: measurement value;treatment interval and duration
+      occurrence: m
     description: Information about treatment involving exposure of plants to varying levels of ph of the growth media, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimen
     title: pH regimen
     examples:
       - value: 7.6;R2/2018-05-11:T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pH regimen
     is_a: core field
     string_serialization: '{float};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0001056
@@ -7114,22 +4699,13 @@ slots:
     inlined_as_list: true
   phaeopigments:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: phaeopigment name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per cubic meter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: phaeopigment name;measurement value
+      preferred_unit: milligram per cubic meter
+      occurrence: m
     description: Concentration of phaeopigments; can include multiple phaeopigments
     title: phaeopigments
     examples:
       - value: 2.5 milligram per cubic meter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - phaeopigments
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000180
@@ -7138,47 +4714,27 @@ slots:
     inlined_as_list: true
   phosphate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      storage_units: umol/L
     description: Concentration of phosphate
     title: phosphate
     examples:
       - value: 0.7 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - phosphate
     is_a: core field
     slot_uri: MIXS:0000505
     range: QuantityValue
     multivalued: false
   phosplipid_fatt_acid:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: phospholipid fatty acid name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: mole per gram, mole per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: phospholipid fatty acid name;measurement value
+      preferred_unit: mole per gram, mole per liter
+      occurrence: m
     description: Concentration of phospholipid fatty acids; can include multiple values
     title: phospholipid fatty acid
     examples:
       - value: 2.98 milligram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - phospholipid fatty acid
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000181
@@ -7187,63 +4743,38 @@ slots:
     inlined_as_list: true
   photon_flux:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: number of photons per second per unit area
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/m2/s
+      expected_value: measurement value
+      preferred_unit: number of photons per second per unit area
+      occurrence: '1'
+      storage_units: umol/m2/s
     description: Measurement of photon flux
     title: photon flux
     examples:
       - value: 3.926 umol/m2/s
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - photon flux
     is_a: core field
     slot_uri: MIXS:0000725
     range: QuantityValue
     multivalued: false
   plant_growth_med:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: EO or enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: EO or enumeration
+      occurrence: '1'
     description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from EO:plant growth medium (follow this link for terms http://purl.obolibrary.org/obo/EO_0007147) or other controlled vocabulary
     title: plant growth medium
     examples:
       - value: hydroponic plant culture media [EO:0007067]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - plant growth medium
     is_a: core field
     slot_uri: MIXS:0001057
     range: ControlledTermValue
     multivalued: false
   plant_product:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: product name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: product name
+      occurrence: '1'
     description: Substance produced by the plant, where the sample was obtained from
     title: plant product
     examples:
       - value: xylem sap [PO:0025539]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - plant product
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0001058
@@ -7251,38 +4782,24 @@ slots:
     multivalued: false
   plant_sex:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Sex of the reproductive parts on the whole plant, e.g. pistillate, staminate, monoecieous, hermaphrodite.
     title: plant sex
     examples:
       - value: Hermaphroditic
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - plant sex
     is_a: core field
     slot_uri: MIXS:0001059
     range: plant_sex_enum
     multivalued: false
   plant_struc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PO
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PO
+      occurrence: '1'
     description: Name of plant structure the sample was obtained from; for Plant Ontology (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO, e.g. petiole epidermis (PO_0000051). If an individual flower is sampled, the sex of it can be recorded here.
     title: plant structure
     examples:
       - value: epidermis [PO:0005679]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - plant structure
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0001060
@@ -7290,22 +4807,13 @@ slots:
     multivalued: false
   pollutants:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: pollutant name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, mole per liter, milligram per liter, microgram per cubic meter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: pollutant name;measurement value
+      preferred_unit: gram, mole per liter, milligram per liter, microgram per cubic meter
+      occurrence: m
     description: Pollutant types and, amount or concentrations measured at the time of sampling; can report multiple pollutants by entering numeric values preceded by name of pollutant
     title: pollutants
     examples:
       - value: lead;0.15 microgram per cubic meter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pollutants
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000107
@@ -7314,19 +4822,12 @@ slots:
     inlined_as_list: true
   pool_dna_extracts:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: pooling status;number of pooled extracts
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: pooling status;number of pooled extracts
+      occurrence: '1'
     description: Indicate whether multiple DNA extractions were mixed. If the answer yes, the number of extracts that were pooled should be given
     title: pooling of DNA extracts (if done)
     examples:
       - value: yes;5
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pooling of DNA extracts (if done)
     is_a: core field
     string_serialization: '{boolean};{integer}'
     slot_uri: MIXS:0000325
@@ -7334,22 +4835,13 @@ slots:
     multivalued: false
   porosity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value or range
-      preferred_unit:
-        tag: preferred_unit
-        value: percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value or range
+      preferred_unit: percentage
+      occurrence: '1'
     description: Porosity of deposited sediment is volume of voids divided by the total volume of sample
     title: porosity
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - porosity
     is_a: core field
     string_serialization: '{float} - {float} {unit}'
     slot_uri: MIXS:0000211
@@ -7357,69 +4849,40 @@ slots:
     multivalued: false
   potassium:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|mg/kg'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|mg/kg'
     description: Concentration of potassium in the sample
     title: potassium
     examples:
       - value: 463 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - potassium
     is_a: core field
     slot_uri: MIXS:0000430
     range: QuantityValue
     multivalued: false
   pour_point:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: 'Temperature at which a liquid becomes semi solid and loses its flow characteristics. In crude oil a high¬†pour point¬†is generally associated with a high paraffin content, typically found in crude deriving from a larger proportion of plant material. (soure: https://en.wikipedia.org/wiki/pour_point)'
     title: pour point
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pour point
     is_a: core field
     slot_uri: MIXS:0000127
     range: QuantityValue
     multivalued: false
   pre_treatment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: pre-treatment type
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: pre-treatment type
+      occurrence: '1'
     description: The process of pre-treatment removes materials that can be easily collected from the raw wastewater
     title: pre-treatment
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pre-treatment
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000348
@@ -7427,19 +4890,12 @@ slots:
     multivalued: false
   pres_animal_insect:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration;count
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration;count
+      occurrence: '1'
     description: The type and number of animals or insects present in the sampling space.
     title: presence of pets, animals, or insects
     examples:
       - value: cat;5
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - presence of pets, animals, or insects
     is_a: core field
     slot_uri: MIXS:0000819
     range: string
@@ -7447,44 +4903,26 @@ slots:
     pattern: ^(cat|dog|rodent|snake|other);\d+$
   pressure:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: atmosphere
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: atm
+      expected_value: measurement value
+      preferred_unit: atmosphere
+      occurrence: '1'
+      storage_units: atm
     description: Pressure to which the sample is subject to, in atmospheres
     title: pressure
     examples:
       - value: 50 atm
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - pressure
     is_a: core field
     slot_uri: MIXS:0000412
     range: QuantityValue
     multivalued: false
   prev_land_use_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining previous land use and dates
     title: history/previous land use method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/previous land use method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000316
@@ -7492,19 +4930,12 @@ slots:
     multivalued: false
   previous_land_use:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: land use name;date
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: land use name;date
+      occurrence: '1'
     description: Previous land use and dates
     title: history/previous land use
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/previous land use
     is_a: core field
     string_serialization: '{text};{timestamp}'
     slot_uri: MIXS:0000315
@@ -7512,44 +4943,26 @@ slots:
     multivalued: false
   primary_prod:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per cubic meter per day, gram per square meter per day
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: g/m2/d|mg/m3/d
+      expected_value: measurement value
+      preferred_unit: milligram per cubic meter per day, gram per square meter per day
+      occurrence: '1'
+      storage_units: g/m2/d|mg/m3/d
     description: Measurement of primary production, generally measured as isotope uptake
     title: primary production
     examples:
       - value: 100 mg/m3/d
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - primary production
     is_a: core field
     slot_uri: MIXS:0000728
     range: QuantityValue
     multivalued: false
   primary_treatment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: primary treatment type
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: primary treatment type
+      occurrence: '1'
     description: The process to produce both a generally homogeneous liquid capable of being treated biologically and a sludge that can be separately treated or processed
     title: primary treatment
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - primary treatment
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000349
@@ -7557,104 +4970,63 @@ slots:
     multivalued: false
   prod_rate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: cubic meter per day
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m3/d
+      expected_value: measurement value
+      preferred_unit: cubic meter per day
+      occurrence: '1'
+      storage_units: m3/d
     description: Oil and/or gas production rates per well (e.g. 524 m3 / day)
     title: production rate
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - production rate
     is_a: core field
     slot_uri: MIXS:0000452
     range: QuantityValue
     multivalued: false
   prod_start_date:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: timestamp
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: timestamp
+      occurrence: '1'
     description: Date of field's first production
     title: production start date
     examples:
       - value: '2018-05-11'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - production start date
     is_a: core field
     slot_uri: MIXS:0001008
     range: TimestampValue
     multivalued: false
   profile_position:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Cross-sectional position in the hillslope where sample was collected.sample area position in relation to surrounding areas
     title: profile position
     examples:
       - value: summit
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - profile position
     is_a: core field
     slot_uri: MIXS:0001084
     range: profile_position_enum
     multivalued: false
   quad_pos:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The quadrant position of the sampling room within the building
     title: quadrant position
     examples:
       - value: West side
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - quadrant position
     is_a: core field
     slot_uri: MIXS:0000820
     range: quad_pos_enum
     multivalued: false
   radiation_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: radiation type name;radiation amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: rad, gray
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: radiation type name;radiation amount;treatment interval and duration
+      preferred_unit: rad, gray
+      occurrence: m
     description: Information about treatment involving exposure of plant or a plant part to a particular radiation regimen; should include the radiation type, amount or intensity administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple radiation regimens
     title: radiation regimen
     examples:
       - value: gamma radiation;60 gray;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - radiation regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000575
@@ -7663,22 +5035,13 @@ slots:
     inlined_as_list: true
   rainfall_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: millimeter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: measurement value;treatment interval and duration
+      preferred_unit: millimeter
+      occurrence: m
     description: Information about treatment involving an exposure to a given amount of rainfall, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
     title: rainfall regimen
     examples:
       - value: 15 millimeter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rainfall regimen
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000576
@@ -7687,19 +5050,12 @@ slots:
     inlined_as_list: true
   reactor_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: reactor type name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: reactor type name
+      occurrence: '1'
     description: Anaerobic digesters can be designed and engineered to operate using a number of different process configurations, as batch or continuous, mesophilic, high solid or low solid, and single stage or multistage
     title: reactor type
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - reactor type
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000350
@@ -7707,113 +5063,66 @@ slots:
     multivalued: false
   redox_potential:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millivolt
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mV
+      expected_value: measurement value
+      preferred_unit: millivolt
+      occurrence: '1'
+      storage_units: mV
     description: Redox potential, measured relative to a hydrogen cell, indicating oxidation or reduction potential
     title: redox potential
     examples:
       - value: 300 mV
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - redox potential
     is_a: core field
     slot_uri: MIXS:0000182
     range: QuantityValue
     multivalued: false
   rel_air_humidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percentage
+      occurrence: '1'
+      storage_units: '%'
     description: Partial vapor and air pressure, density of the vapor and air, or by the actual mass of the vapor and air
     title: relative air humidity
     examples:
       - value: 80%
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - relative air humidity
     is_a: core field
     slot_uri: MIXS:0000121
     range: QuantityValue
     multivalued: false
   rel_humidity_out:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram of air, kilogram of air
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: mixs_inconsistent
+      expected_value: measurement value
+      preferred_unit: gram of air, kilogram of air
+      occurrence: '1'
+      units_alignment_excuse: mixs_inconsistent
     description: The recorded outside relative humidity value at the time of sampling
     title: outside relative humidity
     examples:
       - value: 12 per kilogram of air
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - outside relative humidity
     is_a: core field
     slot_uri: MIXS:0000188
     range: QuantityValue
     multivalued: false
   rel_samp_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The sampling location within the train car
     title: relative sampling location
     examples:
       - value: center of car
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - relative sampling location
     is_a: core field
     slot_uri: MIXS:0000821
     range: rel_samp_loc_enum
     multivalued: false
   reservoir:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name
+      occurrence: '1'
     description: Name of the reservoir (e.g. Carapebus)
     title: reservoir name
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - reservoir name
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000303
@@ -7821,22 +5130,13 @@ slots:
     multivalued: false
   resins_pc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percent
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;measurement value
+      preferred_unit: percent
+      occurrence: '1'
     description: 'Saturate, Aromatic, Resin and Asphaltene¬†(SARA) is an analysis method that divides¬†crude oil¬†components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: resins wt%
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - resins wt%
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000134
@@ -7844,44 +5144,26 @@ slots:
     multivalued: false
   room_air_exch_rate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: liter per hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: L/h
+      expected_value: measurement value
+      preferred_unit: liter per hour
+      occurrence: '1'
+      storage_units: L/h
     description: The rate at which outside air replaces indoor air in a given space
     title: room air exchange rate
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room air exchange rate
     is_a: core field
     slot_uri: MIXS:0000169
     range: QuantityValue
     multivalued: false
   room_architec_elem:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: free text
+      occurrence: '1'
     description: The unique details and component parts that, together, form the architecture of a distinguisahable space within a built structure
     title: room architectural elements
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room architectural elements
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000233
@@ -7889,79 +5171,49 @@ slots:
     multivalued: false
   room_condt:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The condition of the room at the time of sampling
     title: room condition
     examples:
       - value: new
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room condition
     is_a: core field
     slot_uri: MIXS:0000822
     range: room_condt_enum
     multivalued: false
   room_connected:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: List of rooms connected to the sampling room by a doorway
     title: rooms connected by a doorway
     examples:
       - value: office
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooms connected by a doorway
     is_a: core field
     slot_uri: MIXS:0000826
     range: room_connected_enum
     multivalued: false
   room_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The total count of rooms in the built structure including all room types
     title: room count
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room count
     is_a: core field
     slot_uri: MIXS:0000234
     range: TextValue
     multivalued: false
   room_dim:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      preferred_unit: meter
+      occurrence: '1'
     description: The length, width and height of sampling room
     title: room dimensions
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room dimensions
     is_a: core field
     string_serialization: '{integer} {unit} x {integer} {unit} x {integer} {unit}'
     slot_uri: MIXS:0000192
@@ -7969,22 +5221,13 @@ slots:
     multivalued: false
   room_door_dist:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      preferred_unit: meter
+      occurrence: '1'
     description: Distance between doors (meters) in the hallway between the sampling room and adjacent rooms
     title: room door distance
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room door distance
     is_a: core field
     string_serialization: '{integer} {unit}'
     slot_uri: MIXS:0000193
@@ -7992,19 +5235,12 @@ slots:
     multivalued: false
   room_door_share:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: room name;room number
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: room name;room number
+      occurrence: '1'
     description: List of room(s) (room number, room name) sharing a door with the sampling room
     title: rooms that share a door with sampling room
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooms that share a door with sampling room
     is_a: core field
     string_serialization: '{text};{integer}'
     slot_uri: MIXS:0000242
@@ -8012,19 +5248,12 @@ slots:
     multivalued: false
   room_hallway:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: room name;room number
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: room name;room number
+      occurrence: '1'
     description: List of room(s) (room number, room name) located in the same hallway as sampling room
     title: rooms that are on the same hallway
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooms that are on the same hallway
     is_a: core field
     string_serialization: '{text};{integer}'
     slot_uri: MIXS:0000238
@@ -8032,60 +5261,37 @@ slots:
     multivalued: false
   room_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The position of the room within the building
     title: room location in building
     examples:
       - value: interior room
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room location in building
     is_a: core field
     slot_uri: MIXS:0000823
     range: room_loc_enum
     multivalued: false
   room_moist_dam_hist:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The history of moisture damage or mold in the past 12 months. Number of events of moisture damage or mold observed
     title: room moisture damage or mold history
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room moisture damage or mold history
     is_a: core field
     slot_uri: MIXS:0000235
     range: integer
     multivalued: false
   room_net_area:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square feet, square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      preferred_unit: square feet, square meter
+      occurrence: '1'
     description: The net floor area of sampling room. Net area excludes wall thicknesses
     title: room net area
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room net area
     is_a: core field
     string_serialization: '{integer} {unit}'
     slot_uri: MIXS:0000194
@@ -8093,82 +5299,50 @@ slots:
     multivalued: false
   room_occup:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: "1"
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: "1"
     description: Count of room occupancy at time of sampling
     title: room occupancy
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room occupancy
     is_a: core field
     slot_uri: MIXS:0000236
     range: QuantityValue
     multivalued: false
   room_samp_pos:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The horizontal sampling position in the room relative to architectural elements
     title: room sampling position
     examples:
       - value: south corner
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room sampling position
     is_a: core field
     slot_uri: MIXS:0000824
     range: room_samp_pos_enum
     multivalued: false
   room_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The main purpose or activity of the sampling room. A room is any distinguishable space within a structure
     title: room type
     examples:
       - value: bathroom
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room type
     is_a: core field
     slot_uri: MIXS:0000825
     range: room_type_enum
     multivalued: false
   room_vol:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: cubic feet, cubic meter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      preferred_unit: cubic feet, cubic meter
+      occurrence: '1'
     description: Volume of sampling room
     title: room volume
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room volume
     is_a: core field
     string_serialization: '{integer} {unit}'
     slot_uri: MIXS:0000195
@@ -8176,19 +5350,12 @@ slots:
     multivalued: false
   room_wall_share:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: room name;room number
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: room name;room number
+      occurrence: '1'
     description: List of room(s) (room number, room name) sharing a wall with the sampling room
     title: rooms that share a wall with sampling room
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooms that share a wall with sampling room
     is_a: core field
     string_serialization: '{text};{integer}'
     slot_uri: MIXS:0000243
@@ -8196,38 +5363,24 @@ slots:
     multivalued: false
   room_window_count:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: Number of windows in the room
     title: room window count
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - room window count
     is_a: core field
     slot_uri: MIXS:0000237
     range: integer
     multivalued: false
   root_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI,url or free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI,url or free text
+      occurrence: '1'
     description: Relevant rooting conditions such as field plot size, sowing density, container dimensions, number of plants per container.
     title: rooting conditions
     examples:
       - value: http://himedialabs.com/TD/PT158.pdf
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting conditions
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}|{text}'
     slot_uri: MIXS:0001061
@@ -8235,22 +5388,13 @@ slots:
     multivalued: false
   root_med_carbon:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: carbon source name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: carbon source name;measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Source of organic carbon in the culture rooting medium; e.g. sucrose.
     title: rooting medium carbon
     examples:
       - value: sucrose
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium carbon
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000577
@@ -8258,22 +5402,13 @@ slots:
     multivalued: false
   root_med_macronutr:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: macronutrient name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: macronutrient name;measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S); e.g. KH2PO4 (170¬†mg/L).
     title: rooting medium macronutrients
     examples:
       - value: KH2PO4;170¬†milligram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium macronutrients
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000578
@@ -8281,22 +5416,13 @@ slots:
     multivalued: false
   root_med_micronutr:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: micronutrient name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: micronutrient name;measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo); e.g. H3BO3 (6.2¬†mg/L).
     title: rooting medium micronutrients
     examples:
       - value: H3BO3;6.2¬†milligram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium micronutrients
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000579
@@ -8304,44 +5430,26 @@ slots:
     multivalued: false
   root_med_ph:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[pH]'
+      expected_value: measurement value
+      occurrence: '1'
+      storage_units: '[pH]'
     description: pH measurement of the culture rooting medium; e.g. 5.5.
     title: rooting medium pH
     examples:
       - value: '7.5'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium pH
     is_a: core field
     slot_uri: MIXS:0001062
     range: QuantityValue
     multivalued: false
   root_med_regl:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: regulator name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: regulator name;measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Growth regulators in the culture rooting medium such as cytokinins, auxins, gybberellins, abscisic acid; e.g. 0.5¬†mg/L NAA.
     title: rooting medium regulators
     examples:
       - value: abscisic acid;0.75 milligram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium regulators
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000581
@@ -8349,19 +5457,12 @@ slots:
     multivalued: false
   root_med_solid:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name
+      occurrence: '1'
     description: Specification of the solidifying agent in the culture rooting medium; e.g. agar.
     title: rooting medium solidifier
     examples:
       - value: agar
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium solidifier
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0001063
@@ -8369,22 +5470,13 @@ slots:
     multivalued: false
   root_med_suppl:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: supplement name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: supplement name;measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
     description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid (0.5¬†mg/L).
     title: rooting medium organic supplements
     examples:
       - value: nicotinic acid;0.5 milligram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - rooting medium organic supplements
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000580
@@ -8392,44 +5484,26 @@ slots:
     multivalued: false
   salinity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: practical salinity unit, percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%|mg/L'
+      expected_value: measurement value
+      preferred_unit: practical salinity unit, percentage
+      occurrence: '1'
+      storage_units: '%|mg/L'
     description: The total concentration of all dissolved salts in a liquid or solid sample. While salinity can be measured by a complete chemical analysis, this method is difficult and time consuming. More often, it is instead derived from the conductivity measurement. This is known as practical salinity. These derivations compare the specific conductance of the sample to a salinity standard such as seawater.
     title: salinity
     examples:
       - value: 70 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - salinity
     is_a: core field
     slot_uri: MIXS:0000183
     range: QuantityValue
     multivalued: false
   salinity_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining salinity
     title: salinity method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - salinity method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000341
@@ -8437,22 +5511,13 @@ slots:
     multivalued: false
   salt_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: salt name;salt amount;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, microgram, mole per liter, gram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: salt name;salt amount;treatment interval and duration
+      preferred_unit: gram, microgram, mole per liter, gram per liter
+      occurrence: m
     description: Information about treatment involving use of salts as supplement to liquid and soil growth media; should include the name of salt, amount administered, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple salt regimens
     title: salt regimen
     examples:
       - value: NaCl;5 gram per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - salt regimen
     is_a: core field
     string_serialization: '{text};{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000582
@@ -8461,35 +5526,23 @@ slots:
     inlined_as_list: true
   samp_capt_status:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Reason for the sample
     title: sample capture status
     examples:
       - value: farm sample
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample capture status
     is_a: core field
     slot_uri: MIXS:0000860
     range: samp_capt_status_enum
     multivalued: false
   samp_collec_device:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: device name
+      expected_value: device name
     description: The device used to collect an environmental sample. This field accepts terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094).
     title: sample collection device
     examples:
       - value: swab, biopsy, niskin bottle, push core, drag swab [GENEPIO:0002713]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample collection device
     is_a: nucleic acid sequence source field
     string_serialization: '{termLabel} {[termID]}|{text}'
     slot_uri: MIXS:0000002
@@ -8497,16 +5550,11 @@ slots:
     multivalued: false
   samp_collec_method:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI,url , or text
+      expected_value: PMID,DOI,url , or text
     description: The method employed for collecting the sample.
     title: sample collection method
     examples:
       - value: swabbing
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample collection method
     is_a: nucleic acid sequence source field
     string_serialization: '{PMID}|{DOI}|{URL}|{text}'
     slot_uri: MIXS:0001225
@@ -8514,79 +5562,49 @@ slots:
     multivalued: false
   samp_collect_point:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Sampling point on the asset were sample was collected (e.g. Wellhead, storage tank, separator, etc). If "other" is specified, please propose entry in "additional info" field
     title: sample collection point
     examples:
       - value: well
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample collection point
     is_a: core field
     slot_uri: MIXS:0001015
     range: samp_collect_point_enum
     multivalued: false
   samp_dis_stage:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Stage of the disease at the time of sample collection, e.g. inoculation, penetration, infection, growth and reproduction, dissemination of pathogen.
     title: sample disease stage
     examples:
       - value: infection
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample disease stage
     is_a: core field
     slot_uri: MIXS:0000249
     range: samp_dis_stage_enum
     multivalued: false
   samp_floor:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The floor of the building, where the sampling room is located
     title: sampling floor
     examples:
       - value: 4th floor
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sampling floor
     is_a: core field
     slot_uri: MIXS:0000828
     range: samp_floor_enum
     multivalued: false
   samp_loc_corr_rate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value range
-      preferred_unit:
-        tag: preferred_unit
-        value: millimeter per year
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value range
+      preferred_unit: millimeter per year
+      occurrence: '1'
     description: Metal corrosion rate is the speed of metal deterioration due to environmental conditions. As environmental conditions change corrosion rates change accordingly. Therefore, long term corrosion rates are generally more informative than short term rates and for that reason they are preferred during reporting. In the case of suspected MIC, corrosion rate measurements at the time of sampling might provide insights into the involvement of certain microbial community members in MIC as well as potential microbial interplays
     title: corrosion rate at sample location
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - corrosion rate at sample location
     is_a: core field
     string_serialization: '{float} - {float} {unit}'
     slot_uri: MIXS:0000136
@@ -8594,16 +5612,11 @@ slots:
     multivalued: false
   samp_mat_process:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: text
+      expected_value: text
     description: A brief description of any processing applied to the sample during or after retrieving the sample from environment, or a link to the relevant protocol(s) performed.
     title: sample material processing
     examples:
       - value: filtering of seawater, storing samples in ethanol
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample material processing
     is_a: nucleic acid sequence source field
     string_serialization: '{text}'
     slot_uri: MIXS:0000016
@@ -8611,41 +5624,25 @@ slots:
     multivalued: false
   samp_md:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;enumeration
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m
+      expected_value: measurement value;enumeration
+      preferred_unit: meter
+      occurrence: '1'
+      storage_units: m
     description: In non deviated well, measured depth is equal to the true vertical depth, TVD (TVD=TVDSS plus the reference or datum it refers to). In deviated wells, the MD is the length of trajectory of the borehole measured from the same reference or datum. Common datums used are ground level (GL), drilling rig floor (DF), rotary table (RT), kelly bushing (KB) and mean sea level (MSL). If "other" is specified, please propose entry in "additional info" field
     title: sample measured depth
     examples:
       - value: 1534 m
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample measured depth
     is_a: core field
     slot_uri: MIXS:0000413
     range: QuantityValue
     multivalued: false
   samp_name:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: text
+      expected_value: text
     description: A local identifier or name that for the material sample used for extracting nucleic acids, and subsequent sequencing. It can refer either to the original material collected or to any derived sub-samples. It can have any format, but we suggest that you make it concise, unique and consistent within your lab, and as informative as possible. INSDC requires every sample name from a single Submitter to be unique. Use of a globally unique identifier for the field source_mat_id is recommended in addition to sample_name.
     title: sample name
     examples:
       - value: ISDsoil1
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample name
     is_a: investigation field
     string_serialization: '{text}'
     slot_uri: MIXS:0001107
@@ -8653,22 +5650,13 @@ slots:
     multivalued: false
   samp_preserv:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milliliter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;measurement value
+      preferred_unit: milliliter
+      occurrence: '1'
     description: Preservative added to the sample (e.g. Rnalater, alcohol, formaldehyde, etc.). Where appropriate include volume added (e.g. Rnalater; 2 ml)
     title: preservative added to sample
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - preservative added to sample
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000463
@@ -8676,60 +5664,37 @@ slots:
     multivalued: false
   samp_room_id:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: Sampling room number. This ID should be consistent with the designations on the building floor plans
     title: sampling room ID or name
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sampling room ID or name
     is_a: core field
     slot_uri: MIXS:0000244
     range: TextValue
     multivalued: false
   samp_size:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millliter, gram, milligram, liter
-      storage_units:
-        tag: storage_units
-        value: L|g|mL|mg
+      expected_value: measurement value
+      preferred_unit: millliter, gram, milligram, liter
+      storage_units: L|g|mL|mg
     description: The total amount or size (volume (ml), mass (g) or area (m2) ) of sample collected.
     title: amount or size of sample collected
     examples:
       - value: 5 L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - amount or size of sample collected
     is_a: nucleic acid sequence source field
     slot_uri: MIXS:0000001
     range: QuantityValue
     multivalued: false
   samp_sort_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: description of method
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: description of method
+      occurrence: m
     description: Method by which samples are sorted; open face filter collecting total suspended particles, prefilter to remove particles larger than X micrometers in diameter, where common values of X would be 10 and 2.5 full size sorting in a cascade impactor.
     title: sample size sorting method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample size sorting method
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000216
@@ -8738,19 +5703,12 @@ slots:
     inlined_as_list: true
   samp_store_dur:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: duration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: duration
+      occurrence: '1'
     description: Duration for which the sample was stored
     title: sample storage duration
     examples:
       - value: P1Y6M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample storage duration
     is_a: core field
     string_serialization: '{duration}'
     slot_uri: MIXS:0000116
@@ -8758,19 +5716,12 @@ slots:
     multivalued: false
   samp_store_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: location name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: location name
+      occurrence: '1'
     description: Location at which sample was stored, usually name of a specific freezer/room
     title: sample storage location
     examples:
       - value: Freezer no:5
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample storage location
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000755
@@ -8778,58 +5729,35 @@ slots:
     multivalued: false
   samp_store_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: Temperature at which sample was stored, e.g. -80 degree Celsius
     title: sample storage temperature
     examples:
       - value: -80 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample storage temperature
     is_a: core field
     slot_uri: MIXS:0000110
     range: QuantityValue
     multivalued: false
   samp_subtype:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Name of sample sub-type. For example if "sample type" is "Produced Water" then subtype could be "Oil Phase" or "Water Phase". If "other" is specified, please propose entry in "additional info" field
     title: sample subtype
     examples:
       - value: biofilm
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample subtype
     is_a: core field
     slot_uri: MIXS:0000999
     range: samp_subtype_enum
     multivalued: false
   samp_taxon_id:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: Taxonomy ID
+      expected_value: Taxonomy ID
     description: NCBI taxon id of the sample.  Maybe be a single taxon or mixed taxa sample. Use 'synthetic metagenome’ for mock community/positive controls, or 'blank sample' for negative controls.
     title: Taxonomy ID of DNA sample
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - Taxonomy ID of DNA sample
     is_a: investigation field
     slot_uri: MIXS:0001320
     range: ControlledIdentifiedTermValue
@@ -8838,44 +5766,26 @@ slots:
       - coal metagenome [NCBITaxon:1260732] would be a reasonable has_raw_value
   samp_time_out:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: time
-      preferred_unit:
-        tag: preferred_unit
-        value: hour
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: time
+      preferred_unit: hour
+      occurrence: '1'
     description: The recent and long term history of outside sampling
     title: sampling time outside
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sampling time outside
     is_a: core field
     slot_uri: MIXS:0000196
     range: TextValue
     multivalued: false
   samp_transport_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: days;degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value;measurement value
+      preferred_unit: days;degree Celsius
+      occurrence: '1'
     description: Sample transport duration (in days or hrs) and temperature the sample was exposed to (e.g. 5.5 days; 20 ¬∞C)
     title: sample transport conditions
     examples:
       - value: 5 days;-20 degree Celsius
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample transport conditions
     is_a: core field
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000410
@@ -8883,22 +5793,13 @@ slots:
     multivalued: false
   samp_tvdss:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value or measurement value range
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value or measurement value range
+      preferred_unit: meter
+      occurrence: '1'
     description: Depth of the sample i.e. The vertical distance between the sea level and the sampled position in the subsurface. Depth can be reported as an interval for subsurface samples e.g. 1325.75-1362.25 m
     title: sample true vertical depth subsea
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample true vertical depth subsea
     is_a: core field
     string_serialization: '{float}-{float} {unit}'
     slot_uri: MIXS:0000409
@@ -8906,19 +5807,12 @@ slots:
     multivalued: false
   samp_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: GENEPIO:0001246
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: GENEPIO:0001246
+      occurrence: '1'
     description: The type of material from which the sample was obtained. For the Hydrocarbon package, samples include types like core, rock trimmings, drill cuttings, piping section, coupon, pigging debris, solid deposit, produced fluid, produced water, injected water, swabs, etc. For the Food Package, samples are usually categorized as food, body products or tissues, or environmental material. This field accepts terms listed under environmental specimen (http://purl.obolibrary.org/obo/GENEPIO_0001246).
     title: sample type
     examples:
       - value: built environment sample [GENEPIO:0001248]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample type
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000998
@@ -8926,60 +5820,37 @@ slots:
     multivalued: false
   samp_vol_we_dna_ext:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millliter, gram, milligram, square centimeter
-      storage_units:
-        tag: storage_units
-        value: cm2|g|mL|mg
+      expected_value: measurement value
+      preferred_unit: millliter, gram, milligram, square centimeter
+      storage_units: cm2|g|mL|mg
     description: 'Volume (ml) or mass (g) of total collected sample processed for DNA extraction. Note: total sample collected should be entered under the term Sample Size (MIXS:0000001).'
     title: sample volume or weight for DNA extraction
     examples:
       - value: 1500 mL
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample volume or weight for DNA extraction
     is_a: nucleic acid sequence source field
     slot_uri: MIXS:0000111
     range: QuantityValue
     multivalued: false
   samp_weather:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The weather on the sampling day
     title: sampling day weather
     examples:
       - value: foggy
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sampling day weather
     is_a: core field
     slot_uri: MIXS:0000827
     range: samp_weather_enum
     multivalued: false
   samp_well_name:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name
+      occurrence: '1'
     description: Name of the well (e.g. BXA1123) where sample was taken
     title: sample well name
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sample well name
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000296
@@ -8987,22 +5858,13 @@ slots:
     multivalued: false
   saturates_pc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percent
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: name;measurement value
+      preferred_unit: percent
+      occurrence: '1'
     description: 'Saturate, Aromatic, Resin and Asphaltene¬†(SARA) is an analysis method that divides¬†crude oil¬†components according to their polarizability and polarity. There are three main methods to obtain SARA results. The most popular one is known as the Iatroscan TLC-FID and is referred to as IP-143 (source: https://en.wikipedia.org/wiki/Saturate,_aromatic,_resin_and_asphaltene)'
     title: saturates wt%
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - saturates wt%
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000131
@@ -9010,19 +5872,12 @@ slots:
     multivalued: false
   season:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: NCIT:C94729
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: NCIT:C94729
+      occurrence: '1'
     description: The season when sampling occurred. Any of the four periods into which the year is divided by the equinoxes and solstices. This field accepts terms listed under season (http://purl.obolibrary.org/obo/NCIT_C94729).
     title: season
     examples:
       - value: autumn [NCIT:C94733]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - season
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000829
@@ -9030,19 +5885,12 @@ slots:
     multivalued: false
   season_environment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: seasonal environment name;treatment interval and duration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: seasonal environment name;treatment interval and duration
+      occurrence: m
     description: Treatment involving an exposure to a particular season (e.g. Winter, summer, rabi, rainy etc.), treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment
     title: seasonal environment
     examples:
       - value: rainy;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - seasonal environment
     is_a: core field
     string_serialization: '{text};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0001068
@@ -9051,88 +5899,52 @@ slots:
     inlined_as_list: true
   season_precpt:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: millimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mm
+      expected_value: measurement value
+      preferred_unit: millimeter
+      occurrence: '1'
+      storage_units: mm
     description: The average of all seasonal precipitation values known, or an estimated equivalent value derived by such methods as regional indexes or Isohyetal maps.
     title: mean seasonal precipitation
     examples:
       - value: 10 mm
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mean seasonal precipitation
     is_a: core field
     slot_uri: MIXS:0000645
     range: QuantityValue
     multivalued: false
   season_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: Mean seasonal temperature
     title: mean seasonal temperature
     examples:
       - value: 18 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - mean seasonal temperature
     is_a: core field
     slot_uri: MIXS:0000643
     range: QuantityValue
     multivalued: false
   season_use:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The seasons the space is occupied
     title: seasonal use
     examples:
       - value: Winter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - seasonal use
     is_a: core field
     slot_uri: MIXS:0000830
     range: season_use_enum
     multivalued: false
   secondary_treatment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: secondary treatment type
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: secondary treatment type
+      occurrence: '1'
     description: The process for substantially degrading the biological content of the sewage
     title: secondary treatment
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - secondary treatment
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000351
@@ -9140,35 +5952,23 @@ slots:
     multivalued: false
   sediment_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Information about the sediment type based on major constituents
     title: sediment type
     examples:
       - value: biogenous
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sediment type
     is_a: core field
     slot_uri: MIXS:0001078
     range: sediment_type_enum
     multivalued: false
   seq_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: Text or OBI
+      expected_value: Text or OBI
     description: Sequencing machine used. Where possible the term should be taken from the OBI list of DNA sequencers (http://purl.obolibrary.org/obo/OBI_0400103).
     title: sequencing method
     examples:
       - value: 454 Genome Sequencer FLX [OBI:0000702]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sequencing method
     is_a: sequencing field
     string_serialization: '{termLabel} {[termID]}|{text}'
     slot_uri: MIXS:0000050
@@ -9176,16 +5976,11 @@ slots:
     multivalued: false
   seq_quality_check:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: none or manually edited
+      expected_value: none or manually edited
     description: Indicate if the sequence has been called by automatic systems (none) or undergone a manual editing procedure (e.g. by inspecting the raw data or chromatograms). Applied only for sequences that are not submitted to SRA,ENA or DRA
     title: sequence quality check
     examples:
       - value: none
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sequence quality check
     is_a: sequencing field
     string_serialization: '[none|manually edited]'
     slot_uri: MIXS:0000051
@@ -9193,19 +5988,12 @@ slots:
     multivalued: false
   sewage_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: sewage type name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: sewage type name
+      occurrence: '1'
     description: Type of wastewater treatment plant as municipial or industrial
     title: sewage type
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sewage type
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000215
@@ -9213,19 +6001,12 @@ slots:
     multivalued: false
   shad_dev_water_mold:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Signs of the presence of mold or mildew on the shading device
     title: shading device signs of water/mold
     examples:
       - value: no presence of mold visible
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - shading device signs of water/mold
     is_a: core field
     string_serialization: '[presence of mold visible|no presence of mold visible]'
     slot_uri: MIXS:0000834
@@ -9233,38 +6014,24 @@ slots:
     multivalued: false
   shading_device_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The physical condition of the shading device at the time of sampling
     title: shading device condition
     examples:
       - value: new
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - shading device condition
     is_a: core field
     slot_uri: MIXS:0000831
     range: shading_device_cond_enum
     multivalued: false
   shading_device_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The location of the shading device in relation to the built structure
     title: shading device location
     examples:
       - value: exterior
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - shading device location
     is_a: core field
     string_serialization: '[exterior|interior]'
     slot_uri: MIXS:0000832
@@ -9272,19 +6039,12 @@ slots:
     multivalued: false
   shading_device_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: material name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: material name
+      occurrence: '1'
     description: The material the shading device is composed of
     title: shading device material
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - shading device material
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000245
@@ -9292,38 +6052,24 @@ slots:
     multivalued: false
   shading_device_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of shading device
     title: shading device type
     examples:
       - value: slatted aluminum awning
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - shading device type
     is_a: core field
     slot_uri: MIXS:0000835
     range: shading_device_type_enum
     multivalued: false
   sieving:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: design name and/or size;amount
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: design name and/or size;amount
+      occurrence: '1'
     description: Collection design of pooled samples and/or sieve size and amount of sample sieved
     title: composite design/sieving
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - composite design/sieving
     is_a: core field
     string_serialization: '{{text}|{float} {unit}};{float} {unit}'
     slot_uri: MIXS:0000322
@@ -9331,41 +6077,25 @@ slots:
     multivalued: false
   silicate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: umol/L
+      expected_value: measurement value
+      preferred_unit: micromole per liter
+      occurrence: '1'
+      storage_units: umol/L
     description: Concentration of silicate
     title: silicate
     examples:
       - value: 0.05 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - silicate
     is_a: core field
     slot_uri: MIXS:0000184
     range: QuantityValue
     multivalued: false
   size_frac:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: filter size value range
+      expected_value: filter size value range
     description: Filtering pore size used in sample preparation
     title: size fraction selected
     examples:
       - value: 0-0.22 micrometer
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - size fraction selected
     is_a: nucleic acid sequence source field
     string_serialization: '{float}-{float} {unit}'
     slot_uri: MIXS:0000017
@@ -9373,210 +6103,121 @@ slots:
     multivalued: false
   size_frac_low:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: micrometer
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: um
+      expected_value: value
+      preferred_unit: micrometer
+      occurrence: '1'
+      storage_units: um
     description: Refers to the mesh/pore size used to pre-filter/pre-sort the sample. Materials larger than the size threshold are excluded from the sample
     title: size-fraction lower threshold
     examples:
       - value: 0.2 um
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - size-fraction lower threshold
     is_a: core field
     slot_uri: MIXS:0000735
     range: QuantityValue
     multivalued: false
   size_frac_up:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: micrometer
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: um
+      expected_value: value
+      preferred_unit: micrometer
+      occurrence: '1'
+      storage_units: um
     description: Refers to the mesh/pore size used to retain the sample. Materials smaller than the size threshold are excluded from the sample
     title: size-fraction upper threshold
     examples:
       - value: 20 um
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - size-fraction upper threshold
     is_a: core field
     slot_uri: MIXS:0000736
     range: QuantityValue
     multivalued: false
   slope_aspect:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: deg
+      expected_value: measurement value
+      preferred_unit: degree
+      occurrence: '1'
+      storage_units: deg
     description: The direction a slope faces. While looking down a slope use a compass to record the direction you are facing (direction or degrees); e.g., nw or 315 degrees. This measure provides an indication of sun and wind exposure that will influence soil temperature and evapotranspiration.
     title: slope aspect
     examples:
       - value: 35 deg
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - slope aspect
     is_a: core field
     slot_uri: MIXS:0000647
     range: QuantityValue
     multivalued: false
   slope_gradient:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percentage
+      occurrence: '1'
+      storage_units: '%'
     description: Commonly called 'slope'. The angle between ground surface and a horizontal line (in percent). This is the direction that overland water would flow. This measure is usually taken with a hand level meter or clinometer
     title: slope gradient
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - slope gradient
     is_a: core field
     slot_uri: MIXS:0000646
     range: QuantityValue
     multivalued: false
   sludge_retent_time:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: hours
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: h
+      expected_value: measurement value
+      preferred_unit: hours
+      occurrence: '1'
+      storage_units: h
     description: The time activated sludge remains in reactor
     title: sludge retention time
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sludge retention time
     is_a: core field
     slot_uri: MIXS:0000669
     range: QuantityValue
     multivalued: false
   sodium:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Sodium concentration in the sample
     title: sodium
     examples:
       - value: 10.5 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sodium
     is_a: core field
     slot_uri: MIXS:0000428
     range: QuantityValue
     multivalued: false
   soil_horizon:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Specific layer in the land area which measures parallel to the soil surface and possesses physical characteristics which differ from the layers above and beneath
     title: soil horizon
     examples:
       - value: A horizon
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil horizon
     is_a: core field
     slot_uri: MIXS:0001082
     range: soil_horizon_enum
     multivalued: false
   soil_text_measure:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: pending_analysis
+      expected_value: measurement value
+      occurrence: '1'
+      units_alignment_excuse: pending_analysis
     description: The relative proportion of different grain sizes of mineral particles in a soil, as described using a standard system; express as % sand (50 um to 2 mm), silt (2 um to 50 um), and clay (<2 um) with textural name (e.g., silty clay loam) optional.
     title: soil texture measurement
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil texture measurement
     is_a: core field
     slot_uri: MIXS:0000335
     range: QuantityValue
     multivalued: false
   soil_texture_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining soil texture
     title: soil texture method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil texture method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000336
@@ -9584,19 +6225,12 @@ slots:
     multivalued: false
   soil_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: ENVO_00001998
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: ENVO_00001998
+      occurrence: '1'
     description: Description of the soil type or classification. This field accepts terms under soil (http://purl.obolibrary.org/obo/ENVO_00001998).  Multiple terms can be separated by pipes.
     title: soil type
     examples:
       - value: plinthosol [ENVO:00002250]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil type
     is_a: core field
     string_serialization: '{termLabel} {[termID]}'
     slot_uri: MIXS:0000332
@@ -9604,19 +6238,12 @@ slots:
     multivalued: false
   soil_type_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining soil series name or other lower-level classification
     title: soil type method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soil type method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000334
@@ -9624,47 +6251,27 @@ slots:
     multivalued: false
   solar_irradiance:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: kilowatts per square meter per day, ergs per square centimeter per second
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: kW/m2/d|erg/cm2/s
+      expected_value: measurement value
+      preferred_unit: kilowatts per square meter per day, ergs per square centimeter per second
+      occurrence: '1'
+      storage_units: kW/m2/d|erg/cm2/s
     description: The amount of solar energy that arrives at a specific area of a surface during a specific time interval
     title: solar irradiance
     examples:
       - value: 1.36 kW/m2/d
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - solar irradiance
     is_a: core field
     slot_uri: MIXS:0000112
     range: QuantityValue
     multivalued: false
   soluble_inorg_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: soluble inorganic material name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, microgram, mole per liter, gram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: soluble inorganic material name;measurement value
+      preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
+      occurrence: m
     description: Concentration of substances such as ammonia, road-salt, sea-salt, cyanide, hydrogen sulfide, thiocyanates, thiosulfates, etc.
     title: soluble inorganic material
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soluble inorganic material
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000672
@@ -9673,22 +6280,13 @@ slots:
     inlined_as_list: true
   soluble_org_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: soluble organic material name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, microgram, mole per liter, gram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: soluble organic material name;measurement value
+      preferred_unit: gram, microgram, mole per liter, gram per liter, parts per million
+      occurrence: m
     description: Concentration of substances such as urea, fruit sugars, soluble proteins, drugs, pharmaceuticals, etc.
     title: soluble organic material
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soluble organic material
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000673
@@ -9697,41 +6295,25 @@ slots:
     inlined_as_list: true
   soluble_react_phosp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L|ug/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L|ug/L'
     description: Concentration of soluble reactive phosphorus
     title: soluble reactive phosphorus
     examples:
       - value: 0.1 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - soluble reactive phosphorus
     is_a: core field
     slot_uri: MIXS:0000738
     range: QuantityValue
     multivalued: false
   source_mat_id:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: 'for cultures of microorganisms: identifiers for two culture collections; for other material a unique arbitrary identifer'
+      expected_value: 'for cultures of microorganisms: identifiers for two culture collections; for other material a unique arbitrary identifer'
     description: A unique identifier assigned to a material sample (as defined by http://rs.tdwg.org/dwc/terms/materialSampleID, and as opposed to a particular digital record of a material sample) used for extracting nucleic acids, and subsequent sequencing. The identifier can refer either to the original material collected or to any derived sub-samples. The INSDC qualifiers /specimen_voucher, /bio_material, or /culture_collection may or may not share the same value as the source_mat_id field. For instance, the /specimen_voucher qualifier and source_mat_id may both contain 'UAM:Herps:14' , referring to both the specimen voucher and sampled tissue with the same identifier. However, the /culture_collection qualifier may refer to a value from an initial culture (e.g. ATCC:11775) while source_mat_id would refer to an identifier from some derived culture from which the nucleic acids were extracted (e.g. xatc123 or ark:/2154/R2).
     title: source material identifiers
     examples:
       - value: MPI012345
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - source material identifiers
     is_a: nucleic acid sequence source field
     string_serialization: '{text}'
     slot_uri: MIXS:0000026
@@ -9739,19 +6321,12 @@ slots:
     multivalued: false
   space_typ_state:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Customary or normal state of the space
     title: space typical state
     examples:
       - value: typically occupied
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - space typical state
     is_a: core field
     string_serialization: '[typically occupied|typically unoccupied]'
     slot_uri: MIXS:0000770
@@ -9759,139 +6334,86 @@ slots:
     multivalued: false
   specific:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: 'The building specifications. If design is chosen, indicate phase: conceptual, schematic, design development, construction documents'
     title: specifications
     examples:
       - value: construction
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - specifications
     is_a: core field
     slot_uri: MIXS:0000836
     range: specific_enum
     multivalued: false
   specific_humidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram of air, kilogram of air
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: mixs_inconsistent
+      expected_value: measurement value
+      preferred_unit: gram of air, kilogram of air
+      occurrence: '1'
+      units_alignment_excuse: mixs_inconsistent
     description: The mass of water vapour in a unit mass of moist air, usually expressed as grams of vapour per kilogram of air, or, in air conditioning, as grains per pound.
     title: specific humidity
     examples:
       - value: 15 per kilogram of air
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - specific humidity
     is_a: core field
     slot_uri: MIXS:0000214
     range: QuantityValue
     multivalued: false
   sr_dep_env:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Source rock depositional environment (https://en.wikipedia.org/wiki/Source_rock). If "other" is specified, please propose entry in "additional info" field
     title: source rock depositional environment
     examples:
       - value: Marine
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - source rock depositional environment
     is_a: core field
     slot_uri: MIXS:0000996
     range: sr_dep_env_enum
     multivalued: false
   sr_geol_age:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: 'Geological age of source rock (Additional info: https://en.wikipedia.org/wiki/Period_(geology)). If "other" is specified, please propose entry in "additional info" field'
     title: source rock geological age
     examples:
       - value: Silurian
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - source rock geological age
     is_a: core field
     slot_uri: MIXS:0000997
     range: sr_geol_age_enum
     multivalued: false
   sr_kerog_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: 'Origin of kerogen. Type I: Algal (aquatic), Type II: planktonic and soft plant material (aquatic or terrestrial), Type III: terrestrial woody/ fibrous plant material (terrestrial), Type IV: oxidized recycled woody debris (terrestrial) (additional information: https://en.wikipedia.org/wiki/Kerogen). If "other" is specified, please propose entry in "additional info" field'
     title: source rock kerogen type
     examples:
       - value: Type IV
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - source rock kerogen type
     is_a: core field
     slot_uri: MIXS:0000994
     range: sr_kerog_type_enum
     multivalued: false
   sr_lithology:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Lithology of source rock (https://en.wikipedia.org/wiki/Source_rock). If "other" is specified, please propose entry in "additional info" field
     title: source rock lithology
     examples:
       - value: Coal
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - source rock lithology
     is_a: core field
     slot_uri: MIXS:0000995
     range: sr_lithology_enum
     multivalued: false
   standing_water_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: standing water type;treatment interval and duration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: standing water type;treatment interval and duration
+      occurrence: m
     description: Treatment involving an exposure to standing water during a plant's life span, types can be flood water or standing water, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
     title: standing water regimen
     examples:
       - value: standing water;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - standing water regimen
     is_a: core field
     string_serialization: '{text};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0001069
@@ -9900,19 +6422,12 @@ slots:
     inlined_as_list: true
   store_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: storage condition type;duration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: storage condition type;duration
+      occurrence: '1'
     description: Explain how and for how long the soil sample was stored before DNA extraction (fresh/frozen/other).
     title: storage conditions
     examples:
       - value: -20 degree Celsius freezer;P2Y10D
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - storage conditions
     is_a: core field
     string_serialization: '{text};{duration}'
     slot_uri: MIXS:0000327
@@ -9920,273 +6435,159 @@ slots:
     multivalued: false
   substructure_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: The substructure or under building is that largely hidden section of the building which is built off the foundations to the ground floor level
     title: substructure type
     examples:
       - value: basement
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - substructure type
     is_a: core field
     slot_uri: MIXS:0000767
     range: substructure_type_enum
     multivalued: true
   sulfate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L'
     description: Concentration of sulfate in the sample
     title: sulfate
     examples:
       - value: 5 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sulfate
     is_a: core field
     slot_uri: MIXS:0000423
     range: QuantityValue
     multivalued: false
   sulfate_fw:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: Original sulfate concentration in the hydrocarbon resource
     title: sulfate in formation water
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sulfate in formation water
     is_a: core field
     slot_uri: MIXS:0000407
     range: QuantityValue
     multivalued: false
   sulfide:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L'
     description: Concentration of sulfide in the sample
     title: sulfide
     examples:
       - value: 2 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - sulfide
     is_a: core field
     slot_uri: MIXS:0000424
     range: QuantityValue
     multivalued: false
   surf_air_cont:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: Contaminant identified on surface
     title: surface-air contaminant
     examples:
       - value: radon
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - surface-air contaminant
     is_a: core field
     slot_uri: MIXS:0000759
     range: surf_air_cont_enum
     multivalued: true
   surf_humidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percentage
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percentage
+      occurrence: '1'
+      storage_units: '%'
     description: 'Surfaces: water activity as a function of air and material moisture'
     title: surface humidity
     examples:
       - value: 10%
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - surface humidity
     is_a: core field
     slot_uri: MIXS:0000123
     range: QuantityValue
     multivalued: false
   surf_material:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Surface materials at the point of sampling
     title: surface material
     examples:
       - value: wood
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - surface material
     is_a: core field
     slot_uri: MIXS:0000758
     range: surf_material_enum
     multivalued: false
   surf_moisture:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: parts per million, gram per cubic meter, gram per square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|g/m2|g/m3'
+      expected_value: measurement value
+      preferred_unit: parts per million, gram per cubic meter, gram per square meter
+      occurrence: '1'
+      storage_units: '[ppm]|g/m2|g/m3'
     description: Water held on a surface
     title: surface moisture
     examples:
       - value: 0.01 g/m2
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - surface moisture
     is_a: core field
     slot_uri: MIXS:0000128
     range: QuantityValue
     multivalued: false
   surf_moisture_ph:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      occurrence: '1'
     description: ph measurement of surface
     title: surface moisture pH
     examples:
       - value: '7'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - surface moisture pH
     is_a: core field
     slot_uri: MIXS:0000760
     range: double
     multivalued: false
   surf_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: Temperature of the surface at the time of sampling
     title: surface temperature
     examples:
       - value: 15 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - surface temperature
     is_a: core field
     slot_uri: MIXS:0000125
     range: QuantityValue
     multivalued: false
   suspend_part_matter:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: Concentration of suspended particulate matter
     title: suspended particulate matter
     examples:
       - value: 0.5 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - suspended particulate matter
     is_a: core field
     slot_uri: MIXS:0000741
     range: QuantityValue
     multivalued: false
   suspend_solids:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: suspended solid name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram, microgram, milligram per liter, mole per liter, gram per liter, part per million
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: suspended solid name;measurement value
+      preferred_unit: gram, microgram, milligram per liter, mole per liter, gram per liter, part per million
+      occurrence: m
     description: Concentration of substances including a wide variety of material, such as silt, decaying plant and animal matter; can include multiple substances
     title: suspended solids
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - suspended solids
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000150
@@ -10195,41 +6596,25 @@ slots:
     inlined_as_list: true
   tan:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: 'Total Acid Number¬†(TAN) is a measurement of acidity that is determined by the amount of¬†potassium hydroxide¬†in milligrams that is needed to neutralize the acids in one gram of oil.¬†It is an important quality measurement of¬†crude oil. (source: https://en.wikipedia.org/wiki/Total_acid_number)'
     title: total acid number
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total acid number
     is_a: core field
     slot_uri: MIXS:0000120
     range: QuantityValue
     multivalued: false
   target_gene:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gene name
+      expected_value: gene name
     description: Targeted gene or locus name for marker gene studies
     title: target gene
     examples:
       - value: 16S rRNA, 18S rRNA, nif, amoA, rpo
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - target gene
     is_a: sequencing field
     string_serialization: '{text}'
     slot_uri: MIXS:0000044
@@ -10237,16 +6622,11 @@ slots:
     multivalued: false
   target_subfragment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: gene fragment name
+      expected_value: gene fragment name
     description: Name of subfragment of a gene or locus. Important to e.g. identify special regions on marker genes like V6 on 16S rRNA
     title: target subfragment
     examples:
       - value: V6, V9, ITS
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - target subfragment
     is_a: sequencing field
     string_serialization: '{text}'
     slot_uri: MIXS:0000045
@@ -10254,66 +6634,39 @@ slots:
     multivalued: false
   temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      storage_units: Cel
     description: Temperature of the sample at the time of sampling.
     title: temperature
     examples:
       - value: 25 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - temperature
     is_a: environment field
     slot_uri: MIXS:0000113
     range: QuantityValue
     multivalued: false
   temp_out:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: Cel
+      expected_value: measurement value
+      preferred_unit: degree Celsius
+      occurrence: '1'
+      storage_units: Cel
     description: The recorded temperature value at sampling time outside
     title: temperature outside house
     examples:
       - value: 5 Cel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - temperature outside house
     is_a: core field
     slot_uri: MIXS:0000197
     range: QuantityValue
     multivalued: false
   tertiary_treatment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: tertiary treatment type
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: tertiary treatment type
+      occurrence: '1'
     description: The process providing a final treatment stage to raise the effluent quality before it is discharged to the receiving environment
     title: tertiary treatment
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - tertiary treatment
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000352
@@ -10321,57 +6674,36 @@ slots:
     multivalued: false
   tidal_stage:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Stage of tide
     title: tidal stage
     examples:
       - value: high tide
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - tidal stage
     is_a: core field
     slot_uri: MIXS:0000750
     range: tidal_stage_enum
     multivalued: false
   tillage:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: enumeration
+      occurrence: m
     description: Note method(s) used for tilling
     title: history/tillage
     examples:
       - value: chisel
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - history/tillage
     is_a: core field
     slot_uri: MIXS:0001081
     range: tillage_enum
     multivalued: true
   tiss_cult_growth_med:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI,url or free text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI,url or free text
+      occurrence: '1'
     description: Description of plant tissue culture growth media used
     title: tissue culture growth media
     examples:
       - value: https://link.springer.com/content/pdf/10.1007/BF02796489.pdf
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - tissue culture growth media
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}|{text}'
     slot_uri: MIXS:0001070
@@ -10379,194 +6711,110 @@ slots:
     multivalued: false
   toluene:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of toluene in the sample
     title: toluene
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - toluene
     is_a: core field
     slot_uri: MIXS:0000154
     range: QuantityValue
     multivalued: false
   tot_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|%
+      expected_value: measurement value
+      preferred_unit: microgram per liter
+      occurrence: '1'
+      storage_units: ug/L|%
     description: Total carbon content
     title: total carbon
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total carbon
     is_a: core field
     slot_uri: MIXS:0000525
     range: QuantityValue
     multivalued: false
   tot_depth_water_col:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m
+      expected_value: measurement value
+      preferred_unit: meter
+      occurrence: '1'
+      storage_units: m
     description: Measurement of total depth of water column
     title: total depth of water column
     examples:
       - value: 500 m
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total depth of water column
     is_a: core field
     slot_uri: MIXS:0000634
     range: QuantityValue
     multivalued: false
   tot_diss_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|umol/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter
+      occurrence: '1'
+      storage_units: ug/L|umol/L
     description: 'Total dissolved nitrogen concentration, reported as nitrogen, measured by: total dissolved nitrogen = NH4 + NO3NO2 + dissolved organic nitrogen'
     title: total dissolved nitrogen
     examples:
       - value: 40 ug/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total dissolved nitrogen
     is_a: core field
     slot_uri: MIXS:0000744
     range: QuantityValue
     multivalued: false
   tot_inorg_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter
+      occurrence: '1'
+      storage_units: ug/L
     description: Total inorganic nitrogen content
     title: total inorganic nitrogen
     examples:
       - value: 40 ug/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total inorganic nitrogen
     is_a: core field
     slot_uri: MIXS:0000745
     range: QuantityValue
     multivalued: false
   tot_iron:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, milligram per kilogram
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|mg/kg
+      expected_value: measurement value
+      preferred_unit: milligram per liter, milligram per kilogram
+      occurrence: '1'
+      storage_units: mg/L|mg/kg
     description: Concentration of total iron in the sample
     title: total iron
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total iron
     is_a: core field
     slot_uri: MIXS:0000105
     range: QuantityValue
     multivalued: false
   tot_nitro:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, micromole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|ug/L|umol/L|%
+      expected_value: measurement value
+      preferred_unit: microgram per liter, micromole per liter, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|ug/L|umol/L|%
     description: 'Total nitrogen concentration of water samples, calculated by: total nitrogen = total dissolved nitrogen + particulate nitrogen. Can also be measured without filtering, reported as nitrogen'
     title: total nitrogen concentration
     examples:
       - value: 50 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total nitrogen concentration
     is_a: core field
     slot_uri: MIXS:0000102
     range: QuantityValue
     multivalued: false
   tot_nitro_cont_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining the total nitrogen
     title: total nitrogen content method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total nitrogen content method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000338
@@ -10574,44 +6822,26 @@ slots:
     multivalued: false
   tot_nitro_content:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, micromole per liter, milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L|ug/L|umol/L|%
+      expected_value: measurement value
+      preferred_unit: microgram per liter, micromole per liter, milligram per liter
+      occurrence: '1'
+      storage_units: mg/L|ug/L|umol/L|%
     description: Total nitrogen content of the sample
     title: total nitrogen content
     examples:
       - value: 5 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total nitrogen content
     is_a: core field
     slot_uri: MIXS:0000530
     range: QuantityValue
     multivalued: false
   tot_org_c_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining total organic carbon
     title: total organic carbon method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total organic carbon method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000337
@@ -10619,320 +6849,186 @@ slots:
     multivalued: false
   tot_org_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram Carbon per kilogram sample material
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: gram Carbon per kilogram sample material
+      occurrence: '1'
+      storage_units: mg/L
     description: 'Definition for soil: total organic carbon content of the soil, definition otherwise: total organic carbon content'
     title: total organic carbon
     examples:
       - value: 5 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total organic carbon
     is_a: core field
     slot_uri: MIXS:0000533
     range: QuantityValue
     multivalued: false
   tot_part_carb:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|umol/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter, micromole per liter
+      occurrence: '1'
+      storage_units: ug/L|umol/L
     description: Total particulate carbon content
     title: total particulate carbon
     examples:
       - value: 35 umol/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total particulate carbon
     is_a: core field
     slot_uri: MIXS:0000747
     range: QuantityValue
     multivalued: false
   tot_phosp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: micromole per liter, milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L|umol/L'
+      expected_value: measurement value
+      preferred_unit: micromole per liter, milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L|umol/L'
     description: 'Total phosphorus concentration in the sample, calculated by: total phosphorus = total dissolved phosphorus + particulate phosphorus'
     title: total phosphorus
     examples:
       - value: 0.03 mg/L
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total phosphorus
     is_a: core field
     slot_uri: MIXS:0000117
     range: QuantityValue
     multivalued: false
   tot_phosphate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per liter, micromole per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: ug/L|umol/L
+      expected_value: measurement value
+      preferred_unit: microgram per liter, micromole per liter
+      occurrence: '1'
+      storage_units: ug/L|umol/L
     description: Total amount or concentration of phosphate
     title: total phosphate
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total phosphate
     is_a: core field
     slot_uri: MIXS:0000689
     range: QuantityValue
     multivalued: false
   tot_sulfur:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of total sulfur in the sample
     title: total sulfur
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - total sulfur
     is_a: core field
     slot_uri: MIXS:0000419
     range: QuantityValue
     multivalued: false
   train_line:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The subway line name
     title: train line
     examples:
       - value: red
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - train line
     is_a: core field
     slot_uri: MIXS:0000837
     range: train_line_enum
     multivalued: false
   train_stat_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The train station collection location
     title: train station collection location
     examples:
       - value: forest hills
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - train station collection location
     is_a: core field
     slot_uri: MIXS:0000838
     range: train_stat_loc_enum
     multivalued: false
   train_stop_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The train stop collection location
     title: train stop collection location
     examples:
       - value: end
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - train stop collection location
     is_a: core field
     slot_uri: MIXS:0000839
     range: train_stop_loc_enum
     multivalued: false
   turbidity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: formazin turbidity unit, formazin nephelometric units
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[NTU]|[FNU]'
+      expected_value: measurement value
+      preferred_unit: formazin turbidity unit, formazin nephelometric units
+      occurrence: '1'
+      storage_units: '[NTU]|[FNU]'
     description: Measure of the amount of cloudiness or haziness in water caused by individual particles
     title: turbidity
     examples:
       - value: 0.3 [NTU]
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - turbidity
     is_a: core field
     slot_uri: MIXS:0000191
     range: QuantityValue
     multivalued: false
   tvdss_of_hcr_press:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m
+      expected_value: measurement value
+      preferred_unit: meter
+      occurrence: '1'
+      storage_units: m
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where the original pressure was measured (e.g. 1578 m).
     title: depth (TVDSS) of hydrocarbon resource pressure
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - depth (TVDSS) of hydrocarbon resource pressure
     is_a: core field
     slot_uri: MIXS:0000397
     range: QuantityValue
     multivalued: false
   tvdss_of_hcr_temp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      units_alignment_excuse:
-        tag: units_alignment_excuse
-        value: complex_unit
+      expected_value: measurement value
+      preferred_unit: meter
+      occurrence: '1'
+      units_alignment_excuse: complex_unit
     description: True vertical depth subsea (TVDSS) of the hydrocarbon resource where the original temperature was measured (e.g. 1345 m).
     title: depth (TVDSS) of hydrocarbon resource temperature
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - depth (TVDSS) of hydrocarbon resource temperature
     is_a: core field
     slot_uri: MIXS:0000394
     range: QuantityValue
     multivalued: false
   typ_occup_density:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      occurrence: '1'
     description: Customary or normal density of occupants
     title: typical occupant density
     examples:
       - value: '25'
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - typical occupant density
     is_a: core field
     slot_uri: MIXS:0000771
     range: double
     multivalued: false
   ventilation_rate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: cubic meter per minute, liters per second
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: L/s|m3/min
+      expected_value: measurement value
+      preferred_unit: cubic meter per minute, liters per second
+      occurrence: '1'
+      storage_units: L/s|m3/min
     description: Ventilation rate of the system in the sampled premises
     title: ventilation rate
     examples:
       - value: 750 m3/min
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ventilation rate
     is_a: core field
     slot_uri: MIXS:0000114
     range: QuantityValue
     multivalued: false
   ventilation_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: ventilation type name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: ventilation type name
+      occurrence: '1'
     description: Ventilation system used in the sampled premises
     title: ventilation type
     examples:
       - value: Operable windows
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - ventilation type
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000756
@@ -10940,91 +7036,53 @@ slots:
     multivalued: false
   vfa:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of Volatile Fatty Acids in the sample
     title: volatile fatty acids
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - volatile fatty acids
     is_a: core field
     slot_uri: MIXS:0000152
     range: QuantityValue
     multivalued: false
   vfa_fw:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: mg/L
+      expected_value: measurement value
+      preferred_unit: milligram per liter
+      occurrence: '1'
+      storage_units: mg/L
     description: Original volatile fatty acid concentration in the hydrocarbon resource
     title: vfa in formation water
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - vfa in formation water
     is_a: core field
     slot_uri: MIXS:0000408
     range: QuantityValue
     multivalued: false
   vis_media:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The building visual media
     title: visual media
     examples:
       - value: 3D scans
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - visual media
     is_a: core field
     slot_uri: MIXS:0000840
     range: vis_media_enum
     multivalued: false
   viscosity:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: cP at degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value;measurement value
+      preferred_unit: cP at degree Celsius
+      occurrence: '1'
     description: A measure of oil's resistance¬†to gradual deformation by¬†shear stress¬†or¬†tensile stress (e.g. 3.5 cp; 100 ¬∞C)
     title: viscosity
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - viscosity
     is_a: core field
     string_serialization: '{float} {unit};{float} {unit}'
     slot_uri: MIXS:0000126
@@ -11032,22 +7090,13 @@ slots:
     multivalued: false
   volatile_org_comp:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: volatile organic compound name;measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: microgram per cubic meter, parts per million, nanogram per liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: volatile organic compound name;measurement value
+      preferred_unit: microgram per cubic meter, parts per million, nanogram per liter
+      occurrence: m
     description: Concentration of carbon-based chemicals that easily evaporate at room temperature; can report multiple volatile organic compounds by entering numeric values preceded by name of compound
     title: volatile organic compounds
     examples:
       - value: formaldehyde;500 nanogram per liter
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - volatile organic compounds
     is_a: core field
     string_serialization: '{text};{float} {unit}'
     slot_uri: MIXS:0000115
@@ -11056,189 +7105,114 @@ slots:
     inlined_as_list: true
   wall_area:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m2
+      expected_value: measurement value
+      preferred_unit: square meter
+      occurrence: '1'
+      storage_units: m2
     description: The total area of the sampled room's walls
     title: wall area
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall area
     is_a: core field
     slot_uri: MIXS:0000198
     range: QuantityValue
     multivalued: false
   wall_const_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The building class of the wall defined by the composition of the building elements and fire-resistance rating.
     title: wall construction type
     examples:
       - value: fire resistive
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall construction type
     is_a: core field
     slot_uri: MIXS:0000841
     range: wall_const_type_enum
     multivalued: false
   wall_finish_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The material utilized to finish the outer most layer of the wall
     title: wall finish material
     examples:
       - value: wood
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall finish material
     is_a: core field
     slot_uri: MIXS:0000842
     range: wall_finish_mat_enum
     multivalued: false
   wall_height:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      preferred_unit:
-        tag: preferred_unit
-        value: centimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: cm
+      expected_value: value
+      preferred_unit: centimeter
+      occurrence: '1'
+      storage_units: cm
     description: The average height of the walls in the sampled room
     title: wall height
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall height
     is_a: core field
     slot_uri: MIXS:0000221
     range: QuantityValue
     multivalued: false
   wall_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The relative location of the wall within the room
     title: wall location
     examples:
       - value: north
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall location
     is_a: core field
     slot_uri: MIXS:0000843
     range: wall_loc_enum
     multivalued: false
   wall_surf_treatment:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The surface treatment of interior wall
     title: wall surface treatment
     examples:
       - value: paneling
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall surface treatment
     is_a: core field
     slot_uri: MIXS:0000845
     range: wall_surf_treatment_enum
     multivalued: false
   wall_texture:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The feel, appearance, or consistency of a wall surface
     title: wall texture
     examples:
       - value: popcorn
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall texture
     is_a: core field
     slot_uri: MIXS:0000846
     range: wall_texture_enum
     multivalued: false
   wall_thermal_mass:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: joule per degree Celsius
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: J/K
+      expected_value: measurement value
+      preferred_unit: joule per degree Celsius
+      occurrence: '1'
+      storage_units: J/K
     description: The ability of the wall to provide inertia against temperature fluctuations. Generally this means concrete or concrete block that is either exposed or covered only with paint
     title: wall thermal mass
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall thermal mass
     is_a: core field
     slot_uri: MIXS:0000222
     range: QuantityValue
     multivalued: false
   wall_water_mold:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Signs of the presence of mold or mildew on a wall
     title: wall signs of water/mold
     examples:
       - value: no presence of mold visible
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wall signs of water/mold
     is_a: core field
     string_serialization: '[presence of mold visible|no presence of mold visible]'
     slot_uri: MIXS:0000844
@@ -11246,19 +7220,12 @@ slots:
     multivalued: false
   wastewater_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: wastewater type name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: wastewater type name
+      occurrence: '1'
     description: The origin of wastewater such as human waste, rainfall, storm drains, etc.
     title: wastewater type
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wastewater type
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000353
@@ -11266,19 +7233,12 @@ slots:
     multivalued: false
   water_cont_soil_meth:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: PMID,DOI or url
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: PMID,DOI or url
+      occurrence: '1'
     description: Reference or method used in determining the water content of soil
     title: water content method
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water content method
     is_a: core field
     string_serialization: '{PMID}|{DOI}|{URL}'
     slot_uri: MIXS:0000323
@@ -11286,163 +7246,94 @@ slots:
     multivalued: false
   water_content:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: gram per gram or cubic centimeter per cubic centimeter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      preferred_unit: gram per gram or cubic centimeter per cubic centimeter
+      occurrence: '1'
     description: Water content measurement
     title: water content
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water content
     is_a: core field
     slot_uri: MIXS:0000185
     range: string
     multivalued: false
   water_current:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: cubic meter per second, knots
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[kn_i]|m3/s'
+      expected_value: measurement value
+      preferred_unit: cubic meter per second, knots
+      occurrence: '1'
+      storage_units: '[kn_i]|m3/s'
     description: Measurement of magnitude and direction of flow within a fluid
     title: water current
     examples:
       - value: 10 m3/s
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water current
     is_a: core field
     slot_uri: MIXS:0000203
     range: QuantityValue
     multivalued: false
   water_cut:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: percent
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '%'
+      expected_value: measurement value
+      preferred_unit: percent
+      occurrence: '1'
+      storage_units: '%'
     description: Current amount of water (%) in a produced fluid stream; or the average of the combined streams
     title: water cut
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water cut
     is_a: core field
     slot_uri: MIXS:0000454
     range: QuantityValue
     multivalued: false
   water_feat_size:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: square meter
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m2
+      expected_value: measurement value
+      preferred_unit: square meter
+      occurrence: '1'
+      storage_units: m2
     description: The size of the water feature
     title: water feature size
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water feature size
     is_a: core field
     slot_uri: MIXS:0000223
     range: QuantityValue
     multivalued: false
   water_feat_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of water feature present within the building being sampled
     title: water feature type
     examples:
       - value: stream
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water feature type
     is_a: core field
     slot_uri: MIXS:0000847
     range: water_feat_type_enum
     multivalued: false
   water_prod_rate:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: cubic meter per day
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: m3/d
+      expected_value: measurement value
+      preferred_unit: cubic meter per day
+      occurrence: '1'
+      storage_units: m3/d
     description: Water production rates per well (e.g. 987 m3 / day)
     title: water production rate
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water production rate
     is_a: core field
     slot_uri: MIXS:0000453
     range: QuantityValue
     multivalued: false
   water_temp_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: degree Celsius
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: measurement value;treatment interval and duration
+      preferred_unit: degree Celsius
+      occurrence: m
     description: Information about treatment involving an exposure to water with varying degree of temperature, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
     title: water temperature regimen
     examples:
       - value: 15 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - water temperature regimen
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000590
@@ -11451,22 +7342,13 @@ slots:
     inlined_as_list: true
   watering_regm:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value;treatment interval and duration
-      preferred_unit:
-        tag: preferred_unit
-        value: milliliter, liter
-      occurrence:
-        tag: occurrence
-        value: m
+      expected_value: measurement value;treatment interval and duration
+      preferred_unit: milliliter, liter
+      occurrence: m
     description: Information about treatment involving an exposure to watering frequencies, treatment regimen including how many times the treatment was repeated, how long each treatment lasted, and the start and end time of the entire treatment; can include multiple regimens
     title: watering regimen
     examples:
       - value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - watering regimen
     is_a: core field
     string_serialization: '{float} {unit};{Rn/start_time/end_time/duration}'
     slot_uri: MIXS:0000591
@@ -11475,38 +7357,24 @@ slots:
     inlined_as_list: true
   weekday:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The day of the week when sampling occurred
     title: weekday
     examples:
       - value: Sunday
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - weekday
     is_a: core field
     slot_uri: MIXS:0000848
     range: weekday_enum
     multivalued: false
   win:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: text
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: text
+      occurrence: '1'
     description: 'A unique identifier of a well or wellbore. This is part of the Global Framework for Well Identification initiative which is compiled by the Professional Petroleum Data Management Association (PPDM) in an effort to improve well identification systems. (Supporting information: https://ppdm.org/ and http://dl.ppdm.org/dl/690)'
     title: well identification number
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - well identification number
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000297
@@ -11514,19 +7382,12 @@ slots:
     multivalued: false
   wind_direction:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: wind direction name
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: wind direction name
+      occurrence: '1'
     description: Wind direction is the direction from which a wind originates
     title: wind direction
     examples:
       - value: Northwest
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wind direction
     is_a: core field
     string_serialization: '{text}'
     slot_uri: MIXS:0000757
@@ -11534,161 +7395,99 @@ slots:
     multivalued: false
   wind_speed:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: meter per second, kilometer per hour
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: km/h|m/s
+      expected_value: measurement value
+      preferred_unit: meter per second, kilometer per hour
+      occurrence: '1'
+      storage_units: km/h|m/s
     description: Speed of wind measured at the time of sampling
     title: wind speed
     examples:
       - value: 21 km/h
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - wind speed
     is_a: core field
     slot_uri: MIXS:0000118
     range: QuantityValue
     multivalued: false
   window_cond:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The physical condition of the window at the time of sampling
     title: window condition
     examples:
       - value: rupture
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window condition
     is_a: core field
     slot_uri: MIXS:0000849
     range: window_cond_enum
     multivalued: false
   window_cover:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of window covering
     title: window covering
     examples:
       - value: curtains
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window covering
     is_a: core field
     slot_uri: MIXS:0000850
     range: window_cover_enum
     multivalued: false
   window_horiz_pos:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The horizontal position of the window on the wall
     title: window horizontal position
     examples:
       - value: middle
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window horizontal position
     is_a: core field
     slot_uri: MIXS:0000851
     range: window_horiz_pos_enum
     multivalued: false
   window_loc:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The relative location of the window within the room
     title: window location
     examples:
       - value: west
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window location
     is_a: core field
     slot_uri: MIXS:0000852
     range: window_loc_enum
     multivalued: false
   window_mat:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of material used to finish a window
     title: window material
     examples:
       - value: wood
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window material
     is_a: core field
     slot_uri: MIXS:0000853
     range: window_mat_enum
     multivalued: false
   window_open_freq:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: value
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: value
+      occurrence: '1'
     description: The number of times windows are opened per week
     title: window open frequency
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window open frequency
     is_a: core field
     slot_uri: MIXS:0000246
     range: TextValue
     multivalued: false
   window_size:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: inch, meter
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: measurement value
+      preferred_unit: inch, meter
+      occurrence: '1'
     description: The window's length and width
     title: window area/size
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window area/size
     is_a: core field
     string_serialization: '{float} {unit} x {float} {unit}'
     slot_uri: MIXS:0000224
@@ -11696,19 +7495,12 @@ slots:
     multivalued: false
   window_status:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Defines whether the windows were open or closed during environmental testing
     title: window status
     examples:
       - value: open
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window status
     is_a: core field
     string_serialization: '[closed|open]'
     slot_uri: MIXS:0000855
@@ -11716,57 +7508,36 @@ slots:
     multivalued: false
   window_type:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The type of windows
     title: window type
     examples:
       - value: fixed window
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window type
     is_a: core field
     slot_uri: MIXS:0000856
     range: window_type_enum
     multivalued: false
   window_vert_pos:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: The vertical position of the window on the wall
     title: window vertical position
     examples:
       - value: middle
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window vertical position
     is_a: core field
     slot_uri: MIXS:0000857
     range: window_vert_pos_enum
     multivalued: false
   window_water_mold:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: enumeration
-      occurrence:
-        tag: occurrence
-        value: '1'
+      expected_value: enumeration
+      occurrence: '1'
     description: Signs of the presence of mold or mildew on the window.
     title: window signs of water/mold
     examples:
       - value: no presence of mold visible
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - window signs of water/mold
     is_a: core field
     string_serialization: '[presence of mold visible|no presence of mold visible]'
     slot_uri: MIXS:0000854
@@ -11774,57 +7545,35 @@ slots:
     multivalued: false
   xylene:
     annotations:
-      expected_value:
-        tag: expected_value
-        value: measurement value
-      preferred_unit:
-        tag: preferred_unit
-        value: milligram per liter, parts per million
-      occurrence:
-        tag: occurrence
-        value: '1'
-      storage_units:
-        tag: storage_units
-        value: '[ppm]|mg/L'
+      expected_value: measurement value
+      preferred_unit: milligram per liter, parts per million
+      occurrence: '1'
+      storage_units: '[ppm]|mg/L'
     description: Concentration of xylene in the sample
     title: xylene
     examples:
       - value: ''
-    from_schema: http://w3id.org/mixs/terms
-    aliases:
-      - xylene
     is_a: core field
     slot_uri: MIXS:0000156
     range: QuantityValue
     multivalued: false
   core field:
     description: basic fields
-    from_schema: http://w3id.org/mixs/terms
     abstract: true
   environment field:
     description: field describing environmental aspect of a sample
-    from_schema: http://w3id.org/mixs/terms
     abstract: true
   investigation field:
     description: field describing aspect of the investigation/study to which the sample belongs
-    from_schema: http://w3id.org/mixs/terms
     abstract: true
   nucleic acid sequence source field:
-    from_schema: http://w3id.org/mixs/terms
     abstract: true
   sequencing field:
-    from_schema: http://w3id.org/mixs/terms
     abstract: true
   mixs_env_triad_field:
     annotations:
-      tooltip:
-        tag: tooltip
-        value: >-
-          The MIxS environmental triad provides context about where a sample was collected and what it consists of.
-        annotations:
-          source:
-            tag: source
-            value: https://link.springer.com/protocol/10.1007/978-1-0716-3838-5_20
+      tooltip: >-
+        The MIxS environmental triad provides context about where a sample was collected and what it consists of.
     description: >-
       The MIxS environmental triad provides context about where a sample was collected and what it consists of. Its component slots capture the biome that the sample was found in, nearby geographical features that might influence the organisms in the sample, and the substance that was displaced in the process of collecting the sample. Careful population of these slots makes it easier for data users to find samples that are similar, not just in terms of textual values, but through ontological relationships. Furthermore, NMDC requires that its three component slots are populated because the INSDC Biosample databases require that they are populated because the MIxS standard from the GSC requires that they are populated.
     abstract: true
@@ -11834,4 +7583,5 @@ slots:
     created_by: orcid:0000-0002-5004-3362 # Alicia Clum
     contributors:
       - orcid:0000-0001-9076-6066 # Mark Andrew Miller
-source_file: assets/other_mixs_yaml_files/mixs_template.yaml
+classes: []
+settings: null


### PR DESCRIPTION
Addresses #2663 by removing readonly metaslot assertions from generated mixs.yaml.

Replaces this (but keep branch `2663-dont-assert-read-only-slots`)
- https://github.com/microbiomedata/nmdc-schema/pull/2688

## Changes

Apply comprehensive dematerialization pipeline to mixs.yaml generation:

- **Remove all 12 readonly metaslots**: `source_file`, `from_schema`, `owner`, `domain_of`, `is_usage_slot`, `usage_slot_name`, `alias`, `definition_uri`, `imported_from`, `metamodel_version`, `source_file_date`, `source_file_size`, `generation_date`
- **Simplify ExpandedDict → SimpleDict**: prefixes, settings, annotations
- **Remove redundant key fields**: class names, slot names, enum names, slot_usage names, subset names, permissible_values text
- **Remove 489 redundant aliases** that duplicate title field
- **Conditionally remove domain** (except MixsCompliantData)

## Results

- **35.9% reduction in lines**: 11,837 → 7,587 (4,250 lines removed)
- **27.9% smaller file size**: 344K → 248K (96K saved)
- Schema remains fully functional - all tests pass
- SchemaView correctly materializes compact YAML back to full objects on load

## Files Changed

- `project.Makefile`: Added dematerialization transformations to mixs.yaml build target
- `src/schema/mixs.yaml`: Generated output (dematerialized)
- `assets/other_mixs_yaml_files/mixs_template.yaml`: Template adjustments