### PR TITLE
Add test to prevent new units_alignment_excuse annotations

### DIFF
--- a/tests/test_units_alignment.py
+++ b/tests/test_units_alignment.py
@@ -210,4 +210,3 @@ class TestUnitsAlignment(unittest.TestCase):
                             f"If an excuse is genuinely needed, add the slot to ALLOWED_SLOTS_WITH_UNITS_EXCUSE "
                             f"in tests/test_units_alignment.py after team discussion. "
                             f"New excused slots: {new_excused_slots}")
-    


### PR DESCRIPTION
## Summary

Adds a test that enforces a frozen list of slots allowed to have `units_alignment_excuse` annotations. This prevents schema editors from adding new excuses instead of proper `storage_units` annotations.

## Changes

- Added `ALLOWED_SLOTS_WITH_UNITS_EXCUSE` frozen set (11 slots)
- Added `test_no_new_units_alignment_excuses` test

## Current Frozen List

| Slot | Excuse |
|------|--------|
| api | non_ucum_unit |
| biomaterial_purity | pending_analysis |
| concentration | pending_analysis |
| efficiency_percent | mixs_inconsistent |
| exp_pipe | pending_analysis |
| inside_lux | mixs_inconsistent |
| microbial_biomass | complex_unit |
| occup_density_samp | pending_analysis |
| rel_humidity_out | mixs_inconsistent |
| soil_text_measure | pending_analysis |
| value | pending_analysis |

## How to Remove an Excuse

1. Add a `storage_units` annotation with the correct UCUM unit(s)
2. Remove the `units_alignment_excuse` annotation
3. Remove the slot from `ALLOWED_SLOTS_WITH_UNITS_EXCUSE` in `tests/test_units_alignment.py`

## Test Plan

- [x] All existing units alignment tests pass
- [x] New test passes with current schema
- [ ] CI passes

Fixes #2724

🤖 Generated with [Claude Code](https://claude.com/claude-code)