### PR TITLE
Add ontology governance current-state document

### DIFF
--- a/docs/ontology-governance-current-state.md
+++ b/docs/ontology-governance-current-state.md
@@ -18,10 +18,12 @@ The closest thing to a formal policy statement is from closed issue
 
 ## How prefixes work in this schema
 
-The `prefixes:` block in `src/schema/nmdc.yaml` is the **operational allowlist**.
-Any CURIE used in a `meaning:`, mapping, or `id_prefixes:` declaration must resolve
-through a declared prefix. There is no `default_curi_maps:` — resolution depends
-entirely on what is explicitly declared.
+The effective **operational allowlist** of prefixes is the union of all `prefixes:`
+blocks across the materialized schema (the root `src/schema/nmdc.yaml` plus its
+imported modules such as `src/schema/core.yaml`). Any CURIE used in a `meaning:`,
+mapping, or `id_prefixes:` declaration must resolve through one of these declared
+prefixes. There is no `default_curi_maps:` — resolution depends entirely on what
+is explicitly declared somewhere in the schema, not on any implicit or external defaults.
 
 There are three separate enforcement contexts:
 
@@ -75,7 +77,7 @@ These prefixes are used throughout the schema without documented restrictions.
 | `CHMO` | `http://purl.obolibrary.org/obo/CHMO_` | Yes | 3 mappings — chemical methods |
 | `BFO` | `http://purl.obolibrary.org/obo/BFO_` | Yes | Declared; ~3 indirect references via OBI |
 | `MS` | `http://purl.obolibrary.org/obo/MS_` | Yes | 8 `meaning:` + 11 mappings — mass spectrometry terms |
-| `TAXRANK` | bioregistry | Yes | 7 mappings — taxonomic ranks |
+| `TAXRANK` | `http://purl.obolibrary.org/obo/TAXRANK_` | Yes | 7 mappings — taxonomic ranks; prefix declared in `core.yaml` |
 
 #### Scoped (inline comments limit where they may be used)
 
@@ -116,8 +118,10 @@ One `meaning: CFo000000033` reference survived in a commented-out slot — not a
 
 These are identifier namespaces used in `has_function` and related slots.
 They are not ontologies in the semantic grounding sense.
-The `has_function` slot enforces these prefixes via an explicit regex pattern
-(the only place in the schema where ontology prefix is actually machine-enforced).
+The `has_function` slot enforces these prefixes via an explicit regex pattern,
+making it one of the few places in the schema where identifier prefix is
+machine-enforced (alongside MIxS structured patterns such as `NCBITaxon:\d+`
+used in taxon-bearing fields).
 
 `KEGG_PATHWAY`, `KEGG.REACTION`, `RHEA`, `MetaCyc`, `EC`, `GO`, `MetaNetX`,
 `SEED`, `KEGG.ORTHOLOGY`, `EGGNOG`, `PFAM`, `TIGRFAM`, `SUPFAM`, `CATH`,


### PR DESCRIPTION
## Summary

Adds `docs/ontology-governance-current-state.md` — a descriptive account of how nmdc-schema currently handles ontology references. This is a **current-state doc, not a policy doc**. It makes no new decisions.

Addresses the long-standing documentation gap in #1132 and #2921. Policy decisions still need to happen in #1848.

## What the doc covers

- **How prefixes work** — three enforcement contexts (schema build, data validation, JSON-LD/RDF), with a table of what breaks when a prefix is undeclared
- **Four prefix categories** — ontology terms / functional annotation DBs / data source identifiers / technical debt placeholders
- **De facto ontology tiers** — broadly used (OBI, CHEBI, ENVO...) / scoped with inline comments (NCIT, GENEPIO, OMIT...) / needed but undeclared (COB) / explicitly rejected (ChemFOnt)
- **Enforcement levels** — what is actually machine-enforced (the `has_function` regex is the only hard enforcement of ontology scope) vs. advisory (scoping comments, OBO preference)
- **Where ontology terms appear** — `meaning:`, mappings, `class_uri:`, `id_prefixes:`, data values — and what each implies
- **NMDC-specific notes** — env triad, PlannedProcess/COB migration, FMA special case
- **Active alignment work** — which open issues are landscape surveys vs. which need policy first
- **Eight open policy questions** for #1848

## What this does NOT do

- Does not make any grounding decisions
- Does not add or remove any prefixes
- Does not close #1132 or #1848 (those need policy decisions)
- Does not change any schema YAML

## Related issues

Closes part of #2921 (current-state doc step).

Informs / feeds into:
- #1132 — preferred ontologies review
- #1848 — ontology usage guidelines (policy questions listed in the doc)
- #2906 — OBI/PROV/BFO audit
- #2907 / #2908 / #2915 — embeddings landscape survey
- #2912 — MS/chromatography grounding (needs policy before proceeding)
- #2913 — axiom decomposition (needs policy)
- #2917 — PV label filtering (needs policy)
- #2918 — property-oriented retrieval (needs policy)
- #2843 — PlannedProcess COB migration