### PR TITLE
Restrict WFE `id` suffixes and update migrator to validate DOIs and detect duplicate biosample `name`s

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -28,21 +28,13 @@ class Migrator(MigratorBase):
               as a performance improvement.
         """
 
-        # Confirm all DOIs in all studies' `associated_dois` fields conform to the new schema,
-        # which requires that the "10" be followed by a "." character (not just _any_ character).
+        # Validate the format of DOIs in studies.
         self.adapter.do_for_each_document(
             collection_name="study_set",
-            action=self.validate_associated_dois,
+            action=self.validate_study_fields_containing_dois,
         )
 
-        # Confirm all DOIs in the following fields (all of which are optional, single-values, string
-        # fields) of all biosamples confirm to the new schema:
-        # - salinity_meth
-        # - micro_biomass_c_meth
-        # - micro_biomass_n_meth
-        # - non_microb_biomass_method
-        # - org_nitro_method
-        #
+        # Validate the format of DOIs in biosamples.
         self.adapter.do_for_each_document(
             collection_name="biosample_set",
             action=self.validate_biosample_fields_containing_dois,
@@ -64,29 +56,33 @@ class Migrator(MigratorBase):
         # Confirm no study has multiple associated biosamples having the same name.
         self.fail_if_any_study_has_duplicate_biosample_names()
 
-    def validate_associated_dois(self, study: dict) -> None:
+    def validate_study_fields_containing_dois(self, study: dict) -> None:
         r"""
-        Validates the format of each DOI in the specified study's `associated_dois` field.
+        Validates the format of the `doi_value` value of each `Doi` instance, if any, in
+        the specified study's `associated_dois` field.
+
+        Reference: https://microbiomedata.github.io/nmdc-schema/doi_value/
 
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
         >>> database = {'study_set': [
-        ...     {'id': 'nmdc:sty-00-1', 'associated_dois': ['doi:10.1234/abc', 'doi:10.5678/def']},
-        ...     {'id': 'nmdc:sty-00-2', 'associated_dois': ['doi:10.1234/abc', 'doi:10_5678/def']},
+        ...     {'id': 'nmdc:sty-00-1', 'associated_dois': [{'doi_value': 'doi:10.1234/abc'}]},
+        ...     {'id': 'nmdc:sty-00-2', 'associated_dois': [{'doi_value': 'doi:10_1234/abc'}]},
         ...     {'id': 'nmdc:sty-00-3'}
         ... ]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
-        >>> m.validate_associated_dois(database['study_set'][0])  # valid
-        >>> m.validate_associated_dois(database['study_set'][1])  # invalid: second DOI has invalid format
+        >>> m.validate_study_fields_containing_dois(database['study_set'][0])  # valid
+        >>> m.validate_study_fields_containing_dois(database['study_set'][1])  # invalid: doi_value has invalid format
         Traceback (most recent call last):
         ...
-        ValueError: Study nmdc:sty-00-2 has an associated DOI having an invalid format: doi:10_5678/def
-        >>> m.validate_associated_dois(database['study_set'][2])  # valid: no associated DOIs
+        ValueError: Study nmdc:sty-00-2 has an associated DOI whose value has an invalid format: doi:10_1234/abc
+        >>> m.validate_study_fields_containing_dois(database['study_set'][2])  # valid: no associated_dois field
         """
 
         if "associated_dois" in study:
-            for doi in study["associated_dois"]:
+            for doi_instance in study["associated_dois"]:
+                doi = doi_instance["doi_value"]
                 if not isinstance(doi, str) or not re.match(self._target_doi_pattern, doi):
-                    raise ValueError(f"Study {study['id']} has an associated DOI having an invalid format: {doi}")
+                    raise ValueError(f"Study {study['id']} has an associated DOI whose value has an invalid format: {doi}")
 
     def validate_biosample_fields_containing_dois(self, biosample: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -87,20 +87,22 @@ class Migrator(MigratorBase):
     def validate_biosample_fields_containing_dois(self, biosample: dict) -> None:
         r"""
         Validates the format of each DOI in the specified biosample's fields that contain DOIs.
+        Distinguishes a DOI from a PMID and a URL by its prefix (out of those three kinds of
+        strings, only a DOI can begin with `doi:`—in fact, it _must_ begin with that prefix).
 
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
         >>> database = {'biosample_set': [
         ...     {'id': 'nmdc:bsm-00-1', 'salinity_meth': 'doi:10.1234/abc'},
         ...     {'id': 'nmdc:bsm-00-2', 'salinity_meth': 'doi:10_1234/abc'},
-        ...     {'id': 'nmdc:bsm-00-3'}
+        ...     {'id': 'nmdc:bsm-00-3', 'salinity_meth': 'foobarbaz'},
         ... ]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
         >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][0])  # valid
-        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][1])  # invalid: salinity_meth has invalid format
+        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][1])  # invalid: DOI has invalid format
         Traceback (most recent call last):
         ...
         ValueError: Biosample nmdc:bsm-00-2 has a salinity_meth DOI having an invalid format: doi:10_1234/abc
-        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][2])  # valid: no fields containing DOI
+        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][2])  # ignored by this function
         """
 
         names_of_fields_that_can_contain_doi = [
@@ -113,9 +115,12 @@ class Migrator(MigratorBase):
 
         for field_name in names_of_fields_that_can_contain_doi:
             if field_name in biosample:
-                doi = biosample[field_name]
-                if not isinstance(doi, str) or not re.match(self._target_doi_pattern, doi):
-                    raise ValueError(f"Biosample {biosample['id']} has a {field_name} DOI having an invalid format: {doi}")
+                potential_doi: str = biosample[field_name]
+                # Check whether the string begins with "doi:" — otherwise, we'll ignore it
+                if potential_doi.startswith("doi:"):
+                    doi = potential_doi
+                    if not re.match(self._target_doi_pattern, doi):
+                        raise ValueError(f"Biosample {biosample['id']} has a {field_name} DOI having an invalid format: {doi}")
 
     def validate_biosample_name(self, biosample: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -1,3 +1,5 @@
+from typing import Dict, List
+
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
@@ -7,9 +9,23 @@ class Migrator(MigratorBase):
     _from_version = "11.17.1"
     _to_version = "11.18.0"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Initialize a map from study ID to a list of names of that study's associated biosamples.
+        self.map_from_study_id_to_biosample_names: Dict[str, List[str]] = {}
+
     def upgrade(self, commit_changes: bool = False) -> None:
         r"""
         Migrates the database from conforming to the original schema, to conforming to the new schema.
+
+        This does three things:
+        1. Validates that each biosample has a name that is a string.
+        2. Builds a map from study ID to the list of names of that study's associated biosamples.
+        3. Validates that no study has multiple associated biosamples having the same name.
+
+        We could, technically, do all of this in a single pass through the collection. We opted to
+        split it into multiple passes to facilitate testing.
         """
 
         self.adapter.do_for_each_document(
@@ -17,22 +33,80 @@ class Migrator(MigratorBase):
             action=self.validate_biosample_name,
         )
 
+        self.adapter.do_for_each_document(
+            collection_name="biosample_set",
+            action=self.add_biosample_name_to_map_of_study_id_to_biosample_names,
+        )
+
+        self.fail_if_any_study_has_duplicate_biosample_names()
+
     def validate_biosample_name(self, biosample: dict) -> None:
         r"""
         Validates the name of the specified biosample.
 
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
-        >>> database = {'biosample_set': [{'id': 'b1', 'name': 'sample1'}, {'id': 'b2', 'name': 123}, {'id': 'b3'}]}
+        >>> database = {'biosample_set': [{'id': 'nmdc:bsm-00-1', 'name': 'sample1'}, {'id': 'nmdc:bsm-00-2', 'name': 123}, {'id': 'nmdc:bsm-00-3'}]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
         >>> m.validate_biosample_name(database['biosample_set'][0])  # valid
         >>> m.validate_biosample_name(database['biosample_set'][1])  # invalid: non-string
         Traceback (most recent call last):
         ...
-        ValueError: Biosample b2 lacks a string name
+        ValueError: Biosample nmdc:bsm-00-2 lacks a string name
         >>> m.validate_biosample_name(database['biosample_set'][2])  # invalid: missing
         Traceback (most recent call last):
         ...
-        ValueError: Biosample b3 lacks a string name
+        ValueError: Biosample nmdc:bsm-00-3 lacks a string name
         """
         if "name" not in biosample or not isinstance(biosample["name"], str):
             raise ValueError(f"Biosample {biosample['id']} lacks a string name")
+
+    def add_biosample_name_to_map_of_study_id_to_biosample_names(self, biosample: dict) -> None:
+        r"""
+        Adds the name of the specified biosample to the map from study ID to biosample names.
+        
+        Note: Once this has been invoked for each biosample, the resulting map can be used to
+              check for duplicate biosample names within each study.
+
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> database = {'biosample_set': [
+        ...     {'id': 'nmdc:bsm-00-1', 'name': 'apple', 'associated_studies': ['nmdc:sty-00-1', 'nmdc:sty-00-2']},
+        ...     {'id': 'nmdc:bsm-00-2', 'name': 'banana', 'associated_studies': ['nmdc:sty-00-1']},
+        ...     {'id': 'nmdc:bsm-00-3', 'name': 'apple', 'associated_studies': ['nmdc:sty-00-2']}
+        ... ]}
+        >>> m = Migrator(adapter=DictionaryAdapter(database=database))
+        >>> m.add_biosample_name_to_map_of_study_id_to_biosample_names(database['biosample_set'][0])
+        >>> m.add_biosample_name_to_map_of_study_id_to_biosample_names(database['biosample_set'][1])
+        >>> m.add_biosample_name_to_map_of_study_id_to_biosample_names(database['biosample_set'][2])
+        >>> m.map_from_study_id_to_biosample_names
+        {'nmdc:sty-00-1': ['apple', 'banana'], 'nmdc:sty-00-2': ['apple', 'apple']}
+        """
+
+        study_ids = biosample["associated_studies"]
+        name = biosample["name"]
+        for study_id in study_ids:
+
+            # Initialize this study's list, if necessary.
+            if study_id not in self.map_from_study_id_to_biosample_names:
+                self.map_from_study_id_to_biosample_names[study_id] = []
+            
+            # Add this biosample's name to the list.
+            self.map_from_study_id_to_biosample_names[study_id].append(name)
+
+    def fail_if_any_study_has_duplicate_biosample_names(self) -> None:
+        r"""
+        Raises an exception if any study has multiple biosamples that have the same name,
+        according to the map from study ID to biosample names.
+
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> m = Migrator(adapter=DictionaryAdapter(database={}))
+        >>> m.map_from_study_id_to_biosample_names = {'nmdc:sty-00-1': ['apple', 'banana'], 'nmdc:sty-00-2': ['apple', 'apple']}
+        >>> m.fail_if_any_study_has_duplicate_biosample_names()
+        Traceback (most recent call last):
+        ...
+        ValueError: Study nmdc:sty-00-2 has duplicate biosample names: {'apple'}
+        """
+
+        for study_id, biosample_names in self.map_from_study_id_to_biosample_names.items():
+            duplicate_biosample_names = {s for s in biosample_names if biosample_names.count(s) > 1}
+            if len(duplicate_biosample_names) > 0:
+                raise ValueError(f"Study {study_id} has duplicate biosample names: {duplicate_biosample_names}")

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -14,6 +14,15 @@ class Migrator(MigratorBase):
     # Reference: The definition of the slot named `doi_value`.
     _target_doi_pattern = r"^doi:10\.\d{2,9}/.*$"
 
+    # This is a variant of regex pattern defined in the schema we're migrating _to_.
+    # This variant is "agnostic" to the first part of the `id` value, and is only
+    # "picky" about the last part of the `id` value (i.e. the suffix).
+    #
+    # Reference: The definition of the `id_version` "settings" item, and the
+    #            materialized pattern used for `MetagenomeAnnotation.id`.
+    #
+    _target_workflow_execution_id_pattern = r"^.+\.[1-9]{1}[0-9]{0,}$"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -55,6 +64,12 @@ class Migrator(MigratorBase):
 
         # Confirm no study has multiple associated biosamples having the same name.
         self.fail_if_any_study_has_duplicate_biosample_names()
+
+        # Confirm that the suffix of the `id` of each `WorkflowExecution` conforms to the new schema.
+        self.adapter.do_for_each_document(
+            collection_name="workflow_execution_set",
+            action=self.validate_workflow_execution_id_suffix,
+        )
 
     def validate_study_fields_containing_dois(self, study: dict) -> None:
         r"""
@@ -194,3 +209,37 @@ class Migrator(MigratorBase):
             if len(duplicate_biosample_names) > 0:
                 sorted_names: list = sorted(duplicate_biosample_names)  # sorting helps with testing
                 raise ValueError(f"Study {study_id} has duplicate biosample names: {sorted_names}")
+
+    def validate_workflow_execution_id_suffix(self, workflow_execution: dict) -> None:
+        r"""
+        Validates that the suffix of the `id` of the specified `WorkflowExecution` conforms to the
+        new schema, which says that the first digit of the suffix cannot be 0.
+
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> database = {'workflow_execution_set': [
+        ...     {'id': 'nmdc:wfe-00-1'},
+        ...     {'id': 'nmdc:wfe-00-1.1'},
+        ...     {'id': 'nmdc:wfe-00-1.2'},
+        ...     {'id': 'nmdc:wfe-00-1.0'},
+        ...     {'id': 'nmdc:wfe-00-1.01'},
+        ...     {'id': 'nmdc:wfe-00-1.10'},
+        ... ]}
+        >>> m = Migrator(adapter=DictionaryAdapter(database=database))
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][0])  # invalid: no suffix
+        Traceback (most recent call last):
+        ...
+        ValueError: WorkflowExecution nmdc:wfe-00-1 has an invalid ID
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][1])  # valid
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][2])  # valid
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][3])  # invalid: suffix has 0 as first digit
+        Traceback (most recent call last):
+        ...
+        ValueError: WorkflowExecution nmdc:wfe-00-1.0 has an invalid ID
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][4])  # invalid: suffix has 0 as first digit
+        Traceback (most recent call last):
+        ...
+        ValueError: WorkflowExecution nmdc:wfe-00-1.01 has an invalid ID
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][5])  # valid
+        """
+        if not re.match(self._target_workflow_execution_id_pattern, workflow_execution["id"]):
+            raise ValueError(f"WorkflowExecution {workflow_execution['id']} has an invalid ID")

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -19,7 +19,8 @@ class Migrator(MigratorBase):
     # "picky" about the last part of the `id` value (i.e. the suffix).
     #
     # Reference: The definition of the `id_version` "settings" item, and the
-    #            materialized pattern used for `MetagenomeAnnotation.id`.
+    #            materialized pattern used for the `id` slot of a class that
+    #            inherits from `WorkflowExecution` (e.g. `MetagenomeAnnotation`).
     #
     _target_workflow_execution_id_pattern = r"^.+\.[1-9]{1}[0-9]{0,}$"
 

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -225,21 +225,21 @@ class Migrator(MigratorBase):
         ...     {'id': 'nmdc:wfe-00-1.10'},
         ... ]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][0])  # invalid: no suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][0])  # invalid: no suffix
         Traceback (most recent call last):
         ...
-        ValueError: WorkflowExecution nmdc:wfe-00-1 has an invalid ID
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][1])  # valid
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][2])  # valid
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][3])  # invalid: suffix has 0 as first digit
+        ValueError: WorkflowExecution nmdc:wfe-00-1 has an invalid ID suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][1])  # valid
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][2])  # valid
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][3])  # invalid: suffix has 0 as first digit
         Traceback (most recent call last):
         ...
-        ValueError: WorkflowExecution nmdc:wfe-00-1.0 has an invalid ID
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][4])  # invalid: suffix has 0 as first digit
+        ValueError: WorkflowExecution nmdc:wfe-00-1.0 has an invalid ID suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][4])  # invalid: suffix has 0 as first digit
         Traceback (most recent call last):
         ...
-        ValueError: WorkflowExecution nmdc:wfe-00-1.01 has an invalid ID
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][5])  # valid
+        ValueError: WorkflowExecution nmdc:wfe-00-1.01 has an invalid ID suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][5])  # valid
         """
         if not re.match(self._target_workflow_execution_id_pattern, workflow_execution["id"]):
-            raise ValueError(f"WorkflowExecution {workflow_execution['id']} has an invalid ID")
+            raise ValueError(f"WorkflowExecution {workflow_execution['id']} has an invalid ID suffix")

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, List
 
 from nmdc_schema.migrators.migrator_base import MigratorBase
@@ -9,6 +10,10 @@ class Migrator(MigratorBase):
     _from_version = "11.17.1"
     _to_version = "11.18.0"
 
+    # This is the regex pattern defined in the schema we're migrating _to_.
+    # Reference: The definition of the slot named `doi_value`.
+    _target_doi_pattern = r"^doi:10\.\d{2,9}/.*$"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -19,28 +24,102 @@ class Migrator(MigratorBase):
         r"""
         Migrates the database from conforming to the original schema, to conforming to the new schema.
 
-        This does three things:
-        1. Validates that each biosample has a name that is a string.
-        2. Builds a map from study ID to the list of names of that study's associated biosamples.
-        3. Validates that no study has multiple associated biosamples having the same name.
-
-        We could, technically, do all of this in a single pass through the collection. We opted to
-        split it into multiple passes to facilitate testing.
+        TODO: Consider reducing the number of passes we make through the `biosample_set` collection,
+              as a performance improvement.
         """
 
+        # Confirm all DOIs in all studies' `associated_dois` fields conform to the new schema,
+        # which requires that the "10" be followed by a "." character (not just _any_ character).
+        self.adapter.do_for_each_document(
+            collection_name="study_set",
+            action=self.validate_associated_dois,
+        )
+
+        # Confirm all DOIs in the following fields (all of which are optional, single-values, string
+        # fields) of all biosamples confirm to the new schema:
+        # - salinity_meth
+        # - micro_biomass_c_meth
+        # - micro_biomass_n_meth
+        # - non_microb_biomass_method
+        # - org_nitro_method
+        #
+        self.adapter.do_for_each_document(
+            collection_name="biosample_set",
+            action=self.validate_biosample_fields_containing_dois,
+        )
+
+        # Confirm each biosample has a name that is a string.
         self.adapter.do_for_each_document(
             collection_name="biosample_set",
             action=self.validate_biosample_name,
         )
 
+        # Builds a map from study ID to the list of names of that study's associated biosamples.
         self.map_from_study_id_to_biosample_names = {}  # ensure it's initially empty
-
         self.adapter.do_for_each_document(
             collection_name="biosample_set",
             action=self.add_biosample_name_to_map_of_study_id_to_biosample_names,
         )
 
+        # Confirm no study has multiple associated biosamples having the same name.
         self.fail_if_any_study_has_duplicate_biosample_names()
+
+    def validate_associated_dois(self, study: dict) -> None:
+        r"""
+        Validates the format of each DOI in the specified study's `associated_dois` field.
+
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> database = {'study_set': [
+        ...     {'id': 'nmdc:sty-00-1', 'associated_dois': ['doi:10.1234/abc', 'doi:10.5678/def']},
+        ...     {'id': 'nmdc:sty-00-2', 'associated_dois': ['doi:10.1234/abc', 'doi:10_5678/def']},
+        ...     {'id': 'nmdc:sty-00-3'}
+        ... ]}
+        >>> m = Migrator(adapter=DictionaryAdapter(database=database))
+        >>> m.validate_associated_dois(database['study_set'][0])  # valid
+        >>> m.validate_associated_dois(database['study_set'][1])  # invalid: second DOI has invalid format
+        Traceback (most recent call last):
+        ...
+        ValueError: Study nmdc:sty-00-2 has an associated DOI having an invalid format: doi:10_5678/def
+        >>> m.validate_associated_dois(database['study_set'][2])  # valid: no associated DOIs
+        """
+
+        if "associated_dois" in study:
+            for doi in study["associated_dois"]:
+                if not isinstance(doi, str) or not re.match(self._target_doi_pattern, doi):
+                    raise ValueError(f"Study {study['id']} has an associated DOI having an invalid format: {doi}")
+
+    def validate_biosample_fields_containing_dois(self, biosample: dict) -> None:
+        r"""
+        Validates the format of each DOI in the specified biosample's fields that contain DOIs.
+
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> database = {'biosample_set': [
+        ...     {'id': 'nmdc:bsm-00-1', 'salinity_meth': 'doi:10.1234/abc'},
+        ...     {'id': 'nmdc:bsm-00-2', 'salinity_meth': 'doi:10_1234/abc'},
+        ...     {'id': 'nmdc:bsm-00-3'}
+        ... ]}
+        >>> m = Migrator(adapter=DictionaryAdapter(database=database))
+        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][0])  # valid
+        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][1])  # invalid: salinity_meth has invalid format
+        Traceback (most recent call last):
+        ...
+        ValueError: Biosample nmdc:bsm-00-2 has a salinity_meth DOI having an invalid format: doi:10_1234/abc
+        >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][2])  # valid: no fields containing DOI
+        """
+
+        names_of_fields_that_can_contain_doi = [
+            "salinity_meth",
+            "micro_biomass_c_meth",
+            "micro_biomass_n_meth",
+            "non_microb_biomass_method",
+            "org_nitro_method",
+        ]
+
+        for field_name in names_of_fields_that_can_contain_doi:
+            if field_name in biosample:
+                doi = biosample[field_name]
+                if not isinstance(doi, str) or not re.match(self._target_doi_pattern, doi):
+                    raise ValueError(f"Biosample {biosample['id']} has a {field_name} DOI having an invalid format: {doi}")
 
     def validate_biosample_name(self, biosample: dict) -> None:
         r"""

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -33,6 +33,8 @@ class Migrator(MigratorBase):
             action=self.validate_biosample_name,
         )
 
+        self.map_from_study_id_to_biosample_names = {}  # ensure it's initially empty
+
         self.adapter.do_for_each_document(
             collection_name="biosample_set",
             action=self.add_biosample_name_to_map_of_study_id_to_biosample_names,
@@ -103,10 +105,11 @@ class Migrator(MigratorBase):
         >>> m.fail_if_any_study_has_duplicate_biosample_names()
         Traceback (most recent call last):
         ...
-        ValueError: Study nmdc:sty-00-2 has duplicate biosample names: {'apple'}
+        ValueError: Study nmdc:sty-00-2 has duplicate biosample names: ['apple']
         """
 
         for study_id, biosample_names in self.map_from_study_id_to_biosample_names.items():
             duplicate_biosample_names = {s for s in biosample_names if biosample_names.count(s) > 1}
             if len(duplicate_biosample_names) > 0:
-                raise ValueError(f"Study {study_id} has duplicate biosample names: {duplicate_biosample_names}")
+                sorted_names: list = sorted(duplicate_biosample_names)  # sorting helps with testing
+                raise ValueError(f"Study {study_id} has duplicate biosample names: {sorted_names}")

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -94,7 +94,7 @@ class Migrator(MigratorBase):
         >>> database = {'biosample_set': [
         ...     {'id': 'nmdc:bsm-00-1', 'salinity_meth': 'doi:10.1234/abc'},
         ...     {'id': 'nmdc:bsm-00-2', 'salinity_meth': 'doi:10_1234/abc'},
-        ...     {'id': 'nmdc:bsm-00-3', 'salinity_meth': 'foobarbaz'},
+        ...     {'id': 'nmdc:bsm-00-3', 'salinity_meth': 'https://www.example.com'},
         ... ]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
         >>> m.validate_biosample_fields_containing_dois(database['biosample_set'][0])  # valid
@@ -115,10 +115,11 @@ class Migrator(MigratorBase):
 
         for field_name in names_of_fields_that_can_contain_doi:
             if field_name in biosample:
-                potential_doi: str = biosample[field_name]
-                # Check whether the string begins with "doi:" — otherwise, we'll ignore it
-                if potential_doi.startswith("doi:"):
-                    doi = potential_doi
+                field_value = biosample[field_name]
+
+                # Check whether this is a value this migrator is responsible for checking.
+                if isinstance(field_value, str) and field_value.startswith("doi:"):
+                    doi = biosample[field_name]  # concise alias
                     if not re.match(self._target_doi_pattern, doi):
                         raise ValueError(f"Biosample {biosample['id']} has a {field_name} DOI having an invalid format: {doi}")
 

--- a/src/data/invalid/MagsAnalysis-invalid-id-suffix-begins-with-0.yaml
+++ b/src/data/invalid/MagsAnalysis-invalid-id-suffix-begins-with-0.yaml
@@ -1,0 +1,42 @@
+# This example document is invalid because its `id` ends with ".0", whereas the schema requires that the first digit of the suffix be 1-9.
+id: nmdc:wfmag-11-547rwq94.0
+ended_at_time: '2021-09-15T10:13:20+00:00'
+execution_resource: NERSC-Perlmutter
+git_url: git_url1
+name: MAG analysis for project ABCD
+started_at_time: '2021-08-05T14:48:51+00:00'
+type: nmdc:MagsAnalysis
+was_informed_by: "nmdc:omprc-11-547rwq95"
+has_input:
+  - "nmdc:dobj-11-547rwq96"
+has_output:
+  - "nmdc:dobj-11-547rwq97"
+  - "nmdc:dobj-11-547rwq98"
+mags_list:
+- bin_name: bins.40
+  number_of_contig: 20
+  completeness: 97.3
+  contamination: 3.38
+  total_bases: 0
+  gene_count: 20
+  type: nmdc:MagBin
+  bin_quality: MQ
+  num_16s: 0
+  num_5s: 0
+  num_23s: 0
+  gtdbtk_domain: Bacteria
+  gtdbtk_phylum: Verrucomicrobiota
+  gtdbtk_class: Verrucomicrobiae
+  gtdbtk_order: Pedosphaerales
+  gtdbtk_family: UBA11358
+  gtdbtk_genus: UBA11358
+  gtdbtk_species: UBA11358 abc
+  members_id:
+  - nmdc:wfmgas-13-56028x05.1_7_c1
+  - nmdc:wfmgas-13-56028x05.1_9_c1
+  eukaryotic_evaluation:
+      type: nmdc:EukEval
+      completeness: 14.71
+      contamination: 8.82
+      ncbi_lineage_tax_ids: "1-131567-2759-2611352-33682-191814-2603949"
+      ncbi_lineage: "root,cellular organisms,Eukaryota,Discoba,Euglenozoa,Diplonemea,Diplonemidae" 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -138,7 +138,7 @@ settings:
   id_nmdc_prefix: "^(nmdc)"
   id_shoulder: "([0-9][a-z]{0,6}[0-9])"
   id_blade: "([A-Za-z0-9]{1,})"
-  id_version: "(\\.[0-9]{1,})"
+  id_version: "(\\.[1-9]{1}[0-9]{0,})"  # first digit must be > 0;  e.g. ".1", ".2", ".10"
   id_locus: "(_[A-Za-z0-9_\\.-]+)?$"
   # MIxS structured_pattern settings for pattern interpolation.
   # These settings define regex patterns for placeholders like {scientific_float}, {text}, {URL}


### PR DESCRIPTION
This branch includes changes related to three topics. They're all in the same PR because each topic involves some changes to the same migrator. The three topics are:
1. Ensuring no `WorkflowExecution` has an `id` that ends with `.0` (#2914)
2. Ensuring no `Study` has multiple associated `Biosample`s having the same name as one another (#2951)
3. Ensuring all DOI values in specific fields contain a literal `.` following the `10` (#2954)

#### On topic 1

I made a change to the schema, itself, added an example "invalid" data file, and added a method to the `migrator_from_11_17_1_to_11_18_0.py` migrator. The method includes doctests that illustrate the new constraint on `id` suffixes. FYI: @aclum

#### On topic 2

I updated that same migrator so that it would raise an exception if it encountered any `Study` or `Biosample` documents that violate that new constraint. FYI: @aclum 

#### On topic 3

I updated that same migrator again so that it would raise an exception if it encountered any DOI values in the specific fields, that violate that new constraint. FYI: @turbomam 

The migrator still also does what it did before, which is checking whether all biosamples have names that are strings.

#### Fixes the following issues

- Fixes #2951
- Fixes #2954 
- Fixes #2914 