### PR TITLE
Remove note on biosample definitions in core.yaml

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -340,8 +340,6 @@ classes:
       - biospecimen
     description: >-
       Biological source material which can be characterized by an experiment.
-    notes:
-      - could add GOLD and EBI's biosample definitions to the alt_descriptions?
     alt_descriptions:
       embl.ena:
         A sample contains information about the sequenced source material.


### PR DESCRIPTION
Removed notes about adding biosample definitions, based on reviewing the system's source definitions it doesn't make sense to add this, especially for GOLD.