### PR TITLE
Fix ncbi_nmdc_exact_term_matching.py: replace OmicsProcessing with DataGeneration

### DIFF
--- a/src/scripts/ncbi_nmdc_exact_term_matching.py
+++ b/src/scripts/ncbi_nmdc_exact_term_matching.py
@@ -68,8 +68,8 @@ def create_unmapped_ncbi_mapping_file(tsv_output_filepath):
 # ==================================================================================== #
 # Load dataframe containing all the slots from the NMDC schema that need to be mapped
 # to "names" of NCBI BioSample Attributes. The slots that are being mapped belong to
-# the following classes: Biosample, Extraction, LibraryPreparation, DataGeneration,
-# DataObject. The "names" of the NCBI BioSample Attributes can be either the
+# the following classes: Biosample, Extraction, LibraryPreparation, DataGeneration, NucleotideSequencing, MassSpectrometry, DataObject.
+# The "names" of the NCBI BioSample Attributes can be either the
 # harmonized name, synonym, or attribute name (display name)
 # The file at assets/ncbi_mappings/ncbi_attribute_mappings.tsv has been created by
 # using SchemaView() to iterate over relevant classes and retrieving slots from the


### PR DESCRIPTION
## Summary

Fixes `ncbi_nmdc_exact_term_matching.py` which was failing because it referenced the removed `OmicsProcessing` class.

## Changes

Replace `OmicsProcessing` with `DataGeneration` and its subclasses (`NucleotideSequencing`, `MassSpectrometry`) in two locations in the script.

## Context

This bug was discovered while testing asset regeneration after PR #2763 removed CLI aliases for scripts not included in the PyPI package. The script failed with:

```
ValueError: No such class: "OmicsProcessing"
```

## Test Plan

- [x] Verified `make assets/ncbi_mappings/ncbi_attribute_mappings.tsv` succeeds
- [x] Verified `make assets/ncbi_mappings/ncbi_attribute_mappings_filled.tsv` succeeds

Fixes #2762

🤖 Generated with [Claude Code](https://claude.com/claude-code)