### PR TITLE
Add editor and office temporary files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,8 +144,15 @@ venv.bak/
 # mkdocs documentation
 /site
 
-# swap files
+# Vim swap files
+*.swp
 *.swo
+
+# MS Office temporary files
+~$*
+
+# LibreOffice lock files
+.~lock.*#
 
 # mypy
 .mypy_cache/


### PR DESCRIPTION
- *.swp - Vim swap files (was missing, caused accidental commits in PR #2723 and issue #2573)
- ~$* - MS Office (Excel, Word, etc.) temporary files
- .~lock.*# - LibreOffice lock files

Closes #2740

🤖 Generated with [Claude Code](https://claude.com/claude-code)