### PR TITLE
Test docs generation with test_slot_delete_me

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -34,6 +34,17 @@ default_range: string
 
 slots:
 
+  test_slot_delete_me:
+    range: string
+    deprecated: "This slot was added to test documentation generation. Delete after verifying docs work."
+    description: >-
+      A temporary test slot to verify that documentation generation workflows are functioning correctly
+      after GitHub Actions cleanup (PR #2752). This slot should be removed after confirming that
+      the docs preview and deployment work as expected.
+    comments:
+      - "Added for issue #2751"
+      - "If you see this in production docs, something went wrong!"
+
   processing_institution_workflow_metadata:
     range: string
     description: >- 


### PR DESCRIPTION
## Summary

Adds a temporary test slot to verify that documentation generation workflows work correctly after the GitHub Actions cleanup in PR #2752.

## What This Tests

- `main.yaml` - build and test (including linting)
- `test-pages-build.yaml` - PR documentation preview

## Verification

1. Check that this PR's actions pass
2. Check the PR preview link for `test_slot_delete_me` in the slots documentation
3. After merge, verify `deploy-docs.yaml` deploys to production correctly

## Cleanup

After verification, the slot should be removed per #2754.

## Related

- #2751 - Test documentation generation with a trivial schema change
- #2752 - GitHub Actions cleanup and documentation workflow optimization  
- #2754 - Remove test_slot_delete_me after verifying docs generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)