### PR TITLE
Fix bug where link checker GHA workflow failed to install Python dependencies

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -32,9 +32,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'poetry'
-      - name: Install Python dependencies (including "docs" extras)
-        # Reference: https://python-poetry.org/docs/pyproject/#extras
-        run: poetry install --extras docs
+      - name: Install Python dependencies
+        run: poetry install
       - name: Build docs
         run: make gendoc
       - name: Use Lychee to check for broken links


### PR DESCRIPTION
On this branch, I updated an obsolete command in a GHA workflow, so it no longer references an "extras" group that was deleted in commit https://github.com/microbiomedata/nmdc-schema/commit/ce30e81e6f7c1b5108fe632e7fd205417e882f6f. That reference was causing the GHA workflow to fail to run.

Now, the GHA workflow just runs plain 'ol `$ poetry install`, which installs both prod and dev dependencies. The package that had been listed in that "extras" group (prior to commit ce30e81e6f7c1b5108fe632e7fd205417e882f6f) is also listed as a dev dependency, so it will be installed.

Fixes https://github.com/microbiomedata/nmdc-schema/issues/2706