### PR TITLE
Switch build commands to use LinkML unified CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,11 @@ create-data-harmonizer:
 
 prefixmaps:
 	@mkdir -p $(DEST)/prefixmap
-	$(RUN) gen-prefix-map nmdc_schema/nmdc_materialized_patterns.yaml > $(DEST)/prefixmap/nmdc-prefix-map.json
+	$(RUN) linkml generate prefix-map nmdc_schema/nmdc_materialized_patterns.yaml > $(DEST)/prefixmap/nmdc-prefix-map.json
 
 pydantic:
 	@mkdir -p $(DEST)/pydantic
-	$(RUN) gen-pydantic nmdc_schema/nmdc_materialized_patterns.yaml > $(DEST)/pydantic/nmdc_pydantic.py
+	$(RUN) linkml generate pydantic nmdc_schema/nmdc_materialized_patterns.yaml > $(DEST)/pydantic/nmdc_pydantic.py
 
 # Note: `all` is an alias for `site`.
 all: site
@@ -109,7 +109,7 @@ pydantic
 deploy: gendoc mkd-gh-deploy
 
 gen-project: $(PYMODEL) prefixmaps pydantic # depends on src/schema/mixs.yaml # can be nuked with mixs-yaml-clean
-	$(RUN) gen-project \
+	$(RUN) linkml generate project \
 		--exclude excel \
 		--exclude graphql \
 		--exclude jsonld \
@@ -133,7 +133,7 @@ only-test: examples-clean test-python migration-doctests examples/output
 tests: squeaky-clean all test  # simply for convenience to wrap convention of running these three targets to test locally.
 
 test-schema:
-	$(RUN) gen-project \
+	$(RUN) linkml generate project \
 		--exclude excel \
 		--exclude graphql \
 		--exclude jsonld \
@@ -245,8 +245,8 @@ gendoc: $(DOCDIR) prefixmaps
 	cp -rf $(SRC)/docs/* $(DOCDIR)
 	# Use `make_typecode_to_class_map.py` to make a Markdown page that can be used to map a typecode to a schema class.
 	$(RUN) python src/scripts/make_typecode_to_class_map.py > $(DOCDIR)/typecode-to-class-map.md
-	# Generate documentation using the gen-doc command
-	$(RUN) gen-doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) --include src/schema/deprecated.yaml $(SOURCE_SCHEMA_PATH)
+	# Generate documentation
+	$(RUN) linkml generate doc -d $(DOCDIR) --template-directory $(SRC)/$(TEMPLATEDIR) --include src/schema/deprecated.yaml $(SOURCE_SCHEMA_PATH)
 	# Create directory for JavaScript files and copy them
 	# Added copying of prefixmaps output
 	cp -f $(DEST)/prefixmap/nmdc-prefix-map.json $(DOCDIR)
@@ -328,14 +328,14 @@ squeaky-clean: clean examples-clean rdf-clean shuttle-clean site-clean # does no
 	rm -rf local/biosample_slots_ranges_report.tsv
 
 nmdc_schema/nmdc_materialized_patterns.yaml:
-	$(RUN) gen-linkml \
+	$(RUN) linkml generate linkml \
 		--format yaml \
 		--materialize-patterns \
 		--no-materialize-attributes \
 		--output $@ $(SOURCE_SCHEMA_PATH)
 
 nmdc_schema/nmdc_materialized_patterns.schema.json: nmdc_schema/nmdc_materialized_patterns.yaml
-	$(RUN) gen-json-schema \
+	$(RUN) linkml generate json-schema \
 		--closed \
 		--include-range-class-descendants \
 		--top-class Database $< > $@
@@ -363,7 +363,7 @@ check-invalids-for-single-failure:
 	for file in src/data/invalid/*.yaml; do \
 		echo "$$file:"; \
 		target_class=$$(basename $$file | cut -d'-' -f1); \
-		cmd="poetry run linkml-validate --schema nmdc_schema/nmdc_materialized_patterns.yaml --target-class $$target_class $$file"; \
+		cmd="poetry run linkml validate --schema nmdc_schema/nmdc_materialized_patterns.yaml --target-class $$target_class $$file"; \
 		output=$$($$cmd 2>&1 || true); \
 		echo "$$output" | sort | uniq; \
 	done

--- a/project.Makefile
+++ b/project.Makefile
@@ -163,7 +163,7 @@ assets/other_mixs_yaml_files/mixs_env_triad_field_slot.yaml
 
 examples/output: nmdc_schema/nmdc_materialized_patterns.yaml
 	mkdir -p $@
-	$(RUN) linkml-run-examples \
+	$(RUN) linkml examples \
 		--schema $< \
 		--input-directory src/data/valid \
 		--counter-example-input-directory src/data/invalid \
@@ -261,7 +261,7 @@ local/mongo_via_api_as_nmdc_database_after_migrator.yaml: nmdc_schema/nmdc_mater
 .PRECIOUS: local/mongo_via_api_as_nmdc_database_validation.log
 local/mongo_via_api_as_nmdc_database_validation.log: nmdc_schema/nmdc_materialized_patterns.yaml local/mongo_via_api_as_nmdc_database_after_migrator.yaml
 	date # 5m57.559s without functional_annotation_agg or metaproteomics_analysis_activity_set
-	time $(RUN) linkml-validate --schema $^ > $@
+	time $(RUN) linkml validate --schema $^ > $@
 
 #### Combined Command ####
 .PHONY: test-migrator-on-database
@@ -299,7 +299,7 @@ local/mongo_as_unvalidated_nmdc_database.yaml:
 
 local/mongo_as_nmdc_database.ttl: nmdc_schema/nmdc_materialized_patterns.yaml local/mongo_as_nmdc_database_rdf_safe.yaml
 	date # 681.99 seconds on 2023-08-30 without functional_annotation_agg or metaproteomics_analysis_activity_set
-	time $(RUN) linkml-convert --output $@ --schema $^
+	time $(RUN) linkml convert --output $@ --schema $^
 	mv $@ $@.tmp
 	cat  assets/my_emsl_prefix.ttl $@.tmp  > $@
 	rm -rf $@.tmp
@@ -381,7 +381,7 @@ local/gold-study-ids.json:
 		-H 'accept: application/json'
 
 local/nmdc-no-use-native-uris.owl.ttl: src/schema/nmdc.yaml
-	$(RUN) gen-owl --no-use-native-uris $< > $@
+	$(RUN) linkml generate owl --no-use-native-uris $< > $@
 
 
 local/nmdc_materialized.ttl: src/schema/nmdc.yaml
@@ -421,7 +421,7 @@ diagrams-all: diagrams-clean assets/plantuml.png assets/plantuml.pdf assets/merm
 #		--classes SubstanceEntity
 
 assets/plantuml.puml: src/schema/nmdc.yaml
-	$(RUN) gen-plantuml \
+	$(RUN) linkml generate plantuml \
 		--classes ChemicalConversionProcess \
 		--classes ChemicalEntity \
 		--classes ChromatographicSeparationProcess \
@@ -445,7 +445,7 @@ assets/plantuml.pdf: assets/plantuml.svg
 	inkscape --export-filename=$@ $<
 
 assets/mermaid-erd.mmd: src/schema/nmdc.yaml
-	$(RUN) gen-erdiagram \
+	$(RUN) linkml generate erdiagram \
 		--format mermaid \
 		--classes ChemicalConversionProcess \
 		--classes ChemicalEntity \


### PR DESCRIPTION
## Summary

- Replace all standalone `gen-*` and `linkml-*` CLI commands in `Makefile` and `project.Makefile` with their unified `linkml {subcommand}` equivalents
- 14 command invocations migrated across 2 files; `linkml lint` was already migrated
- Make target names (e.g., `gen-project:`) are unchanged — only the commands they execute were updated

## Changes

**Makefile** (8 commands):
- `gen-prefix-map` → `linkml generate prefix-map`
- `gen-pydantic` → `linkml generate pydantic`
- `gen-project` → `linkml generate project` (2 occurrences)
- `gen-doc` → `linkml generate doc`
- `gen-linkml` → `linkml generate linkml`
- `gen-json-schema` → `linkml generate json-schema`
- `linkml-validate` → `linkml validate`

**project.Makefile** (6 commands):
- `linkml-run-examples` → `linkml examples`
- `linkml-validate` → `linkml validate`
- `linkml-convert` → `linkml convert`
- `gen-owl` → `linkml generate owl`
- `gen-plantuml` → `linkml generate plantuml`
- `gen-erdiagram` → `linkml generate erdiagram`

## Test plan

- [ ] Run `make squeaky-clean all test` to verify full build works with unified CLI commands
- [ ] Verify CI passes

Closes #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)