### PR TITLE
Constrain add_date and mod_date to xsd:date within ProvenanceMetadata

### DIFF
--- a/src/data/invalid/Biosample-invalid-add_date.yaml
+++ b/src/data/invalid/Biosample-invalid-add_date.yaml
@@ -1,6 +1,6 @@
 # Tests that GOLD-format dates are rejected for add_date within provenance_metadata.
-# The slot_usage on ProvenanceMetadata constrains add_date to range: date (xsd:date),
-# so only ISO 8601 YYYY-MM-DD strings are accepted.
+# The slot_usage on ProvenanceMetadata constrains add_date to range: date
+# (linkml:date, mapped to xsd:date), so only YYYY-MM-DD strings are accepted.
 id: nmdc:bsm-99-badDate1
 type: nmdc:Biosample
 associated_studies:

--- a/src/data/invalid/Biosample-invalid-mod_date.yaml
+++ b/src/data/invalid/Biosample-invalid-mod_date.yaml
@@ -1,6 +1,7 @@
 # Tests that datetime values are rejected for mod_date within provenance_metadata.
-# The slot_usage on ProvenanceMetadata constrains mod_date to range: date (xsd:date),
-# so only ISO 8601 YYYY-MM-DD strings are accepted. An unquoted ISO datetime like
+# The slot_usage on ProvenanceMetadata constrains mod_date to range: date
+# (linkml:date, mapped to xsd:date), so only YYYY-MM-DD strings are accepted.
+# An unquoted datetime like
 # 2023-01-25T00:00:00 is parsed by PyYAML as a native datetime.datetime object,
 # which fails JSON Schema validation.
 id: nmdc:bsm-99-badDate2

--- a/src/data/valid/Biosample-add_date-mod_date.yaml
+++ b/src/data/valid/Biosample-add_date-mod_date.yaml
@@ -1,5 +1,6 @@
-# Tests that ISO 8601 dates (YYYY-MM-DD) are accepted for add_date and mod_date
-# within provenance_metadata, where slot_usage constrains the range to date.
+# Tests that YYYY-MM-DD dates are accepted for add_date and mod_date within
+# provenance_metadata, where slot_usage constrains range to linkml:date (mapped
+# to xsd:date, generates JSON Schema "format": "date").
 # Dates must be quoted to prevent PyYAML (YAML 1.1) from parsing them as
 # native datetime.date objects, which linkml-validate's JSON Schema pathway rejects.
 id: nmdc:bsm-99-dateTest

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -531,12 +531,12 @@ classes:
       add_date:
         range: date
         comments:
-          - Constrained to xsd:date (YYYY-MM-DD) within ProvenanceMetadata. The global range remains string for backward compatibility with GOLD-format dates on Biosample and DataGeneration.
+          - "range: date is the LinkML date type (linkml:date, mapped to xsd:date), which accepts YYYY-MM-DD strings. Constrained here within ProvenanceMetadata; the global range remains string for backward compatibility with GOLD-format dates on Biosample and DataGeneration."
           - In YAML data files, date values must be quoted (e.g., '2021-03-31') to prevent PyYAML from parsing them as native datetime.date objects, which linkml-validate rejects.
       mod_date:
         range: date
         comments:
-          - Constrained to xsd:date (YYYY-MM-DD) within ProvenanceMetadata. The global range remains string for backward compatibility with GOLD-format dates on Biosample and DataGeneration.
+          - "range: date is the LinkML date type (linkml:date, mapped to xsd:date), which accepts YYYY-MM-DD strings. Constrained here within ProvenanceMetadata; the global range remains string for backward compatibility with GOLD-format dates on Biosample and DataGeneration."
           - In YAML data files, date values must be quoted (e.g., '2023-01-25') to prevent PyYAML from parsing them as native datetime.date objects, which linkml-validate rejects.
       version:
         description: The version tag of the software used to generate the NMDC metadata record


### PR DESCRIPTION
## Summary

Adds `slot_usage` on `ProvenanceMetadata` to constrain `add_date` and `mod_date` to `range: date` (xsd:date, YYYY-MM-DD).

The global range on these slots remains `string` for backward compatibility with GOLD-format dates on Biosample and DataGeneration. Only values within `provenance_metadata` are constrained.

Closes #2830
Part of #2806
Depends on #2833 (base branch)

## YAML quoting requirement

Date values in YAML data files must be quoted (e.g., `'2021-03-31'`). Without quotes, PyYAML (YAML 1.1) parses bare dates as native `datetime.date` objects, which `linkml-validate`'s JSON Schema pathway rejects. LinkML's `ReferenceValidator` and `XSDDate` class do support native date objects, but that code path is not used by `linkml-validate`.

## Test files added

| File | Purpose | Expected result |
|------|---------|----------------|
| `valid/Biosample-add_date-mod_date.yaml` | Quoted ISO dates in `provenance_metadata` | Pass |
| `invalid/Biosample-invalid-add_date.yaml` | GOLD-format date (`28-JUL-14 12.00.00...`) in `provenance_metadata` | Fail |
| `invalid/Biosample-invalid-mod_date.yaml` | Unquoted datetime (`2023-01-25T00:00:00`) in `provenance_metadata` | Fail |

## Validation results

```
=== VALID ===
No issues found (EXIT: 0)

=== INVALID add_date ===
[ERROR] '28-JUL-14 12.00.00.000000000 AM' is not a 'date' in /provenance_metadata/add_date (EXIT: 1)

=== INVALID mod_date ===
[ERROR] datetime.datetime(2023, 1, 25, 0, 0) is not of type 'string', 'null' in /provenance_metadata/mod_date (EXIT: 1)
```

## Test plan

- [x] `linkml-lint` passes
- [x] `linkml-validate` accepts valid file
- [x] `linkml-validate` rejects both invalid files
- [ ] Full `make test` (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)