### PR TITLE
Update urllib3 to 2.6.0 (security fix)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4379,4 +4379,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "27cf425fe5f2c03c3f1dc6fcfa8ab225406d0bfa6a6711044b47319e4f0e9d09"
+content-hash = "eec25defb7f2040ec91387bd9652d2a2458f477aec36976333549bbbf33027a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ python-dotenv = "*"
 pyyaml = "^6"
 rdflib = "^6.2.0" # some LinkML components are not compatible with rdflib 7+ yet
 requests = "^2"
+urllib3 = ">=2.6.0"
 
 [tool.poetry.group.dev.dependencies] # cruft for cookiecutter update could be installed with pipx?
 autopep8 = "^2.2.0"
@@ -161,3 +162,6 @@ testpaths = ["tests"]
 extend_exclude = [
     "nmdc_schema/nmdc-pydantic.py"
 ]
+# urllib3 is a transitive dependency (via requests) but we pin it directly
+# to ensure users get security fixes (CVE-2025-66471, CVE-2025-66418)
+per_rule_ignores = {DEP002 = ["urllib3"]}


### PR DESCRIPTION
## Summary

Updates urllib3 from 2.5.0 to 2.6.0 to address security vulnerabilities.

### Security Fixes
- **CVE-2025-66471** (8.9 High): Fixed decompression bomb vulnerability in streaming API
- **CVE-2025-66418** (8.9 High): Fixed DoS vulnerability via unlimited Content-Encoding header links

## Related

- Closes #2769
- Alternative to dependabot PR #2768

🤖 Generated with [Claude Code](https://claude.com/claude-code)