### PR TITLE
Rename migrator to reflect schema versions and add required parameter

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_14_0_to_11_15_1.py
+++ b/nmdc_schema/migrators/migrator_from_11_14_0_to_11_15_1.py
@@ -1,0 +1,12 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Migrates a database between two schemas."""
+
+    _from_version = "11.14.0"
+    _to_version = "11.15.1"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_15_1_to_11_16_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_15_1_to_11_16_0.py
@@ -7,7 +7,7 @@ class Migrator(MigratorBase):
     _from_version = "11.15.1"
     _to_version = "11.16.0"
 
-    def upgrade(self) -> None:
+    def upgrade(self, commit_changes: bool = False) -> None:
         r"""Migrates the database from conforming to the original schema, to conforming to the new schema."""
 
         self.adapter.process_each_document("workflow_execution_set", [self.make_uses_calibration_multivalued])
@@ -24,7 +24,5 @@ class Migrator(MigratorBase):
         """
 
         if workflow_execution.get("uses_calibration") is not None:
-            workflow_execution[
-                "uses_calibration"
-            ] = [workflow_execution["uses_calibration"]]
+            workflow_execution["uses_calibration"] = [workflow_execution["uses_calibration"]]
         return workflow_execution


### PR DESCRIPTION
On this branch, I did the following things:
- Created a "no op" migrator named `migrator_from_11_14_0_to_11_15_1.py` to indicate that no migration is necessary between those schema versions
- Renamed the existing migrator to `migrator_from_11_15_1_to_11_16_0.py` to reflect the schema versions it deals with
- Added the required `commit_changes` parameter (introduced in https://github.com/microbiomedata/nmdc-schema/pull/2523) to the `upgrade` function
- Reformatted a line of code so it's easier for me to read

Fixes: https://github.com/microbiomedata/nmdc-schema/issues/2814