### PR TITLE
Document readonly metaslots directive and architectural changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ through Feb 2026) that affect the build system and project layout:
   three via `include` directives.
 - **Unified LinkML CLI** (PR #2839, 2026-02-20): Build commands switched
   from legacy `gen-owl`, `gen-json-schema`, etc. to `linkml generate owl`,
-  `linkml generate jsonschema`, etc. Old `gen-*` entry points still exist
+  `linkml generate json-schema`, etc. Old `gen-*` entry points still exist
   in linkml but are no longer used here.
 - **LinkML 1.10.0 upgrade** (PR #2849, 2026-02-26): Adds new OWL flags
   like `--enum-inherits-as-subclass-of`. Drops Python 3.9.

--- a/src/docs/developer-docs.md
+++ b/src/docs/developer-docs.md
@@ -44,6 +44,6 @@ of the dematerialization step
 | 2026-02-26 | [#2848](https://github.com/microbiomedata/nmdc-schema/pull/2848) | **Makefile reorganization**: MIxS pipeline moved to `makefiles/mixs.Makefile`, migrator targets to `makefiles/migrators.Makefile`. RDF conversion tooling removed. |
 | 2026-02-26 | [#2849](https://github.com/microbiomedata/nmdc-schema/pull/2849) | **LinkML 1.10.0 upgrade**: new OWL flags (`--enum-inherits-as-subclass-of`), Python 3.9 dropped. |
 | 2026-02-26 | [#2846](https://github.com/microbiomedata/nmdc-schema/pull/2846) | **Dead code removal**: `about.yaml` and experimental scripts removed. |
-| 2026-02-20 | [#2839](https://github.com/microbiomedata/nmdc-schema/pull/2839) | **Unified LinkML CLI**: build uses `linkml generate owl`, `linkml generate jsonschema`, etc. instead of legacy `gen-owl`, `gen-json-schema`. |
 | 2026-02-21 | [#2302](https://github.com/microbiomedata/nmdc-schema/pull/2302) | **Downloads page**: schema-derived JSON and YAML files downloadable via docs website. |
+| 2026-02-20 | [#2839](https://github.com/microbiomedata/nmdc-schema/pull/2839) | **Unified LinkML CLI**: build uses `linkml generate owl`, `linkml generate json-schema`, etc. instead of legacy `gen-owl`, `gen-json-schema`. |
 | 2025-10-28 | [#2696](https://github.com/microbiomedata/nmdc-schema/pull/2696) | **Dematerialize mixs.yaml**: all 12 readonly metaslots stripped from generated `mixs.yaml` (35% line reduction). |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Add directive listing the 12 LinkML readonly metaslots that must never be asserted in hand-edited schema YAML, with pointer to the dematerialization pipeline in `makefiles/mixs.Makefile`. Add dated changelog of architectural changes from Oct 2025 through Feb 2026.
- **developer-docs.md**: Add FAQ entries for readonly metaslots (why they exist, where stripping happens, link to PR #2696) and a table of architectural changes with dates and PR links.

Closes #2854

## Context

PR #2696 (Oct 2025) added a `yq eval` pipeline to strip all 12 readonly metaslots from generated `mixs.yaml`, but there was no documentation or AI-agent directive warning against reintroducing them. Several architectural changes (Makefile reorg #2848, unified CLI #2839, LinkML 1.10.0 #2849, dead code removal #2846, downloads page #2302) also lacked a discoverable summary for reviewers.

## Test plan

- [ ] `mkdocs build` passes (docs-only change)
- [ ] CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)