### PR TITLE
Clean up commented status values in StatusEnum

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -1040,14 +1040,6 @@ enums:
     permissible_values:
       pass: { }
       fail: { }
-  #      accepted: { }
-  #      archived: { }
-  #      deleted: { }
-  #      draft: { }
-  #      rejected: { }
-  #      submitted: { }
-  #      superseded: { }
-  #      withdrawn: { }
   
   NucleotideSequencingEnum:
     permissible_values:


### PR DESCRIPTION
This PR removes commented out permissible values in the StatusEnum enumeration.