### PR TITLE
Add `orbitrap_exploris_120` as permissible value to `InstrumentModelEnum`

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -798,10 +798,10 @@ enums:
           - Orbitrap IQ-X Tribrid
           - Thermo Orbitrap IQ-X Tribrid
       
-      orbitrap_exploris:
+      orbitrap_exploris_120:
         aliases:
-          - Orbitrap Exploris
-          - Thermo Orbitrap Exploris
+          - Orbitrap Exploris 120
+          - Thermo Orbitrap Exploris 120
 
       solarix_7T:
         aliases:


### PR DESCRIPTION
Adds `orbitrap_exploris_120` as permissible value to `InstrumentModelEnum`, which is needed for the EcoFab LCMS Metabolomics data.  Closes #2699 