### PR TITLE
Add OLS4 embeddings search for ontology term discovery (1/3: retrieval baseline)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ clean:
 include project.Makefile
 include makefiles/mixs.Makefile
 include makefiles/migrators.Makefile
+include makefiles/ontology-alignment.Makefile
 
 # custom
 site-clean: clean

--- a/docs/ontology-alignment-ols4.md
+++ b/docs/ontology-alignment-ols4.md
@@ -1,0 +1,177 @@
+# OLS4 Embeddings Search for nmdc-schema Ontology Alignment
+
+This document describes how to use the OLS4 embeddings search pipeline to
+discover ontology term candidates for nmdc-schema elements (classes, slots,
+enums, and permissible values).
+
+## Background
+
+[OLS4](https://www.ebi.ac.uk/ols4/) hosts ~276 ontologies and provides an
+LLM embeddings search endpoint (`/api/v2/classes/llm_search`) using the
+`llama-embed-nemotron-8b_pca512` model. This pipeline queries that endpoint
+for every schema element and produces SSSOM-style TSV output, then enriches
+results with schema-aware diagnostics.
+
+**No API key is needed.** The OLS4 embeddings API is public. The only
+constraint is courtesy rate-limiting (0.5s delay between requests by default).
+
+## Quick start
+
+```bash
+# Enrich the committed baseline results (instant, no API calls)
+make ols4-embeddings-postprocess
+
+# Run a smoke test against OBI only (~30s)
+make ols4-embeddings-smoke
+
+# Re-run the full exhaustive search (~19 min)
+make ols4-embeddings-search
+```
+
+## Scripts
+
+### `src/scripts/ols4_embeddings_search.py`
+
+Iterates schema elements, queries OLS4, writes raw SSSOM-style TSV.
+
+```bash
+poetry run python src/scripts/ols4_embeddings_search.py --help
+```
+
+Key options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--schema` | `src/schema/nmdc.yaml` | Schema to iterate |
+| `--element-types` | `classes,slots,enums,pvs` | Which element types to search |
+| `--ontology` | (all) | Restrict to one ontology (e.g. `obi`, `envo`) |
+| `--rows` | 5 | Results per query |
+| `--delay` | 0.5 | Seconds between API requests |
+| `--skip-mapped` | off | Skip elements that already have mappings |
+| `-o` | `ols4_embeddings_results.tsv` | Output file |
+
+**Query construction:** CamelCase names are expanded to spaces, underscores
+replaced. If the element has a description, it's truncated to 200 chars and
+appended after a colon: `"Biosample: A material sample..."`.
+
+### `src/scripts/ols4_embeddings_postprocess.py`
+
+Enriches raw search results with schema context and lexical diagnostics.
+
+```bash
+poetry run python src/scripts/ols4_embeddings_postprocess.py \
+  --semantic-results src/scripts/ols4_embeddings_results.tsv
+```
+
+Key options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--semantic-threshold` | 0.90 | Confidence threshold for "strong semantic" |
+| `--lexical-threshold` | 0.45 | Score below which lexical similarity is "weak" |
+| `--allowed-ontologies` | (all) | Comma-separated prefixes to keep (e.g. `OBI,ENVO`) |
+| `--excluded-ontologies` | (none) | Comma-separated prefixes to exclude |
+| `--subject-categories` | (all) | Filter to specific categories: `class,slot,enum,permissible_value` |
+| `--resolve-ols-metadata` | off | Make additional OLS4 API calls to distinguish classes from properties |
+
+**Outputs** (in `local/`, gitignored):
+- Enriched TSV with 34 columns including lexical profile, structural analysis, and bucket classification
+- Summary JSON with counts by bucket, source, match type
+
+## Interpreting results
+
+### Semantic vs. lexical classification
+
+Each result row is classified into a 2x2 matrix:
+
+| | Strong lexical (>= 0.45) | Weak lexical (< 0.45) |
+|---|---|---|
+| **Strong semantic (>= 0.90)** | `strong_semantic_strong_lexical` — expected matches | `strong_semantic_weak_lexical` — novel candidates |
+| **Weak semantic (< 0.90)** | `weak_semantic_strong_lexical` — name overlap, low confidence | `weak_semantic_weak_lexical` — unlikely matches |
+
+The `strong_semantic_weak_lexical` bucket is the most interesting for
+discovery — these are cases where the embedding model sees semantic
+similarity despite different labels. However, **many of these are noise**
+for short/generic PV labels (e.g. "east" matching species names, "wood"
+matching tree species). See [#2917](https://github.com/microbiomedata/nmdc-schema/issues/2917) for filtering improvements.
+
+### Structural support
+
+The post-processor checks whether a match is structurally plausible given
+the NMDC element type:
+
+- **class -> class**: always supported
+- **slot -> class**: supported only if the slot's range is an enum or class
+  (i.e., it expects a `class_filler`). Scalar-range slots mapped to classes
+  get `slot_class_scalar_mismatch`.
+- **PV -> class**: supported if there's ontology source overlap with
+  existing mappings
+- **enum -> class**: supported if source overlap with existing mappings
+
+### Key columns in the enriched TSV
+
+| Column | Description |
+|--------|-------------|
+| `confidence` | OLS4 embedding similarity score (0-1) |
+| `lexical_score` | Max of token Jaccard, SequenceMatcher ratio, containment, exact/normalized match |
+| `semantic_vs_lexical` | 2x2 bucket classification |
+| `structural_bucket` | Refined classification incorporating structural plausibility |
+| `structural_fit` | Boolean: is this match structurally plausible? |
+| `structural_reason` | Why (or why not): `slot_class_range_fit`, `slot_class_scalar_mismatch`, etc. |
+| `schema_expected_alignment_type` | `class_filler` or `property_like` |
+| `existing_mappings` | Mappings already declared in the schema for this element |
+
+## OLS4 API reference
+
+The OLS4 LLM search endpoint is:
+
+```
+GET https://www.ebi.ac.uk/ols4/api/v2/classes/llm_search
+    ?q=<query text>
+    &model=llama-embed-nemotron-8b_pca512
+    &rows=<number of results>
+```
+
+Scoped to a specific ontology:
+
+```
+GET https://www.ebi.ac.uk/ols4/api/v2/ontologies/{ontology_id}/classes/llm_search
+    ?q=<query text>
+    &model=llama-embed-nemotron-8b_pca512
+    &rows=<number of results>
+```
+
+- **No authentication** required
+- Returns JSON with an `elements` array, each element having `curie`, `label`,
+  `ontologyId`, `score`, `iri`, etc.
+- The embeddings corpus covers **210 of 276** OLS4 ontologies
+- Dominant sources in results: SNOMED, NCIT, NCBITaxon, EFO, ENVO
+
+### Coverage relative to nmdc-schema
+
+Of the ~31 ontology prefixes used in nmdc-schema, only 3 are missing from the
+OLS4 embeddings corpus:
+
+- **MISO** (1 reference in schema) — BioPortal-only
+- **FMA** (declared but unused) — see [#2920](https://github.com/microbiomedata/nmdc-schema/issues/2920)
+- **gtpo** (placeholder with `example.org` URI)
+
+All heavily-used prefixes (OBI, CHEBI, MS, NCIT, ENVO, GO, NCBITaxon) are covered.
+
+## Current results summary
+
+The committed baseline (`src/scripts/ols4_embeddings_results.tsv`) contains:
+- **45,940 rows** from **2,298 schema elements** across 210 ontologies
+- **2,284 rows** with confidence > 0.90
+- **1,959** strong semantic + strong lexical
+- **325** strong semantic + weak lexical (novel candidates)
+- Only **2** of those 325 are structurally supported (both for the `model` slot)
+
+## Related issues
+
+- [#2907](https://github.com/microbiomedata/nmdc-schema/issues/2907) — Use OLS4 embeddings search to discover ontology mappings
+- [#2906](https://github.com/microbiomedata/nmdc-schema/issues/2906) — Audit direct PROV and OBI usage
+- [#2912](https://github.com/microbiomedata/nmdc-schema/issues/2912) — Ground MS/chromatography enums in OBI
+- [#2913](https://github.com/microbiomedata/nmdc-schema/issues/2913) — Use OWL axiom decomposition to refine matches
+- [#2917](https://github.com/microbiomedata/nmdc-schema/issues/2917) — Filter short/generic PV labels
+- [#2918](https://github.com/microbiomedata/nmdc-schema/issues/2918) — Add property-oriented retrieval

--- a/makefiles/ontology-alignment.Makefile
+++ b/makefiles/ontology-alignment.Makefile
@@ -1,0 +1,66 @@
+# Ontology alignment via OLS4 embeddings search and post-processing
+#
+# Prerequisites:
+#   poetry install --with dev,deps
+#
+# No API key needed — the OLS4 embeddings endpoint is public.
+#
+# Quick start:
+#   make ols4-embeddings-postprocess   # enrich committed baseline (no API calls)
+#   make ols4-embeddings-smoke         # small OBI-only test (~30 queries)
+#   make ols4-embeddings-search        # full exhaustive run (~19 min)
+
+OLS4_RESULTS = src/scripts/ols4_embeddings_results.tsv
+OLS4_ENRICHED = local/ols4_embeddings_enriched.tsv
+OLS4_SUMMARY = local/ols4_embeddings_summary.json
+
+.PHONY: ols4-embeddings-search ols4-embeddings-smoke ols4-embeddings-postprocess
+.PHONY: ols4-embeddings-postprocess-obi ols4-embeddings-postprocess-slots
+
+# ---------- OLS4 retrieval ----------
+
+# Full exhaustive search: all element types, full OLS4 corpus
+# ~2,300 queries x 0.5s = ~19 min. Overwrites committed results TSV.
+ols4-embeddings-search:
+	$(RUN) python src/scripts/ols4_embeddings_search.py \
+		--schema $(SOURCE_SCHEMA_PATH) \
+		--element-types classes,slots,enums,pvs \
+		--rows 5 \
+		-o $(OLS4_RESULTS)
+
+# Smoke test: classes only, OBI only (~60 queries, ~30s)
+ols4-embeddings-smoke:
+	$(RUN) python src/scripts/ols4_embeddings_search.py \
+		--schema $(SOURCE_SCHEMA_PATH) \
+		--element-types classes \
+		--ontology obi \
+		--rows 3 \
+		-o local/ols4_embeddings_smoke_obi.tsv -v
+
+# ---------- OLS4 post-processing ----------
+
+# Enrich full results with schema context and lexical diagnostics (no API calls)
+ols4-embeddings-postprocess: $(OLS4_RESULTS)
+	$(RUN) python src/scripts/ols4_embeddings_postprocess.py \
+		--schema $(SOURCE_SCHEMA_PATH) \
+		--semantic-results $(OLS4_RESULTS) \
+		-o $(OLS4_ENRICHED) \
+		--summary-json $(OLS4_SUMMARY)
+
+# Post-process filtered to OBI only
+ols4-embeddings-postprocess-obi: $(OLS4_RESULTS)
+	$(RUN) python src/scripts/ols4_embeddings_postprocess.py \
+		--schema $(SOURCE_SCHEMA_PATH) \
+		--semantic-results $(OLS4_RESULTS) \
+		--allowed-ontologies OBI \
+		-o local/ols4_embeddings_obi_enriched.tsv \
+		--summary-json local/ols4_embeddings_obi_summary.json
+
+# Post-process filtered to slots only (useful for property alignment analysis)
+ols4-embeddings-postprocess-slots: $(OLS4_RESULTS)
+	$(RUN) python src/scripts/ols4_embeddings_postprocess.py \
+		--schema $(SOURCE_SCHEMA_PATH) \
+		--semantic-results $(OLS4_RESULTS) \
+		--subject-categories slot \
+		-o local/ols4_embeddings_slots_enriched.tsv \
+		--summary-json local/ols4_embeddings_slots_summary.json

--- a/makefiles/ontology-alignment.Makefile
+++ b/makefiles/ontology-alignment.Makefile
@@ -9,18 +9,23 @@
 #   make ols4-embeddings-postprocess   # enrich committed baseline (no API calls)
 #   make ols4-embeddings-smoke         # small OBI-only test (~30 queries)
 #   make ols4-embeddings-search        # full exhaustive run (~19 min)
+#   make ols4-embeddings-clean         # remove all generated output from local/
 
-OLS4_RESULTS = src/scripts/ols4_embeddings_results.tsv
+# Committed baseline results (regenerate with ols4-embeddings-search, then copy)
+OLS4_BASELINE = assets/ontology_alignment/ols4_embeddings_results.tsv
+# Fresh search results go to local/ (gitignored)
+OLS4_RESULTS = local/ols4_embeddings_results.tsv
 OLS4_ENRICHED = local/ols4_embeddings_enriched.tsv
 OLS4_SUMMARY = local/ols4_embeddings_summary.json
 
 .PHONY: ols4-embeddings-search ols4-embeddings-smoke ols4-embeddings-postprocess
 .PHONY: ols4-embeddings-postprocess-obi ols4-embeddings-postprocess-slots
+.PHONY: ols4-embeddings-clean ols4-embeddings-update-baseline
 
 # ---------- OLS4 retrieval ----------
 
 # Full exhaustive search: all element types, full OLS4 corpus
-# ~2,300 queries x 0.5s = ~19 min. Overwrites committed results TSV.
+# ~2,300 queries x 0.5s = ~19 min. Writes to local/ (gitignored).
 ols4-embeddings-search:
 	$(RUN) python src/scripts/ols4_embeddings_search.py \
 		--schema $(SOURCE_SCHEMA_PATH) \
@@ -37,30 +42,41 @@ ols4-embeddings-smoke:
 		--rows 3 \
 		-o local/ols4_embeddings_smoke_obi.tsv -v
 
+# Update the committed baseline from a fresh search run
+ols4-embeddings-update-baseline: $(OLS4_RESULTS)
+	cp $(OLS4_RESULTS) $(OLS4_BASELINE)
+	@echo "Baseline updated. Review the diff and commit if appropriate."
+
 # ---------- OLS4 post-processing ----------
 
-# Enrich full results with schema context and lexical diagnostics (no API calls)
-ols4-embeddings-postprocess: $(OLS4_RESULTS)
+# Enrich results with schema context and lexical diagnostics (no API calls).
+# Uses local results if available, falls back to committed baseline.
+ols4-embeddings-postprocess:
 	$(RUN) python src/scripts/ols4_embeddings_postprocess.py \
 		--schema $(SOURCE_SCHEMA_PATH) \
-		--semantic-results $(OLS4_RESULTS) \
+		--semantic-results $(if $(wildcard $(OLS4_RESULTS)),$(OLS4_RESULTS),$(OLS4_BASELINE)) \
 		-o $(OLS4_ENRICHED) \
 		--summary-json $(OLS4_SUMMARY)
 
 # Post-process filtered to OBI only
-ols4-embeddings-postprocess-obi: $(OLS4_RESULTS)
+ols4-embeddings-postprocess-obi:
 	$(RUN) python src/scripts/ols4_embeddings_postprocess.py \
 		--schema $(SOURCE_SCHEMA_PATH) \
-		--semantic-results $(OLS4_RESULTS) \
+		--semantic-results $(if $(wildcard $(OLS4_RESULTS)),$(OLS4_RESULTS),$(OLS4_BASELINE)) \
 		--allowed-ontologies OBI \
 		-o local/ols4_embeddings_obi_enriched.tsv \
 		--summary-json local/ols4_embeddings_obi_summary.json
 
 # Post-process filtered to slots only (useful for property alignment analysis)
-ols4-embeddings-postprocess-slots: $(OLS4_RESULTS)
+ols4-embeddings-postprocess-slots:
 	$(RUN) python src/scripts/ols4_embeddings_postprocess.py \
 		--schema $(SOURCE_SCHEMA_PATH) \
-		--semantic-results $(OLS4_RESULTS) \
+		--semantic-results $(if $(wildcard $(OLS4_RESULTS)),$(OLS4_RESULTS),$(OLS4_BASELINE)) \
 		--subject-categories slot \
 		-o local/ols4_embeddings_slots_enriched.tsv \
 		--summary-json local/ols4_embeddings_slots_summary.json
+
+# ---------- Cleanup ----------
+
+ols4-embeddings-clean:
+	rm -f local/ols4_embeddings_*.tsv local/ols4_embeddings_*.json

--- a/nmdc_schema/ontology_alignment_prototype.py
+++ b/nmdc_schema/ontology_alignment_prototype.py
@@ -196,8 +196,9 @@ def _class_record(sv: SchemaView, class_name: str) -> SchemaElementRecord:
     for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
         mappings.extend(getattr(class_def, field_name, []) or [])
     existing_mappings = _sorted_mappings(mappings)
+    subject_id = class_def.class_uri or f"nmdc:{class_name}"
     return SchemaElementRecord(
-        subject_id=f"nmdc:{class_name}",
+        subject_id=subject_id,
         subject_label=class_def.title or class_name,
         subject_category="class",
         subject_description=class_def.description or "",
@@ -236,8 +237,9 @@ def _slot_record(sv: SchemaView, slot_name: str) -> SchemaElementRecord:
         for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
             range_mapping_sources.update(mapping_source(value) for value in (getattr(class_def, field_name, []) or []))
     existing_mappings = _sorted_mappings(mappings)
+    subject_id = slot_def.slot_uri or f"nmdc:{slot_name}"
     return SchemaElementRecord(
-        subject_id=f"nmdc:{slot_name}",
+        subject_id=subject_id,
         subject_label=slot_def.title or slot_name,
         subject_category="slot",
         subject_description=slot_def.description or "",
@@ -276,6 +278,11 @@ def _enum_record(sv: SchemaView, enum_name: str) -> SchemaElementRecord:
     )
 
 
+def _sanitize_pv_text(text: str) -> str:
+    """Sanitize permissible value text to produce valid CURIE-like identifiers."""
+    return re.sub(r"[^A-Za-z0-9._-]", "_", text)
+
+
 def _pv_record(enum_name: str, pv_name: str, pv: PermissibleValue) -> SchemaElementRecord:
     mappings = []
     for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
@@ -284,8 +291,9 @@ def _pv_record(enum_name: str, pv_name: str, pv: PermissibleValue) -> SchemaElem
         mappings.append(str(pv.meaning))
     existing_mappings = _sorted_mappings(mappings)
     owner_mapping_sources = tuple(sorted({mapping_source(value) for value in existing_mappings if mapping_source(value)}))
+    sanitized_pv = _sanitize_pv_text(pv_name)
     return SchemaElementRecord(
-        subject_id=f"nmdc:{enum_name}.{pv_name}",
+        subject_id=f"nmdc:{enum_name}.{sanitized_pv}",
         subject_label=pv.text or pv_name,
         subject_category="permissible_value",
         subject_description=pv.description or "",
@@ -542,7 +550,7 @@ def summarize_alignment_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "by_object_kind": {},
         "by_object_source": {},
         "strong_semantic_weak_lexical_by_source": {},
-        "structurally_supported_semantic_weak_lexical_by_source": {},
+        "strong_semantic_weak_lexical_structurally_supported_by_source": {},
     }
     for row in rows:
         classification = row["semantic_vs_lexical"]
@@ -559,7 +567,7 @@ def summarize_alignment_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
             bucket = summary["strong_semantic_weak_lexical_by_source"]
             bucket[source] = bucket.get(source, 0) + 1
         if structural_bucket == "strong_semantic_weak_lexical_structurally_supported":
-            bucket = summary["structurally_supported_semantic_weak_lexical_by_source"]
+            bucket = summary["strong_semantic_weak_lexical_structurally_supported_by_source"]
             bucket[source] = bucket.get(source, 0) + 1
     return summary
 

--- a/nmdc_schema/ontology_alignment_prototype.py
+++ b/nmdc_schema/ontology_alignment_prototype.py
@@ -1,0 +1,581 @@
+"""Helpers for comparing semantic alignment hits against lexical strength.
+
+This module is intentionally lightweight so it can run in the base nmdc-schema
+environment while supporting OLS4 result post-processing without rerunning the
+expensive semantic search.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+import requests
+from linkml_runtime.linkml_model.meta import PermissibleValue
+from linkml_runtime.utils.schemaview import SchemaView
+
+
+OLS4_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
+SCALAR_TYPES = {
+    "string",
+    "integer",
+    "float",
+    "double",
+    "decimal",
+    "boolean",
+    "date",
+    "datetime",
+    "time",
+    "uri",
+    "uriorcurie",
+    "ncname",
+    "objectidentifier",
+}
+CONTROLLED_TERM_RANGES = {
+    "OntologyClass",
+    "ControlledTermValue",
+    "ControlledIdentifiedTermValue",
+}
+
+
+@dataclass(frozen=True)
+class SchemaElementRecord:
+    """Minimal schema-side context for alignment review."""
+
+    subject_id: str
+    subject_label: str
+    subject_category: str
+    subject_description: str
+    element_name: str
+    range_name: str
+    range_kind: str
+    owners: tuple[str, ...]
+    owner_mapping_sources: tuple[str, ...]
+    range_mapping_sources: tuple[str, ...]
+    existing_mappings: tuple[str, ...]
+    existing_mapping_sources: tuple[str, ...]
+    expected_alignment_type: str
+
+
+@dataclass(frozen=True)
+class LexicalProfile:
+    """Simple local lexical similarity features."""
+
+    exact_label_match: bool
+    normalized_label_match: bool
+    token_jaccard: float
+    sequence_ratio: float
+    containment: float
+    lexical_score: float
+
+
+@dataclass(frozen=True)
+class OlsEntityMetadata:
+    """Minimal OLS-side metadata used for structural review."""
+
+    object_id: str
+    object_source: str
+    object_kind: str
+    iri: str
+    description: str
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text for rough lexical comparison."""
+    text = text or ""
+    text = text.replace("_", " ")
+    text = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", " ", text)
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return " ".join(text.split())
+
+
+def token_set(text: str) -> set[str]:
+    """Convert text to a normalized token set."""
+    normalized = normalize_text(text)
+    return set(normalized.split()) if normalized else set()
+
+
+def mapping_source(curie: str) -> str:
+    """Extract the prefix/source from a CURIE-like value."""
+    if not curie:
+        return ""
+    if ":" in curie:
+        return curie.split(":", 1)[0].upper()
+    return curie.upper()
+
+
+def lexical_profile(subject_label: str, object_label: str) -> LexicalProfile:
+    """Compute local lexical features for a candidate mapping."""
+    raw_subject = (subject_label or "").strip()
+    raw_object = (object_label or "").strip()
+    norm_subject = normalize_text(raw_subject)
+    norm_object = normalize_text(raw_object)
+
+    subject_tokens = token_set(raw_subject)
+    object_tokens = token_set(raw_object)
+    if subject_tokens or object_tokens:
+        token_jaccard = len(subject_tokens & object_tokens) / len(subject_tokens | object_tokens)
+    else:
+        token_jaccard = 0.0
+
+    sequence_ratio = SequenceMatcher(None, norm_subject, norm_object).ratio() if norm_subject or norm_object else 0.0
+
+    containment = 0.0
+    if subject_tokens and object_tokens:
+        containment = max(
+            len(subject_tokens & object_tokens) / len(subject_tokens),
+            len(subject_tokens & object_tokens) / len(object_tokens),
+        )
+
+    exact_label_match = raw_subject == raw_object and bool(raw_subject)
+    normalized_label_match = norm_subject == norm_object and bool(norm_subject)
+    lexical_score = max(
+        1.0 if exact_label_match else 0.0,
+        0.98 if normalized_label_match else 0.0,
+        token_jaccard,
+        sequence_ratio,
+        containment,
+    )
+    return LexicalProfile(
+        exact_label_match=exact_label_match,
+        normalized_label_match=normalized_label_match,
+        token_jaccard=token_jaccard,
+        sequence_ratio=sequence_ratio,
+        containment=containment,
+        lexical_score=lexical_score,
+    )
+
+
+def _sorted_mappings(mappings: list[str] | None) -> tuple[str, ...]:
+    values = mappings or []
+    return tuple(sorted({value for value in values if value}))
+
+
+def _sources_from_mappings(mappings: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted({mapping_source(value) for value in mappings if mapping_source(value)}))
+
+
+def _range_kind(sv: SchemaView, range_name: str) -> str:
+    if not range_name:
+        return "none"
+    lowered = range_name.lower()
+    if lowered in SCALAR_TYPES:
+        return "scalar"
+    if range_name in CONTROLLED_TERM_RANGES:
+        return "class_filler"
+    if range_name in sv.all_enums():
+        return "enum"
+    if range_name in sv.all_classes():
+        return "class"
+    if range_name in sv.all_types():
+        return "scalar"
+    return "unknown"
+
+
+def _expected_alignment_type(subject_category: str, range_kind: str) -> str:
+    if subject_category == "slot":
+        if range_kind in {"scalar"}:
+            return "property_like"
+        if range_kind in {"enum", "class", "class_filler"}:
+            return "class_filler"
+        return "ambiguous"
+    if subject_category in {"class", "permissible_value", "enum"}:
+        return "class_like"
+    return "ambiguous"
+
+
+def _class_record(sv: SchemaView, class_name: str) -> SchemaElementRecord:
+    class_def = sv.get_class(class_name)
+    mappings = []
+    for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+        mappings.extend(getattr(class_def, field_name, []) or [])
+    existing_mappings = _sorted_mappings(mappings)
+    return SchemaElementRecord(
+        subject_id=f"nmdc:{class_name}",
+        subject_label=class_def.title or class_name,
+        subject_category="class",
+        subject_description=class_def.description or "",
+        element_name=class_name,
+        range_name="",
+        range_kind="none",
+        owners=tuple(),
+        owner_mapping_sources=tuple(),
+        range_mapping_sources=tuple(),
+        existing_mappings=existing_mappings,
+        existing_mapping_sources=_sources_from_mappings(existing_mappings),
+        expected_alignment_type="class_like",
+    )
+
+
+def _slot_record(sv: SchemaView, slot_name: str) -> SchemaElementRecord:
+    slot_def = sv.induced_slot(slot_name)
+    mappings = []
+    for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+        mappings.extend(getattr(slot_def, field_name, []) or [])
+    owners = tuple(sorted(slot_def.domain_of or []))
+    owner_mapping_sources: set[str] = set()
+    for owner_name in owners:
+        owner_def = sv.get_class(owner_name)
+        for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+            owner_mapping_sources.update(mapping_source(value) for value in (getattr(owner_def, field_name, []) or []))
+    range_name = slot_def.range or ""
+    range_kind = _range_kind(sv, range_name)
+    range_mapping_sources: set[str] = set()
+    if range_kind == "enum":
+        enum_def = sv.get_enum(range_name)
+        for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+            range_mapping_sources.update(mapping_source(value) for value in (getattr(enum_def, field_name, []) or []))
+    elif range_kind == "class":
+        class_def = sv.get_class(range_name)
+        for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+            range_mapping_sources.update(mapping_source(value) for value in (getattr(class_def, field_name, []) or []))
+    existing_mappings = _sorted_mappings(mappings)
+    return SchemaElementRecord(
+        subject_id=f"nmdc:{slot_name}",
+        subject_label=slot_def.title or slot_name,
+        subject_category="slot",
+        subject_description=slot_def.description or "",
+        element_name=slot_name,
+        range_name=range_name,
+        range_kind=range_kind,
+        owners=owners,
+        owner_mapping_sources=tuple(sorted(filter(None, owner_mapping_sources))),
+        range_mapping_sources=tuple(sorted(filter(None, range_mapping_sources))),
+        existing_mappings=existing_mappings,
+        existing_mapping_sources=_sources_from_mappings(existing_mappings),
+        expected_alignment_type=_expected_alignment_type("slot", range_kind),
+    )
+
+
+def _enum_record(sv: SchemaView, enum_name: str) -> SchemaElementRecord:
+    enum_def = sv.get_enum(enum_name)
+    mappings = []
+    for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+        mappings.extend(getattr(enum_def, field_name, []) or [])
+    existing_mappings = _sorted_mappings(mappings)
+    return SchemaElementRecord(
+        subject_id=f"nmdc:{enum_name}",
+        subject_label=enum_def.title or enum_name,
+        subject_category="enum",
+        subject_description=enum_def.description or "",
+        element_name=enum_name,
+        range_name="",
+        range_kind="none",
+        owners=tuple(),
+        owner_mapping_sources=tuple(),
+        range_mapping_sources=tuple(),
+        existing_mappings=existing_mappings,
+        existing_mapping_sources=_sources_from_mappings(existing_mappings),
+        expected_alignment_type="class_like",
+    )
+
+
+def _pv_record(enum_name: str, pv_name: str, pv: PermissibleValue) -> SchemaElementRecord:
+    mappings = []
+    for field_name in ("exact_mappings", "close_mappings", "related_mappings", "narrow_mappings", "broad_mappings"):
+        mappings.extend(getattr(pv, field_name, []) or [])
+    if pv.meaning:
+        mappings.append(str(pv.meaning))
+    existing_mappings = _sorted_mappings(mappings)
+    owner_mapping_sources = tuple(sorted({mapping_source(value) for value in existing_mappings if mapping_source(value)}))
+    return SchemaElementRecord(
+        subject_id=f"nmdc:{enum_name}.{pv_name}",
+        subject_label=pv.text or pv_name,
+        subject_category="permissible_value",
+        subject_description=pv.description or "",
+        element_name=pv_name,
+        range_name="",
+        range_kind="none",
+        owners=(enum_name,),
+        owner_mapping_sources=owner_mapping_sources,
+        range_mapping_sources=tuple(),
+        existing_mappings=existing_mappings,
+        existing_mapping_sources=_sources_from_mappings(existing_mappings),
+        expected_alignment_type="class_like",
+    )
+
+
+def build_schema_index(schema_path: str | Path) -> dict[str, SchemaElementRecord]:
+    """Index nmdc schema elements by subject_id."""
+    sv = SchemaView(str(schema_path))
+    records: dict[str, SchemaElementRecord] = {}
+
+    for class_name in sv.all_classes().keys():
+        record = _class_record(sv, class_name)
+        records[record.subject_id] = record
+
+    for slot_name in sv.all_slots().keys():
+        record = _slot_record(sv, slot_name)
+        records[record.subject_id] = record
+
+    for enum_name, enum_def in sv.all_enums().items():
+        record = _enum_record(sv, enum_name)
+        records[record.subject_id] = record
+        for pv_name, pv in (enum_def.permissible_values or {}).items():
+            pv_record = _pv_record(enum_name, pv_name, pv)
+            records[pv_record.subject_id] = pv_record
+
+    return records
+
+
+def read_alignment_rows(path: str | Path) -> list[dict[str, str]]:
+    """Read a TSV of alignment rows."""
+    with Path(path).open() as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        return list(reader)
+
+
+def classify_alignment(
+    semantic_confidence: float,
+    lexical_score_value: float,
+    semantic_threshold: float,
+    lexical_threshold: float,
+) -> str:
+    """Classify the semantic/lexical relationship for one hit."""
+    if semantic_confidence >= semantic_threshold and lexical_score_value < lexical_threshold:
+        return "strong_semantic_weak_lexical"
+    if semantic_confidence >= semantic_threshold and lexical_score_value >= lexical_threshold:
+        return "strong_semantic_strong_lexical"
+    if semantic_confidence < semantic_threshold and lexical_score_value >= lexical_threshold:
+        return "weak_semantic_strong_lexical"
+    return "weak_semantic_weak_lexical"
+
+
+def parse_csv_option(value: str | None) -> set[str]:
+    """Parse a comma-separated CLI option into an uppercase set."""
+    if not value:
+        return set()
+    return {item.strip().upper() for item in value.split(",") if item.strip()}
+
+
+def ols_entity_metadata(
+    object_id: str,
+    object_source: str,
+    cache: dict[tuple[str, str], OlsEntityMetadata],
+) -> OlsEntityMetadata:
+    """Resolve minimal OLS metadata for a hit using exact CURIE search."""
+    cache_key = (object_id, object_source)
+    if cache_key in cache:
+        return cache[cache_key]
+
+    params = {"q": object_id, "queryFields": "obo_id", "exact": "true"}
+    metadata = OlsEntityMetadata(
+        object_id=object_id,
+        object_source=object_source,
+        object_kind="class",
+        iri="",
+        description="",
+    )
+    try:
+        response = requests.get(OLS4_SEARCH_URL, params=params, timeout=30)
+        response.raise_for_status()
+        docs = response.json().get("response", {}).get("docs", [])
+        for doc in docs:
+            prefix = (doc.get("ontology_prefix") or "").upper()
+            if prefix == object_source.upper() and doc.get("obo_id") == object_id:
+                metadata = OlsEntityMetadata(
+                    object_id=object_id,
+                    object_source=object_source,
+                    object_kind=(doc.get("type") or "class").lower(),
+                    iri=doc.get("iri") or "",
+                    description=" ".join(doc.get("description") or []),
+                )
+                break
+    except requests.RequestException:
+        pass
+
+    cache[cache_key] = metadata
+    return metadata
+
+
+def match_type(subject_category: str, object_kind: str) -> str:
+    """Derive a coarse match type."""
+    normalized_object_kind = object_kind or "class"
+    if subject_category == "class":
+        return f"class->{normalized_object_kind}"
+    if subject_category == "slot":
+        return f"slot->{normalized_object_kind}"
+    if subject_category == "permissible_value":
+        return f"pv->{normalized_object_kind}"
+    if subject_category == "enum":
+        return f"enum->{normalized_object_kind}"
+    return f"{subject_category}->{normalized_object_kind}"
+
+
+def structural_support(record: SchemaElementRecord | None, metadata: OlsEntityMetadata) -> tuple[bool, str]:
+    """Estimate whether a candidate is structurally plausible from the NMDC side."""
+    if record is None:
+        return (False, "missing_schema_record")
+
+    if record.subject_category == "class":
+        return (metadata.object_kind == "class", "class_to_class" if metadata.object_kind == "class" else "class_to_nonclass")
+
+    if record.subject_category == "permissible_value":
+        source_overlap = metadata.object_source in set(record.existing_mapping_sources) | set(record.owner_mapping_sources)
+        if metadata.object_kind != "class":
+            return (False, "pv_to_nonclass")
+        return (source_overlap, "pv_source_overlap" if source_overlap else "pv_source_mismatch")
+
+    if record.subject_category == "enum":
+        source_overlap = metadata.object_source in set(record.existing_mapping_sources)
+        if metadata.object_kind != "class":
+            return (False, "enum_to_nonclass")
+        return (source_overlap, "enum_source_overlap" if source_overlap else "enum_source_mismatch")
+
+    if record.subject_category == "slot":
+        source_overlap = metadata.object_source in set(record.existing_mapping_sources) | set(record.owner_mapping_sources) | set(
+            record.range_mapping_sources
+        )
+        if metadata.object_kind == "property":
+            if record.expected_alignment_type == "property_like":
+                return (True, "slot_property_scalar_fit")
+            return (source_overlap, "slot_property_source_overlap" if source_overlap else "slot_property_mismatch")
+        if metadata.object_kind == "class":
+            if record.expected_alignment_type == "class_filler":
+                return (True, "slot_class_range_fit")
+            if source_overlap:
+                return (True, "slot_class_source_overlap")
+            return (False, "slot_class_scalar_mismatch")
+        return (False, "slot_unknown_object_kind")
+
+    return (False, "unsupported_subject_category")
+
+
+def enrich_alignment_rows(
+    rows: list[dict[str, str]],
+    schema_index: dict[str, SchemaElementRecord],
+    semantic_threshold: float,
+    lexical_threshold: float,
+    allowed_ontologies: set[str] | None = None,
+    excluded_ontologies: set[str] | None = None,
+    allowed_subject_categories: set[str] | None = None,
+    resolve_ols_metadata: bool = False,
+) -> list[dict[str, Any]]:
+    """Join semantic hits to schema metadata, lexical features, and structural support."""
+    enriched: list[dict[str, Any]] = []
+    metadata_cache: dict[tuple[str, str], OlsEntityMetadata] = {}
+    allowed_ontologies = allowed_ontologies or set()
+    excluded_ontologies = excluded_ontologies or set()
+    allowed_subject_categories = {item.lower() for item in (allowed_subject_categories or set())}
+
+    for row in rows:
+        record = schema_index.get(row["subject_id"])
+        source = (row.get("object_source") or "").upper()
+        subject_category = (row.get("subject_category") or "").lower()
+
+        if allowed_ontologies and source not in allowed_ontologies:
+            continue
+        if excluded_ontologies and source in excluded_ontologies:
+            continue
+        if allowed_subject_categories and subject_category not in allowed_subject_categories:
+            continue
+
+        profile = lexical_profile(row.get("subject_label", ""), row.get("object_label", ""))
+        semantic_confidence = float(row.get("confidence", 0.0) or 0.0)
+        classification = classify_alignment(
+            semantic_confidence=semantic_confidence,
+            lexical_score_value=profile.lexical_score,
+            semantic_threshold=semantic_threshold,
+            lexical_threshold=lexical_threshold,
+        )
+        metadata = (
+            ols_entity_metadata(row.get("object_id", ""), source, metadata_cache)
+            if resolve_ols_metadata
+            else OlsEntityMetadata(
+                object_id=row.get("object_id", ""),
+                object_source=source,
+                object_kind="class",
+                iri="",
+                description="",
+            )
+        )
+        structural_fit, structural_reason = structural_support(record, metadata)
+        match_type_value = match_type(subject_category, metadata.object_kind)
+        enriched.append(
+            {
+                **row,
+                "semantic_confidence": semantic_confidence,
+                "lexical_score": round(profile.lexical_score, 4),
+                "token_jaccard": round(profile.token_jaccard, 4),
+                "sequence_ratio": round(profile.sequence_ratio, 4),
+                "containment": round(profile.containment, 4),
+                "exact_label_match": profile.exact_label_match,
+                "normalized_label_match": profile.normalized_label_match,
+                "semantic_vs_lexical": classification,
+                "match_type": match_type_value,
+                "object_kind": metadata.object_kind,
+                "object_iri": metadata.iri,
+                "object_description": metadata.description[:200],
+                "schema_range": record.range_name if record else "",
+                "schema_range_kind": record.range_kind if record else "",
+                "schema_expected_alignment_type": record.expected_alignment_type if record else "",
+                "schema_owners": "|".join(record.owners) if record else "",
+                "existing_mappings": "|".join(record.existing_mappings) if record else "",
+                "existing_mapping_sources": "|".join(record.existing_mapping_sources) if record else "",
+                "owner_mapping_sources": "|".join(record.owner_mapping_sources) if record else "",
+                "range_mapping_sources": "|".join(record.range_mapping_sources) if record else "",
+                "structural_fit": structural_fit,
+                "structural_reason": structural_reason,
+                "structural_bucket": (
+                    "strong_semantic_weak_lexical_structurally_supported"
+                    if classification == "strong_semantic_weak_lexical" and structural_fit
+                    else classification
+                ),
+            }
+        )
+    return enriched
+
+
+def summarize_alignment_rows(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a compact summary for reporting."""
+    summary: dict[str, Any] = {
+        "total_rows": len(rows),
+        "by_semantic_vs_lexical": {},
+        "by_structural_bucket": {},
+        "by_match_type": {},
+        "by_object_kind": {},
+        "by_object_source": {},
+        "strong_semantic_weak_lexical_by_source": {},
+        "structurally_supported_semantic_weak_lexical_by_source": {},
+    }
+    for row in rows:
+        classification = row["semantic_vs_lexical"]
+        structural_bucket = row["structural_bucket"]
+        source = row.get("object_source", "")
+        match_type_value = row.get("match_type", "")
+        object_kind = row.get("object_kind", "")
+        summary["by_semantic_vs_lexical"][classification] = summary["by_semantic_vs_lexical"].get(classification, 0) + 1
+        summary["by_structural_bucket"][structural_bucket] = summary["by_structural_bucket"].get(structural_bucket, 0) + 1
+        summary["by_match_type"][match_type_value] = summary["by_match_type"].get(match_type_value, 0) + 1
+        summary["by_object_kind"][object_kind] = summary["by_object_kind"].get(object_kind, 0) + 1
+        summary["by_object_source"][source] = summary["by_object_source"].get(source, 0) + 1
+        if classification == "strong_semantic_weak_lexical":
+            bucket = summary["strong_semantic_weak_lexical_by_source"]
+            bucket[source] = bucket.get(source, 0) + 1
+        if structural_bucket == "strong_semantic_weak_lexical_structurally_supported":
+            bucket = summary["structurally_supported_semantic_weak_lexical_by_source"]
+            bucket[source] = bucket.get(source, 0) + 1
+    return summary
+
+
+def write_tsv(rows: list[dict[str, Any]], output_path: str | Path) -> None:
+    """Write rows as TSV."""
+    if not rows:
+        Path(output_path).write_text("")
+        return
+    fieldnames = list(rows[0].keys())
+    with Path(output_path).open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_json(data: dict[str, Any], output_path: str | Path) -> None:
+    """Write summary JSON."""
+    Path(output_path).write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")

--- a/src/docs/ontology-alignment-ols4.md
+++ b/src/docs/ontology-alignment-ols4.md
@@ -101,11 +101,13 @@ The post-processor checks whether a match is structurally plausible given
 the NMDC element type:
 
 - **class -> class**: always supported
-- **slot -> class**: supported only if the slot's range is an enum or class
-  (i.e., it expects a `class_filler`). Scalar-range slots mapped to classes
-  get `slot_class_scalar_mismatch`.
+- **slot -> property**: supported if the slot has a scalar range
+  (`property_like`), or if there's ontology source overlap
+- **slot -> class**: supported if the slot's range is an enum or class
+  (`class_filler`), or if there's ontology source overlap. Scalar-range
+  slots with no source overlap get `slot_class_scalar_mismatch`.
 - **PV -> class**: supported if there's ontology source overlap with
-  existing mappings
+  existing mappings or owner mappings
 - **enum -> class**: supported if source overlap with existing mappings
 
 ### Key columns in the enriched TSV

--- a/src/docs/ontology-alignment-ols4.md
+++ b/src/docs/ontology-alignment-ols4.md
@@ -60,7 +60,7 @@ Enriches raw search results with schema context and lexical diagnostics.
 
 ```bash
 poetry run python src/scripts/ols4_embeddings_postprocess.py \
-  --semantic-results src/scripts/ols4_embeddings_results.tsv
+  --semantic-results assets/ontology_alignment/ols4_embeddings_results.tsv
 ```
 
 Key options:
@@ -162,7 +162,7 @@ All heavily-used prefixes (OBI, CHEBI, MS, NCIT, ENVO, GO, NCBITaxon) are covere
 
 ## Current results summary
 
-The committed baseline (`src/scripts/ols4_embeddings_results.tsv`) contains:
+The committed baseline (`assets/ontology_alignment/ols4_embeddings_results.tsv`) contains:
 - **45,940 rows** from **2,298 schema elements** across 210 ontologies
 - **2,284 rows** with confidence > 0.90
 - **1,959** strong semantic + strong lexical

--- a/src/scripts/ols4_embeddings_postprocess.py
+++ b/src/scripts/ols4_embeddings_postprocess.py
@@ -1,0 +1,114 @@
+"""Post-process OLS4 embeddings results with schema-aware diagnostics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from nmdc_schema.ontology_alignment_prototype import (
+    build_schema_index,
+    enrich_alignment_rows,
+    parse_csv_option,
+    read_alignment_rows,
+    summarize_alignment_rows,
+    write_json,
+    write_tsv,
+)
+
+
+@click.command()
+@click.option("--schema", default="src/schema/nmdc.yaml", show_default=True, help="Path to LinkML schema YAML")
+@click.option(
+    "--semantic-results",
+    required=True,
+    help="TSV of semantic candidates, e.g. ols4_embeddings_results.tsv",
+)
+@click.option(
+    "--output",
+    "-o",
+    default="local/ols4_embeddings_enriched.tsv",
+    show_default=True,
+    help="Output TSV path for enriched candidate rows",
+)
+@click.option(
+    "--summary-json",
+    default="local/ols4_embeddings_summary.json",
+    show_default=True,
+    help="Summary JSON path",
+)
+@click.option(
+    "--semantic-threshold",
+    default=0.90,
+    show_default=True,
+    help="Threshold for strong semantic confidence",
+)
+@click.option(
+    "--lexical-threshold",
+    default=0.45,
+    show_default=True,
+    help="Threshold below which lexical similarity is treated as weak",
+)
+@click.option(
+    "--allowed-ontologies",
+    default="",
+    help="Comma-separated ontology prefixes to keep, e.g. OBI,ENVO,CHMO",
+)
+@click.option(
+    "--excluded-ontologies",
+    default="",
+    help="Comma-separated ontology prefixes to exclude",
+)
+@click.option(
+    "--subject-categories",
+    default="",
+    help="Comma-separated subject categories to keep: class,slot,enum,permissible_value",
+)
+@click.option(
+    "--resolve-ols-metadata/--skip-ols-metadata",
+    default=False,
+    show_default=True,
+    help="Resolve per-hit OLS metadata to distinguish classes from properties",
+)
+def cli(
+    schema: str,
+    semantic_results: str,
+    output: str,
+    summary_json: str,
+    semantic_threshold: float,
+    lexical_threshold: float,
+    allowed_ontologies: str,
+    excluded_ontologies: str,
+    subject_categories: str,
+    resolve_ols_metadata: bool,
+) -> None:
+    """Enrich OLS4 semantic hits with schema context and lexical diagnostics."""
+    schema_index = build_schema_index(schema)
+    semantic_rows = read_alignment_rows(semantic_results)
+    enriched = enrich_alignment_rows(
+        rows=semantic_rows,
+        schema_index=schema_index,
+        semantic_threshold=semantic_threshold,
+        lexical_threshold=lexical_threshold,
+        allowed_ontologies=parse_csv_option(allowed_ontologies),
+        excluded_ontologies=parse_csv_option(excluded_ontologies),
+        allowed_subject_categories={item.lower() for item in parse_csv_option(subject_categories)},
+        resolve_ols_metadata=resolve_ols_metadata,
+    )
+
+    Path(output).parent.mkdir(parents=True, exist_ok=True)
+    Path(summary_json).parent.mkdir(parents=True, exist_ok=True)
+    write_tsv(enriched, output)
+
+    summary = summarize_alignment_rows(enriched)
+    summary["schema_elements_indexed"] = len(schema_index)
+    write_json(summary, summary_json)
+
+    click.echo(f"Indexed schema elements: {len(schema_index)}")
+    click.echo(f"Semantic candidates analyzed: {len(enriched)}")
+    click.echo(f"Wrote enriched TSV: {output}")
+    click.echo(f"Wrote summary JSON: {summary_json}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/src/scripts/ols4_embeddings_search.py
+++ b/src/scripts/ols4_embeddings_search.py
@@ -108,7 +108,10 @@ def extract_score(element: dict) -> str:
     """Extract the similarity score from an OLS4 result."""
     score = element.get("score")
     if score is not None:
-        return f"{score:.4f}"
+        try:
+            return f"{float(score):.4f}"
+        except (TypeError, ValueError):
+            return str(score)
     return ""
 
 
@@ -238,7 +241,7 @@ def main(
         format="%(levelname)s %(message)s",
     )
 
-    types = set(element_types.split(","))
+    types = {t.strip().lower() for t in element_types.split(",")}
     sv = SchemaView(schema)
     all_rows: list[dict] = []
     total_queries = 0

--- a/src/scripts/ols4_embeddings_search.py
+++ b/src/scripts/ols4_embeddings_search.py
@@ -12,7 +12,7 @@ See --help for options.
 
 import csv
 import logging
-import sys
+import re
 import time
 from pathlib import Path
 from typing import Optional
@@ -78,10 +78,11 @@ def extract_curie(element: dict) -> Optional[str]:
     short_form = element.get("shortForm")
     if short_form:
         return short_form
-    # Fall back to IRI
+    # Fall back to full IRI prefixed with "iri:" so downstream consumers
+    # can distinguish it from a real CURIE (intentional for traceability).
     iri = element.get("iri")
     if iri:
-        return iri
+        return f"iri:{iri}"
     return None
 
 
@@ -317,7 +318,8 @@ def main(
                 if skip_mapped and pv.meaning:
                     skipped += 1
                     continue
-                subject_id = f"nmdc:{enum_name}.{pv_text}"
+                sanitized_pv = re.sub(r"[^A-Za-z0-9._-]", "_", pv_text)
+                subject_id = f"nmdc:{enum_name}.{sanitized_pv}"
                 results = search_element(
                     subject_id,
                     pv_text,

--- a/src/scripts/ols4_embeddings_search.py
+++ b/src/scripts/ols4_embeddings_search.py
@@ -1,0 +1,357 @@
+"""Search OLS4 embeddings API for ontology term candidates matching nmdc-schema elements.
+
+Iterates classes, slots, enums, and permissible values from the schema,
+sends name + description to the OLS4 LLM search endpoint, and writes
+results as SSSOM-style TSV.
+
+Usage:
+    poetry run python src/scripts/ols4_embeddings_search.py [OPTIONS]
+
+See --help for options.
+"""
+
+import csv
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+import click
+import requests
+from linkml_runtime.utils.schemaview import SchemaView
+
+logger = logging.getLogger(__name__)
+
+OLS4_BASE = "https://www.ebi.ac.uk/ols4/api/v2"
+DEFAULT_MODEL = "llama-embed-nemotron-8b_pca512"
+DEFAULT_SCHEMA = "src/schema/nmdc.yaml"
+DEFAULT_ROWS = 5
+DEFAULT_DELAY = 0.5  # seconds between requests
+
+SSSOM_HEADER = [
+    "subject_id",
+    "subject_label",
+    "subject_category",
+    "subject_description",
+    "object_id",
+    "object_label",
+    "object_source",
+    "predicate_id",
+    "mapping_justification",
+    "confidence",
+    "comment",
+]
+
+
+def ols4_llm_search(
+    query: str,
+    model: str = DEFAULT_MODEL,
+    rows: int = DEFAULT_ROWS,
+    ontology: Optional[str] = None,
+    endpoint: str = "classes",
+) -> list[dict]:
+    """Call OLS4 embeddings search and return parsed results."""
+    if ontology:
+        url = f"{OLS4_BASE}/ontologies/{ontology}/{endpoint}/llm_search"
+    else:
+        url = f"{OLS4_BASE}/{endpoint}/llm_search"
+
+    params = {"q": query, "model": model, "rows": rows}
+
+    try:
+        resp = requests.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("elements", [])
+    except requests.RequestException as e:
+        logger.warning("OLS4 request failed for %r: %s", query[:60], e)
+        return []
+
+
+def extract_curie(element: dict) -> Optional[str]:
+    """Extract a CURIE from an OLS4 search result element."""
+    # OLS4 v2 uses camelCase field names
+    curie = element.get("curie")
+    if curie:
+        return curie
+    short_form = element.get("shortForm")
+    if short_form:
+        return short_form
+    # Fall back to IRI
+    iri = element.get("iri")
+    if iri:
+        return iri
+    return None
+
+
+def extract_label(element: dict) -> str:
+    """Extract label from an OLS4 result (may be a list)."""
+    label = element.get("label")
+    if isinstance(label, list):
+        return label[0] if label else ""
+    return label or ""
+
+
+def extract_ontology(element: dict) -> str:
+    """Extract the source ontology from an OLS4 result."""
+    ontology_id = element.get("ontologyId") or ""
+    if not ontology_id:
+        appears_in = element.get("appearsIn", [])
+        if appears_in:
+            ontology_id = appears_in[0]
+    return ontology_id.upper()
+
+
+def extract_score(element: dict) -> str:
+    """Extract the similarity score from an OLS4 result."""
+    score = element.get("score")
+    if score is not None:
+        return f"{score:.4f}"
+    return ""
+
+
+def build_query(name: str, description: Optional[str]) -> str:
+    """Build a search query from element name and description."""
+    # Expand CamelCase
+    expanded = ""
+    for i, ch in enumerate(name):
+        if ch.isupper() and i > 0 and name[i - 1].islower():
+            expanded += " "
+        expanded += ch
+    # Replace underscores
+    expanded = expanded.replace("_", " ")
+
+    if description:
+        # Truncate long descriptions to keep queries focused
+        desc = description[:200].strip()
+        return f"{expanded}: {desc}"
+    return expanded
+
+
+def search_element(
+    subject_id: str,
+    subject_label: str,
+    subject_category: str,
+    description: Optional[str],
+    model: str,
+    rows: int,
+    delay: float,
+    ontology: Optional[str],
+) -> list[dict]:
+    """Search OLS4 for one schema element and return SSSOM rows."""
+    query = build_query(subject_label, description)
+    results = ols4_llm_search(query, model=model, rows=rows, ontology=ontology)
+    time.sleep(delay)
+
+    sssom_rows = []
+    for hit in results:
+        curie = extract_curie(hit)
+        if not curie:
+            continue
+        label = extract_label(hit)
+        source = extract_ontology(hit)
+        score = extract_score(hit)
+        sssom_rows.append(
+            {
+                "subject_id": subject_id,
+                "subject_label": subject_label,
+                "subject_category": subject_category,
+                "subject_description": (description or "")[:200],
+                "object_id": curie,
+                "object_label": label,
+                "object_source": source,
+                "predicate_id": "skos:closeMatch",
+                "mapping_justification": "semapv:SemanticSimilarityThresholdMatching",
+                "confidence": score,
+                "comment": "",
+            }
+        )
+    return sssom_rows
+
+
+@click.command()
+@click.option(
+    "--schema",
+    default=DEFAULT_SCHEMA,
+    show_default=True,
+    help="Path to LinkML schema YAML",
+)
+@click.option(
+    "--output",
+    "-o",
+    default="ols4_embeddings_results.tsv",
+    show_default=True,
+    help="Output TSV file",
+)
+@click.option(
+    "--model",
+    default=DEFAULT_MODEL,
+    show_default=True,
+    help="OLS4 embedding model name",
+)
+@click.option(
+    "--rows",
+    default=DEFAULT_ROWS,
+    show_default=True,
+    help="Number of OLS4 results per query",
+)
+@click.option(
+    "--delay",
+    default=DEFAULT_DELAY,
+    show_default=True,
+    help="Seconds between API requests",
+)
+@click.option(
+    "--ontology",
+    default=None,
+    help="Restrict search to a specific ontology (e.g. 'obi', 'envo')",
+)
+@click.option(
+    "--element-types",
+    default="classes,slots,enums,pvs",
+    show_default=True,
+    help="Comma-separated element types to search",
+)
+@click.option(
+    "--skip-mapped/--include-mapped",
+    default=False,
+    show_default=True,
+    help="Skip elements that already have mappings",
+)
+@click.option("--verbose", "-v", is_flag=True, help="Verbose logging")
+def main(
+    schema: str,
+    output: str,
+    model: str,
+    rows: int,
+    delay: float,
+    ontology: Optional[str],
+    element_types: str,
+    skip_mapped: bool,
+    verbose: bool,
+):
+    """Search OLS4 embeddings for ontology terms matching nmdc-schema elements."""
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    types = set(element_types.split(","))
+    sv = SchemaView(schema)
+    all_rows: list[dict] = []
+    total_queries = 0
+    skipped = 0
+
+    def has_mappings(element) -> bool:
+        return bool(
+            getattr(element, "exact_mappings", None)
+            or getattr(element, "close_mappings", None)
+            or getattr(element, "broad_mappings", None)
+            or getattr(element, "related_mappings", None)
+            or getattr(element, "narrow_mappings", None)
+        )
+
+    # Classes
+    if "classes" in types:
+        classes = sv.all_classes()
+        logger.info("Searching %d classes...", len(classes))
+        for name, cls in classes.items():
+            if skip_mapped and has_mappings(cls):
+                skipped += 1
+                continue
+            curie = cls.class_uri or f"nmdc:{name}"
+            results = search_element(
+                curie, name, "class", cls.description, model, rows, delay, ontology
+            )
+            all_rows.extend(results)
+            total_queries += 1
+            if total_queries % 50 == 0:
+                logger.info("  ...%d queries done, %d results so far", total_queries, len(all_rows))
+
+    # Slots
+    if "slots" in types:
+        all_slots = sv.all_slots()
+        logger.info("Searching %d slots...", len(all_slots))
+        for name, slot in all_slots.items():
+            if skip_mapped and has_mappings(slot):
+                skipped += 1
+                continue
+            curie = slot.slot_uri or f"nmdc:{name}"
+            results = search_element(
+                curie, name, "slot", slot.description, model, rows, delay, ontology
+            )
+            all_rows.extend(results)
+            total_queries += 1
+            if total_queries % 50 == 0:
+                logger.info("  ...%d queries done, %d results so far", total_queries, len(all_rows))
+
+    # Enums
+    if "enums" in types:
+        all_enums = sv.all_enums()
+        logger.info("Searching %d enums...", len(all_enums))
+        for name, enum in all_enums.items():
+            if skip_mapped and has_mappings(enum):
+                skipped += 1
+                continue
+            curie = f"nmdc:{name}"
+            results = search_element(
+                curie, name, "enum", enum.description, model, rows, delay, ontology
+            )
+            all_rows.extend(results)
+            total_queries += 1
+            if total_queries % 50 == 0:
+                logger.info("  ...%d queries done, %d results so far", total_queries, len(all_rows))
+
+    # Permissible values
+    if "pvs" in types:
+        all_enums = sv.all_enums()
+        pv_count = sum(
+            len(e.permissible_values) for e in all_enums.values() if e.permissible_values
+        )
+        logger.info("Searching %d permissible values...", pv_count)
+        for enum_name, enum in all_enums.items():
+            if not enum.permissible_values:
+                continue
+            for pv_text, pv in enum.permissible_values.items():
+                if skip_mapped and pv.meaning:
+                    skipped += 1
+                    continue
+                subject_id = f"nmdc:{enum_name}.{pv_text}"
+                results = search_element(
+                    subject_id,
+                    pv_text,
+                    "permissible_value",
+                    pv.description,
+                    model,
+                    rows,
+                    delay,
+                    ontology,
+                )
+                all_rows.extend(results)
+                total_queries += 1
+                if total_queries % 50 == 0:
+                    logger.info(
+                        "  ...%d queries done, %d results so far",
+                        total_queries,
+                        len(all_rows),
+                    )
+
+    # Write output
+    output_path = Path(output)
+    with output_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=SSSOM_HEADER, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(all_rows)
+
+    logger.info(
+        "Done. %d queries, %d results written to %s (skipped %d already-mapped)",
+        total_queries,
+        len(all_rows),
+        output_path,
+        skipped,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ontology_alignment_prototype.py
+++ b/tests/test_ontology_alignment_prototype.py
@@ -1,0 +1,122 @@
+from nmdc_schema.ontology_alignment_prototype import (
+    OlsEntityMetadata,
+    SchemaElementRecord,
+    classify_alignment,
+    lexical_profile,
+    match_type,
+    normalize_text,
+    structural_support,
+)
+
+
+def test_normalize_text_splits_camel_case_and_underscores():
+    assert normalize_text("LibraryPreparation_Kit") == "library preparation kit"
+
+
+def test_lexical_profile_detects_strong_lexical_match():
+    profile = lexical_profile("ProcessedSample", "processed specimen")
+    assert profile.lexical_score >= 0.45
+    assert profile.containment > 0
+
+
+def test_lexical_profile_detects_weak_lexical_match():
+    profile = lexical_profile("FunctionalAnnotation", "employment status")
+    assert profile.lexical_score < 0.45
+
+
+def test_classify_alignment_flags_semantic_only_hits():
+    classification = classify_alignment(
+        semantic_confidence=0.93,
+        lexical_score_value=0.21,
+        semantic_threshold=0.90,
+        lexical_threshold=0.45,
+    )
+    assert classification == "strong_semantic_weak_lexical"
+
+
+def test_match_type_slot_to_class():
+    assert match_type("slot", "class") == "slot->class"
+
+
+def test_structural_support_for_scalar_slot_to_class_is_false():
+    record = SchemaElementRecord(
+        subject_id="nmdc:test_slot",
+        subject_label="test_slot",
+        subject_category="slot",
+        subject_description="",
+        element_name="test_slot",
+        range_name="string",
+        range_kind="scalar",
+        owners=("Study",),
+        owner_mapping_sources=tuple(),
+        range_mapping_sources=tuple(),
+        existing_mappings=tuple(),
+        existing_mapping_sources=tuple(),
+        expected_alignment_type="property_like",
+    )
+    metadata = OlsEntityMetadata(
+        object_id="OBI:0000066",
+        object_source="OBI",
+        object_kind="class",
+        iri="http://purl.obolibrary.org/obo/OBI_0000066",
+        description="investigation",
+    )
+    supported, reason = structural_support(record, metadata)
+    assert supported is False
+    assert reason == "slot_class_scalar_mismatch"
+
+
+def test_structural_support_for_enum_backed_slot_to_class_is_true():
+    record = SchemaElementRecord(
+        subject_id="nmdc:test_slot",
+        subject_label="test_slot",
+        subject_category="slot",
+        subject_description="",
+        element_name="test_slot",
+        range_name="InstrumentModelEnum",
+        range_kind="enum",
+        owners=("DataGeneration",),
+        owner_mapping_sources=("OBI",),
+        range_mapping_sources=tuple(),
+        existing_mappings=tuple(),
+        existing_mapping_sources=tuple(),
+        expected_alignment_type="class_filler",
+    )
+    metadata = OlsEntityMetadata(
+        object_id="OBI:0002630",
+        object_source="OBI",
+        object_kind="class",
+        iri="http://purl.obolibrary.org/obo/OBI_0002630",
+        description="instrument model term",
+    )
+    supported, reason = structural_support(record, metadata)
+    assert supported is True
+    assert reason == "slot_class_range_fit"
+
+
+def test_structural_support_for_pv_without_source_overlap_is_false():
+    record = SchemaElementRecord(
+        subject_id="nmdc:MassSpectrometryEnum.metabolome",
+        subject_label="metabolome",
+        subject_category="permissible_value",
+        subject_description="",
+        element_name="metabolome",
+        range_name="",
+        range_kind="none",
+        owners=("MassSpectrometryEnum",),
+        owner_mapping_sources=tuple(),
+        range_mapping_sources=tuple(),
+        existing_mappings=tuple(),
+        existing_mapping_sources=tuple(),
+        expected_alignment_type="class_like",
+    )
+    metadata = OlsEntityMetadata(
+        object_id="OBI:0000366",
+        object_source="OBI",
+        object_kind="class",
+        iri="http://purl.obolibrary.org/obo/OBI_0000366",
+        description="metabolite profiling assay",
+    )
+    supported, reason = structural_support(record, metadata)
+    assert supported is False
+    assert reason == "pv_source_mismatch"


### PR DESCRIPTION
## Series

This is part 1 of 3 PRs that add ontology alignment tooling to nmdc-schema:
1. **#2916** — Registry counts: which ontologies are in which sources
2. **#2909** (this PR) — OLS4 retrieval: search schema elements against OLS4 embeddings, produce ranked candidates
3. **#2910** — Comparison: evaluate OLS4 candidates against LinkML-ecosystem alternatives (oaklib, linkml-store, BioPortal)

## What this gives contributors

`make ols4-embeddings-postprocess` takes the committed baseline and produces a ranked, filtered list of candidate ontology mappings for every class, slot, enum, and permissible value in nmdc-schema. No API keys needed, runs in seconds.

When a contributor needs to find an OBI mapping for a new slot, or wants to know which schema elements lack ontological grounding, the output answers those questions directly — filtered by ontology, ranked by confidence, with structural plausibility checks that flag whether a match actually makes sense given the element type and range.

`make ols4-embeddings-search` regenerates the baseline from the OLS4 API (~19 min). `make ols4-embeddings-smoke` runs a quick OBI-only test in 30 seconds.

## What changed

- `src/scripts/ols4_embeddings_search.py` — queries OLS4 LLM embeddings API for all schema elements
- `src/scripts/ols4_embeddings_postprocess.py` — enriches results with schema context, lexical diagnostics, structural plausibility
- `nmdc_schema/ontology_alignment_prototype.py` — shared analysis module (schema indexing, enrichment, bucketing)
- `assets/ontology_alignment/ols4_embeddings_results.tsv` — committed baseline (45,940 candidates from 2,298 elements)
- `makefiles/ontology-alignment.Makefile` — all Make targets with cleanup
- `src/docs/ontology-alignment-ols4.md` — usage guide, interpretation, API reference

## Key numbers from the baseline

- 45,940 candidate rows across 210 ontologies
- 2,284 rows with confidence > 0.90
- 1,959 strong semantic + strong lexical (expected matches)
- 325 strong semantic + weak lexical (novel discovery candidates)
- 437 OBI matches in the raw candidate set

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>