### PR TITLE
Quote ecosystem_path_id example value as string

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -258,7 +258,7 @@ slots:
     range: integer
     description: A unique id representing the GOLD classifiers associated with a sample.
     examples:
-      - value: 6026
+      - value: "6026"
     see_also:
     - https://gold.jgi.doe.gov/ecosystem_classification  
 


### PR DESCRIPTION
## Summary

Fixes LinkML metamodel validation error by quoting the `ecosystem_path_id` example value as a string.

## Error

```
src/schema/basic_slots.yaml
  error    In slots > ecosystem_path_id > examples > [0] > value: 6026 is not of type 'string', 'null'  (valid-schema)
```

## Fix

LinkML example values must be strings in YAML (per the [Example class](https://linkml.io/linkml-model/latest/docs/Example/) where `value` has type String). The linter interprets the string according to the slot's declared `range: integer`.

```yaml
# Before
- value: 6026

# After  
- value: "6026"
```

Fixes #2745

🤖 Generated with [Claude Code](https://claude.com/claude-code)