### PR TITLE
Remove test_slot_delete_me (docs test complete)

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -34,17 +34,6 @@ default_range: string
 
 slots:
 
-  test_slot_delete_me:
-    range: string
-    deprecated: "This slot was added to test documentation generation. Delete after verifying docs work."
-    description: >-
-      A temporary test slot to verify that documentation generation workflows are functioning correctly
-      after GitHub Actions cleanup (PR #2752). This slot should be removed after confirming that
-      the docs preview and deployment work as expected.
-    comments:
-      - "Added for issue #2751"
-      - "If you see this in production docs, something went wrong!"
-
   processing_institution_workflow_metadata:
     range: string
     description: >- 


### PR DESCRIPTION
## Summary

Removes the temporary `test_slot_delete_me` slot after verifying documentation workflows work correctly.

## Verification Complete

- ✅ PR preview deployed correctly (test-pages-build.yaml)
- ✅ Production docs deployed correctly (deploy-docs.yaml)  
- ✅ `test_slot_delete_me` appeared in both preview and production docs

## Related

Fixes #2754
- #2751 - Test documentation generation with a trivial schema change
- #2752 - GitHub Actions cleanup and documentation workflow optimization
- #2755 - Test docs generation with test_slot_delete_me

🤖 Generated with [Claude Code](https://claude.com/claude-code)