### PR TITLE
Release prep: regenerate artifacts for v11.17.0-rc.4

### DIFF
--- a/nmdc_schema/nmdc.py
+++ b/nmdc_schema/nmdc.py
@@ -1,5 +1,5 @@
 # Auto generated from nmdc.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-02-27T18:01:43
+# Generation date: 2026-02-28T11:37:08
 # Schema: NMDC
 #
 # id: https://w3id.org/nmdc/nmdc
@@ -56,8 +56,8 @@ from rdflib import (
     URIRef
 )
 
-from linkml_runtime.linkml_model.types import Boolean, Decimal, Float, Integer, String, Uriorcurie
-from linkml_runtime.utils.metamodelcore import Bool, Decimal, URIorCURIE
+from linkml_runtime.linkml_model.types import Boolean, Date, Decimal, Float, Integer, String, Uriorcurie
+from linkml_runtime.utils.metamodelcore import Bool, Decimal, URIorCURIE, XSDDate
 
 metamodel_version = "1.7.0"
 version = "0.0.0"
@@ -2069,12 +2069,10 @@ class Biosample(Sample):
     ecosystem_subtype: Optional[str] = None
     specific_ecosystem: Optional[str] = None
     ecosystem_path_id: Optional[int] = None
-    add_date: Optional[str] = None
     community: Optional[str] = None
     habitat: Optional[str] = None
     host_name: Optional[str] = None
     location: Optional[str] = None
-    mod_date: Optional[str] = None
     ncbi_taxonomy_name: Optional[str] = None
     proport_woa_temperature: Optional[str] = None
     salinity_category: Optional[str] = None
@@ -3692,9 +3690,6 @@ class Biosample(Sample):
         if self.ecosystem_path_id is not None and not isinstance(self.ecosystem_path_id, int):
             self.ecosystem_path_id = int(self.ecosystem_path_id)
 
-        if self.add_date is not None and not isinstance(self.add_date, str):
-            self.add_date = str(self.add_date)
-
         if self.community is not None and not isinstance(self.community, str):
             self.community = str(self.community)
 
@@ -3706,9 +3701,6 @@ class Biosample(Sample):
 
         if self.location is not None and not isinstance(self.location, str):
             self.location = str(self.location)
-
-        if self.mod_date is not None and not isinstance(self.mod_date, str):
-            self.mod_date = str(self.mod_date)
 
         if self.ncbi_taxonomy_name is not None and not isinstance(self.ncbi_taxonomy_name, str):
             self.ncbi_taxonomy_name = str(self.ncbi_taxonomy_name)
@@ -5379,11 +5371,10 @@ class DataGeneration(DataEmitterProcess):
     analyte_category: str = None
     associated_studies: Union[Union[str, StudyId], list[Union[str, StudyId]]] = None
     has_input: Union[Union[str, SampleId], list[Union[str, SampleId]]] = None
-    add_date: Optional[str] = None
     instrument_used: Optional[Union[Union[str, InstrumentId], list[Union[str, InstrumentId]]]] = empty_list()
-    mod_date: Optional[str] = None
     principal_investigator: Optional[Union[dict, PersonValue]] = None
     instrument_instance_specifier: Optional[str] = None
+    provenance_metadata: Optional[Union[dict, "ProvenanceMetadata"]] = None
     has_output: Optional[Union[Union[str, DataObjectId], list[Union[str, DataObjectId]]]] = empty_list()
 
     def __post_init__(self, *_: str, **kwargs: Any):
@@ -5404,21 +5395,18 @@ class DataGeneration(DataEmitterProcess):
             self.has_input = [self.has_input] if self.has_input is not None else []
         self.has_input = [v if isinstance(v, SampleId) else SampleId(v) for v in self.has_input]
 
-        if self.add_date is not None and not isinstance(self.add_date, str):
-            self.add_date = str(self.add_date)
-
         if not isinstance(self.instrument_used, list):
             self.instrument_used = [self.instrument_used] if self.instrument_used is not None else []
         self.instrument_used = [v if isinstance(v, InstrumentId) else InstrumentId(v) for v in self.instrument_used]
-
-        if self.mod_date is not None and not isinstance(self.mod_date, str):
-            self.mod_date = str(self.mod_date)
 
         if self.principal_investigator is not None and not isinstance(self.principal_investigator, PersonValue):
             self.principal_investigator = PersonValue(**as_dict(self.principal_investigator))
 
         if self.instrument_instance_specifier is not None and not isinstance(self.instrument_instance_specifier, str):
             self.instrument_instance_specifier = str(self.instrument_instance_specifier)
+
+        if self.provenance_metadata is not None and not isinstance(self.provenance_metadata, ProvenanceMetadata):
+            self.provenance_metadata = ProvenanceMetadata(**as_dict(self.provenance_metadata))
 
         if not isinstance(self.has_output, list):
             self.has_output = [self.has_output] if self.has_output is not None else []
@@ -6468,7 +6456,9 @@ class ProvenanceMetadata(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = NMDC.ProvenanceMetadata
 
     type: Union[str, URIorCURIE] = None
+    add_date: Optional[Union[str, XSDDate]] = None
     git_url: Optional[str] = None
+    mod_date: Optional[Union[str, XSDDate]] = None
     version: Optional[str] = None
     source_system_of_record: Optional[Union[str, "SourceSystemEnum"]] = None
     submission_portal_identifier: Optional[Union[str, list[str]]] = empty_list()
@@ -6478,8 +6468,14 @@ class ProvenanceMetadata(YAMLRoot):
             self.MissingRequiredField("type")
         self.type = str(self.class_class_curie)
 
+        if self.add_date is not None and not isinstance(self.add_date, XSDDate):
+            self.add_date = XSDDate(self.add_date)
+
         if self.git_url is not None and not isinstance(self.git_url, str):
             self.git_url = str(self.git_url)
+
+        if self.mod_date is not None and not isinstance(self.mod_date, XSDDate):
+            self.mod_date = XSDDate(self.mod_date)
 
         if self.version is not None and not isinstance(self.version, str):
             self.version = str(self.version)
@@ -13661,6 +13657,12 @@ slots.WorkflowExecution_was_informed_by = Slot(uri=NMDC['basic_classes/was_infor
 
 slots.WorkflowExecution_version = Slot(uri=NMDC.version, name="WorkflowExecution_version", curie=NMDC.curie('version'),
                    model_uri=NMDC.WorkflowExecution_version, domain=WorkflowExecution, range=Optional[str])
+
+slots.ProvenanceMetadata_add_date = Slot(uri=NMDC.add_date, name="ProvenanceMetadata_add_date", curie=NMDC.curie('add_date'),
+                   model_uri=NMDC.ProvenanceMetadata_add_date, domain=ProvenanceMetadata, range=Optional[Union[str, XSDDate]])
+
+slots.ProvenanceMetadata_mod_date = Slot(uri=NMDC.mod_date, name="ProvenanceMetadata_mod_date", curie=NMDC.curie('mod_date'),
+                   model_uri=NMDC.ProvenanceMetadata_mod_date, domain=ProvenanceMetadata, range=Optional[Union[str, XSDDate]])
 
 slots.ProvenanceMetadata_version = Slot(uri=NMDC.version, name="ProvenanceMetadata_version", curie=NMDC.curie('version'),
                    model_uri=NMDC.ProvenanceMetadata_version, domain=ProvenanceMetadata, range=Optional[str])

--- a/nmdc_schema/nmdc.schema.json
+++ b/nmdc_schema/nmdc.schema.json
@@ -75,13 +75,6 @@
                     ],
                     "description": "Actual mass of water vapor present in the air water vapor mixture."
                 },
-                "add_date": {
-                    "description": "The date on which the information was added to the database.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "add_recov_method": {
                     "description": "Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed for increase of hydrocarbon recovery from resource and start date for each one of them. If \"other\" is specified, please propose entry in \"additional info\" field",
                     "type": [
@@ -2574,13 +2567,6 @@
                     },
                     "type": [
                         "array",
-                        "null"
-                    ]
-                },
-                "mod_date": {
-                    "description": "The last date on which the database information was modified.",
-                    "type": [
-                        "string",
                         "null"
                     ]
                 },
@@ -9095,13 +9081,6 @@
             ],
             "description": "Spectrometry where the sample is converted into gaseous ions which are characterised by their mass-to-charge ratio and relative abundance.",
             "properties": {
-                "add_date": {
-                    "description": "The date on which the information was added to the database.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "alternative_identifiers": {
                     "description": "A list of alternative identifiers for the entity.",
                     "items": {
@@ -9208,13 +9187,6 @@
                         "null"
                     ]
                 },
-                "mod_date": {
-                    "description": "The last date on which the database information was modified.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "name": {
                     "description": "A human readable label for an entity",
                     "type": [
@@ -9246,6 +9218,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "provenance_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ProvenanceMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Provides information about the provenance of a record."
                 },
                 "qc_comment": {
                     "description": "Slot to store additional comments about laboratory or workflow output. For workflow output it may describe the particular workflow stage that failed. (ie Failed at call-stage due to a malformed fastq file).",
@@ -11928,13 +11911,6 @@
             "additionalProperties": false,
             "description": "A DataGeneration in which the sequence of DNA or RNA molecules is generated.",
             "properties": {
-                "add_date": {
-                    "description": "The date on which the information was added to the database.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "alternative_identifiers": {
                     "description": "A list of alternative identifiers for the entity.",
                     "items": {
@@ -12051,13 +12027,6 @@
                         "null"
                     ]
                 },
-                "mod_date": {
-                    "description": "The last date on which the database information was modified.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "name": {
                     "description": "A human readable label for an entity",
                     "type": [
@@ -12095,6 +12064,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "provenance_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ProvenanceMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Provides information about the provenance of a record."
                 },
                 "qc_comment": {
                     "description": "Slot to store additional comments about laboratory or workflow output. For workflow output it may describe the particular workflow stage that failed. (ie Failed at call-stage due to a malformed fastq file).",
@@ -13003,8 +12983,24 @@
             "additionalProperties": false,
             "description": "Metadata pertaining to how a record was created.",
             "properties": {
+                "add_date": {
+                    "description": "The date on which the information was added to the database.",
+                    "format": "date",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "git_url": {
                     "description": "The url of the software repository used to generate the NMDC metadata record",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "mod_date": {
+                    "description": "The last date on which the database information was modified.",
+                    "format": "date",
                     "type": [
                         "string",
                         "null"

--- a/nmdc_schema/nmdc_materialized_patterns.json
+++ b/nmdc_schema/nmdc_materialized_patterns.json
@@ -24623,13 +24623,12 @@
       "is_a": "DataEmitterProcess",
       "abstract": true,
       "slots": [
-        "add_date",
         "analyte_category",
         "associated_studies",
         "instrument_used",
-        "mod_date",
         "principal_investigator",
-        "instrument_instance_specifier"
+        "instrument_instance_specifier",
+        "provenance_metadata"
       ],
       "slot_usage": {
         "has_input": {
@@ -24782,13 +24781,31 @@
       "description": "Metadata pertaining to how a record was created.",
       "from_schema": "https://w3id.org/nmdc/nmdc",
       "slots": [
+        "add_date",
         "git_url",
+        "mod_date",
         "version",
         "source_system_of_record",
         "submission_portal_identifier",
         "type"
       ],
       "slot_usage": {
+        "add_date": {
+          "name": "add_date",
+          "comments": [
+            "range: date is the LinkML date type (linkml:date, mapped to xsd:date), which accepts YYYY-MM-DD strings. Constrained here within ProvenanceMetadata; the global range remains string for backward compatibility with legacy exported data.",
+            "In YAML data files, date values must be quoted (e.g., '2021-03-31') to prevent PyYAML from parsing them as native datetime.date objects, which linkml-validate rejects."
+          ],
+          "range": "date"
+        },
+        "mod_date": {
+          "name": "mod_date",
+          "comments": [
+            "range: date is the LinkML date type (linkml:date, mapped to xsd:date), which accepts YYYY-MM-DD strings. Constrained here within ProvenanceMetadata; the global range remains string for backward compatibility with legacy exported data.",
+            "In YAML data files, date values must be quoted (e.g., '2023-01-25') to prevent PyYAML from parsing them as native datetime.date objects, which linkml-validate rejects."
+          ],
+          "range": "date"
+        },
         "version": {
           "name": "version",
           "description": "The version tag of the software used to generate the NMDC metadata record"
@@ -25464,12 +25481,10 @@
         "ecosystem_subtype",
         "specific_ecosystem",
         "ecosystem_path_id",
-        "add_date",
         "community",
         "habitat",
         "host_name",
         "location",
-        "mod_date",
         "ncbi_taxonomy_name",
         "proport_woa_temperature",
         "salinity_category",

--- a/nmdc_schema/nmdc_materialized_patterns.schema.json
+++ b/nmdc_schema/nmdc_materialized_patterns.schema.json
@@ -76,13 +76,6 @@
                     "description": "Actual mass of water vapor present in the air water vapor mixture.",
                     "pattern": "^[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?( *- *[-+]?[0-9]*\\.?[0-9]+(?:[eE][-+]?[0-9]+)?)? *.*$"
                 },
-                "add_date": {
-                    "description": "The date on which the information was added to the database.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "add_recov_method": {
                     "description": "Additional (i.e. Secondary, tertiary, etc.) recovery methods deployed for increase of hydrocarbon recovery from resource and start date for each one of them. If \"other\" is specified, please propose entry in \"additional info\" field",
                     "pattern": "^(Water Injection|Dump Flood|Gas Injection|Wag Immiscible Injection|Polymer Addition|Surfactant Addition|Not Applicable|other);(\\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\\d|3[01])(T([01]\\d|2[0-3]):([0-5]\\d)(:([0-5]\\d))?(\\.\\d+)?(Z|([+-][01]\\d:[0-5]\\d))?)?)?)?$",
@@ -2680,13 +2673,6 @@
                     },
                     "type": [
                         "array",
-                        "null"
-                    ]
-                },
-                "mod_date": {
-                    "description": "The last date on which the database information was modified.",
-                    "type": [
-                        "string",
                         "null"
                     ]
                 },
@@ -9337,13 +9323,6 @@
             ],
             "description": "Spectrometry where the sample is converted into gaseous ions which are characterised by their mass-to-charge ratio and relative abundance.",
             "properties": {
-                "add_date": {
-                    "description": "The date on which the information was added to the database.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "alternative_identifiers": {
                     "description": "A list of alternative identifiers for the entity.",
                     "items": {
@@ -9457,13 +9436,6 @@
                         "null"
                     ]
                 },
-                "mod_date": {
-                    "description": "The last date on which the database information was modified.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "name": {
                     "description": "A human readable label for an entity",
                     "type": [
@@ -9495,6 +9467,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "provenance_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ProvenanceMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Provides information about the provenance of a record."
                 },
                 "qc_comment": {
                     "description": "Slot to store additional comments about laboratory or workflow output. For workflow output it may describe the particular workflow stage that failed. (ie Failed at call-stage due to a malformed fastq file).",
@@ -12213,13 +12196,6 @@
             "additionalProperties": false,
             "description": "A DataGeneration in which the sequence of DNA or RNA molecules is generated.",
             "properties": {
-                "add_date": {
-                    "description": "The date on which the information was added to the database.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "alternative_identifiers": {
                     "description": "A list of alternative identifiers for the entity.",
                     "items": {
@@ -12340,13 +12316,6 @@
                         "null"
                     ]
                 },
-                "mod_date": {
-                    "description": "The last date on which the database information was modified.",
-                    "type": [
-                        "string",
-                        "null"
-                    ]
-                },
                 "name": {
                     "description": "A human readable label for an entity",
                     "type": [
@@ -12384,6 +12353,17 @@
                             "type": "null"
                         }
                     ]
+                },
+                "provenance_metadata": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ProvenanceMetadata"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "Provides information about the provenance of a record."
                 },
                 "qc_comment": {
                     "description": "Slot to store additional comments about laboratory or workflow output. For workflow output it may describe the particular workflow stage that failed. (ie Failed at call-stage due to a malformed fastq file).",
@@ -13295,8 +13275,24 @@
             "additionalProperties": false,
             "description": "Metadata pertaining to how a record was created.",
             "properties": {
+                "add_date": {
+                    "description": "The date on which the information was added to the database.",
+                    "format": "date",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "git_url": {
                     "description": "The url of the software repository used to generate the NMDC metadata record",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "mod_date": {
+                    "description": "The last date on which the database information was modified.",
+                    "format": "date",
                     "type": [
                         "string",
                         "null"

--- a/nmdc_schema/nmdc_materialized_patterns.yaml
+++ b/nmdc_schema/nmdc_materialized_patterns.yaml
@@ -19410,13 +19410,12 @@ classes:
     is_a: DataEmitterProcess
     abstract: true
     slots:
-    - add_date
     - analyte_category
     - associated_studies
     - instrument_used
-    - mod_date
     - principal_investigator
     - instrument_instance_specifier
+    - provenance_metadata
     slot_usage:
       has_input:
         name: has_input
@@ -19533,12 +19532,36 @@ classes:
     description: Metadata pertaining to how a record was created.
     from_schema: https://w3id.org/nmdc/nmdc
     slots:
+    - add_date
     - git_url
+    - mod_date
     - version
     - source_system_of_record
     - submission_portal_identifier
     - type
     slot_usage:
+      add_date:
+        name: add_date
+        comments:
+        - 'range: date is the LinkML date type (linkml:date, mapped to xsd:date),
+          which accepts YYYY-MM-DD strings. Constrained here within ProvenanceMetadata;
+          the global range remains string for backward compatibility with legacy exported
+          data.'
+        - In YAML data files, date values must be quoted (e.g., '2021-03-31') to prevent
+          PyYAML from parsing them as native datetime.date objects, which linkml-validate
+          rejects.
+        range: date
+      mod_date:
+        name: mod_date
+        comments:
+        - 'range: date is the LinkML date type (linkml:date, mapped to xsd:date),
+          which accepts YYYY-MM-DD strings. Constrained here within ProvenanceMetadata;
+          the global range remains string for backward compatibility with legacy exported
+          data.'
+        - In YAML data files, date values must be quoted (e.g., '2023-01-25') to prevent
+          PyYAML from parsing them as native datetime.date objects, which linkml-validate
+          rejects.
+        range: date
       version:
         name: version
         description: The version tag of the software used to generate the NMDC metadata
@@ -20189,12 +20212,10 @@ classes:
     - ecosystem_subtype
     - specific_ecosystem
     - ecosystem_path_id
-    - add_date
     - community
     - habitat
     - host_name
     - location
-    - mod_date
     - ncbi_taxonomy_name
     - proport_woa_temperature
     - salinity_category

--- a/nmdc_schema/nmdc_pydantic.py
+++ b/nmdc_schema/nmdc_pydantic.py
@@ -5878,7 +5878,7 @@ class Study(NamedThing):
                                               'for this study.'}},
          'domain_of': ['OntologyClass', 'Study', 'Biosample'],
          'exact_mappings': ['dcterms:alternative', 'skos:altLabel']} })
-    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'Biosample']} })
+    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'DataGeneration', 'Biosample']} })
     alternative_titles: Optional[list[str]] = Field(default=[], description="""A list of alternative titles for the entity. The distinction between title and alternative titles is application-specific.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study'], 'exact_mappings': ['dcterms:alternative']} })
     ecosystem: Optional[str] = Field(default=None, description="""An ecosystem is a combination of a physical environment (abiotic factors) and all the organisms (biotic factors) that interact with this environment. Ecosystem is in position 1/5 in a GOLD path.""", json_schema_extra = { "linkml_meta": {'comments': ['The abiotic factors play a profound role on the type and '
                       'composition of organisms in a given environment. The GOLD '
@@ -7142,7 +7142,6 @@ class DataGeneration(DataEmitterProcess):
                                        'structured_pattern': {'interpolated': True,
                                                               'syntax': '{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$'}}}})
 
-    add_date: Optional[str] = Field(default=None, description="""The date on which the information was added to the database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     analyte_category: str = Field(default=..., description="""The type of analyte(s) that were measured in the data generation process
 """, json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration']} })
     associated_studies: list[str] = Field(default=..., description="""The study associated with a resource.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample'],
@@ -7151,9 +7150,9 @@ class DataGeneration(DataEmitterProcess):
     instrument_used: Optional[list[str]] = Field(default=[], description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'MaterialProcessing'],
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
-    mod_date: Optional[str] = Field(default=None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     principal_investigator: Optional[PersonValue] = Field(default=None, description="""Principal Investigator who led the study and/or generated the dataset.""", json_schema_extra = { "linkml_meta": {'aliases': ['PI'], 'domain_of': ['Study', 'DataGeneration']} })
     instrument_instance_specifier: Optional[str] = Field(default=None, description="""A unique value that identifies an individual instrument instance, such as a serial number or similar identifiers assigned by the manufacturer or user.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration']} })
+    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'DataGeneration', 'Biosample']} })
     has_input: list[str] = Field(default=..., description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
          'structured_pattern': {'interpolated': True,
@@ -7339,7 +7338,6 @@ class NucleotideSequencing(DataGeneration):
          'is_a': 'external_database_identifiers',
          'mixins': ['insdc_identifiers']} })
     ncbi_project_name: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['NucleotideSequencing']} })
-    add_date: Optional[str] = Field(default=None, description="""The date on which the information was added to the database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     analyte_category: NucleotideSequencingEnum = Field(default=..., description="""The type of analyte(s) that were measured in the data generation process
 """, json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration']} })
     associated_studies: list[str] = Field(default=..., description="""The study associated with a resource.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample'],
@@ -7348,9 +7346,9 @@ class NucleotideSequencing(DataGeneration):
     instrument_used: Optional[list[str]] = Field(default=[], description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'MaterialProcessing'],
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
-    mod_date: Optional[str] = Field(default=None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     principal_investigator: Optional[PersonValue] = Field(default=None, description="""Principal Investigator who led the study and/or generated the dataset.""", json_schema_extra = { "linkml_meta": {'aliases': ['PI'], 'domain_of': ['Study', 'DataGeneration']} })
     instrument_instance_specifier: Optional[str] = Field(default=None, description="""A unique value that identifies an individual instrument instance, such as a serial number or similar identifiers assigned by the manufacturer or user.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration']} })
+    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'DataGeneration', 'Biosample']} })
     has_input: list[str] = Field(default=..., description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
          'structured_pattern': {'interpolated': True,
@@ -7606,7 +7604,6 @@ class MassSpectrometry(DataGeneration):
     has_mass_spectrometry_configuration: str = Field(default=..., description="""The identifier of the associated MassSpectrometryConfiguration.""", json_schema_extra = { "linkml_meta": {'domain_of': ['MassSpectrometry'],
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:mscon-{id_shoulder}-{id_blade}$'}} })
-    add_date: Optional[str] = Field(default=None, description="""The date on which the information was added to the database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     analyte_category: MassSpectrometryEnum = Field(default=..., description="""The type of analyte(s) that were measured in the data generation process
 """, json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration']} })
     associated_studies: list[str] = Field(default=..., description="""The study associated with a resource.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample'],
@@ -7615,9 +7612,9 @@ class MassSpectrometry(DataGeneration):
     instrument_used: Optional[list[str]] = Field(default=[], description="""What instrument was used during DataGeneration or MaterialProcessing.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'MaterialProcessing'],
          'structured_pattern': {'interpolated': True,
                                 'syntax': '{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$'}} })
-    mod_date: Optional[str] = Field(default=None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     principal_investigator: Optional[PersonValue] = Field(default=None, description="""Principal Investigator who led the study and/or generated the dataset.""", json_schema_extra = { "linkml_meta": {'aliases': ['PI'], 'domain_of': ['Study', 'DataGeneration']} })
     instrument_instance_specifier: Optional[str] = Field(default=None, description="""A unique value that identifies an individual instrument instance, such as a serial number or similar identifiers assigned by the manufacturer or user.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration']} })
+    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'DataGeneration', 'Biosample']} })
     has_input: list[str] = Field(default=..., description="""An input to a process.""", json_schema_extra = { "linkml_meta": {'aliases': ['input'],
          'domain_of': ['PlannedProcess'],
          'structured_pattern': {'interpolated': True,
@@ -8061,18 +8058,64 @@ class ProvenanceMetadata(ConfiguredBaseModel):
     """
     linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'nmdc:ProvenanceMetadata',
          'from_schema': 'https://w3id.org/nmdc/nmdc',
-         'slot_usage': {'git_url': {'description': 'The url of the software repository '
+         'slot_usage': {'add_date': {'comments': ['range: date is the LinkML date type '
+                                                  '(linkml:date, mapped to xsd:date), '
+                                                  'which accepts YYYY-MM-DD strings. '
+                                                  'Constrained here within '
+                                                  'ProvenanceMetadata; the global '
+                                                  'range remains string for backward '
+                                                  'compatibility with legacy exported '
+                                                  'data.',
+                                                  'In YAML data files, date values '
+                                                  "must be quoted (e.g., '2021-03-31') "
+                                                  'to prevent PyYAML from parsing them '
+                                                  'as native datetime.date objects, '
+                                                  'which linkml-validate rejects.'],
+                                     'name': 'add_date',
+                                     'range': 'date'},
+                        'git_url': {'description': 'The url of the software repository '
                                                    'used to generate the NMDC metadata '
                                                    'record',
                                     'name': 'git_url'},
+                        'mod_date': {'comments': ['range: date is the LinkML date type '
+                                                  '(linkml:date, mapped to xsd:date), '
+                                                  'which accepts YYYY-MM-DD strings. '
+                                                  'Constrained here within '
+                                                  'ProvenanceMetadata; the global '
+                                                  'range remains string for backward '
+                                                  'compatibility with legacy exported '
+                                                  'data.',
+                                                  'In YAML data files, date values '
+                                                  "must be quoted (e.g., '2023-01-25') "
+                                                  'to prevent PyYAML from parsing them '
+                                                  'as native datetime.date objects, '
+                                                  'which linkml-validate rejects.'],
+                                     'name': 'mod_date',
+                                     'range': 'date'},
                         'version': {'description': 'The version tag of the software '
                                                    'used to generate the NMDC metadata '
                                                    'record',
                                     'name': 'version'}}})
 
+    add_date: Optional[date] = Field(default=None, description="""The date on which the information was added to the database.""", json_schema_extra = { "linkml_meta": {'comments': ['range: date is the LinkML date type (linkml:date, mapped to '
+                      'xsd:date), which accepts YYYY-MM-DD strings. Constrained here '
+                      'within ProvenanceMetadata; the global range remains string for '
+                      'backward compatibility with legacy exported data.',
+                      'In YAML data files, date values must be quoted (e.g., '
+                      "'2021-03-31') to prevent PyYAML from parsing them as native "
+                      'datetime.date objects, which linkml-validate rejects.'],
+         'domain_of': ['ProvenanceMetadata']} })
     git_url: Optional[str] = Field(default=None, description="""The url of the software repository used to generate the NMDC metadata record""", json_schema_extra = { "linkml_meta": {'domain_of': ['WorkflowExecution', 'ProvenanceMetadata'],
          'examples': [{'value': 'https://github.com/microbiomedata/mg_annotation/releases/tag/0.1'},
                       {'value': 'https://github.com/microbiomedata/metaMS/blob/master/metaMS/gcmsWorkflow.py'}]} })
+    mod_date: Optional[date] = Field(default=None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'comments': ['range: date is the LinkML date type (linkml:date, mapped to '
+                      'xsd:date), which accepts YYYY-MM-DD strings. Constrained here '
+                      'within ProvenanceMetadata; the global range remains string for '
+                      'backward compatibility with legacy exported data.',
+                      'In YAML data files, date values must be quoted (e.g., '
+                      "'2023-01-25') to prevent PyYAML from parsing them as native "
+                      'datetime.date objects, which linkml-validate rejects.'],
+         'domain_of': ['ProvenanceMetadata']} })
     version: Optional[str] = Field(default=None, description="""The version tag of the software used to generate the NMDC metadata record""", json_schema_extra = { "linkml_meta": {'domain_of': ['WorkflowExecution', 'ProvenanceMetadata'],
          'exact_mappings': ['schema:version'],
          'examples': [{'value': 'v1.2.0'}]} })
@@ -9101,7 +9144,7 @@ class Biosample(Sample):
          'mixins': ['neon_identifiers']} })
     alternative_names: Optional[list[str]] = Field(default=[], description="""A list of alternative names used to refer to the entity. The distinction between name and alternative names is application-specific.  This should not be used for identifers which have their own slots (e.g., bioproject:PRJNA406974)""", json_schema_extra = { "linkml_meta": {'domain_of': ['OntologyClass', 'Study', 'Biosample'],
          'exact_mappings': ['dcterms:alternative', 'skos:altLabel']} })
-    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'Biosample']} })
+    provenance_metadata: Optional[ProvenanceMetadata] = Field(default=None, description="""Provides information about the provenance of a record.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Study', 'DataGeneration', 'Biosample']} })
     gold_biosample_identifiers: Optional[list[str]] = Field(default=[], description="""Unique identifier for a biosample submitted to GOLD that matches the NMDC submitted biosample""", json_schema_extra = { "linkml_meta": {'annotations': {'tooltip': {'tag': 'tooltip',
                                      'value': 'Provide the GOLD biosample IDs '
                                               'associated with this biosample.'}},
@@ -12955,12 +12998,10 @@ class Biosample(Sample):
     ecosystem_path_id: Optional[int] = Field(default=None, description="""A unique id representing the GOLD classifiers associated with a sample.""", json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample'],
          'examples': [{'value': '6026'}],
          'see_also': ['https://gold.jgi.doe.gov/ecosystem_classification']} })
-    add_date: Optional[str] = Field(default=None, description="""The date on which the information was added to the database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     community: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample']} })
     habitat: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['FieldResearchSite', 'Biosample']} })
     host_name: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample']} })
     location: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample']} })
-    mod_date: Optional[str] = Field(default=None, description="""The last date on which the database information was modified.""", json_schema_extra = { "linkml_meta": {'domain_of': ['DataGeneration', 'Biosample']} })
     ncbi_taxonomy_name: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample']} })
     proport_woa_temperature: Optional[str] = Field(default=None, json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample']} })
     salinity_category: Optional[str] = Field(default=None, description="""Categorical description of the sample's salinity. Examples: halophile, halotolerant, hypersaline, huryhaline""", json_schema_extra = { "linkml_meta": {'domain_of': ['Biosample'],


### PR DESCRIPTION
## Summary

- Regenerated build artifacts via `make squeaky-clean all test` (33 tests pass, all doctests pass)
- Targets the `2829-add-dates-to-provenance-metadata` feature branch for a pre-release

After merging, tag `v11.17.0-rc.4` from the feature branch to publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)