### PR TITLE
Skip preview deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/test-pages-build.yaml
+++ b/.github/workflows/test-pages-build.yaml
@@ -51,7 +51,7 @@ jobs:
         run: poetry run mkdocs build -d site
 
       - name: Deploy preview
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: site/


### PR DESCRIPTION
## Summary
- Adds `if: github.actor != 'dependabot[bot]'` to the "Deploy preview" step in `test-pages-build.yaml`
- The `rossjrw/pr-preview-action` requires write access to `gh-pages`, but Dependabot PRs get a read-only `GITHUB_TOKEN`, so the deploy always fails
- The schema build and mkdocs build still run on all PRs — only the deploy step is skipped

## Test plan
- [ ] Verify this PR's own "Preview documentation build" check passes (it's not a Dependabot PR, so deploy should still run)
- [ ] After merging, comment `@dependabot rebase` on #2880 and verify it goes green

Closes #2881