### PR TITLE
Disallow ".0" suffix on `WorkflowExecution.id` values and update migrator accordingly

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -14,6 +14,15 @@ class Migrator(MigratorBase):
     # Reference: The definition of the slot named `doi_value`.
     _target_doi_pattern = r"^doi:10\.\d{2,9}/.*$"
 
+    # This is a variant of regex pattern defined in the schema we're migrating _to_.
+    # This variant is "agnostic" to the first part of the `id` value, and is only
+    # "picky" about the last part of the `id` value (i.e. the suffix).
+    #
+    # Reference: The definition of the `id_version` "settings" item, and the
+    #            materialized pattern used for `MetagenomeAnnotation.id`.
+    #
+    _target_workflow_execution_id_pattern = r"^.+\.[1-9]{1}[0-9]{0,}$"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -55,6 +64,12 @@ class Migrator(MigratorBase):
 
         # Confirm no study has multiple associated biosamples having the same name.
         self.fail_if_any_study_has_duplicate_biosample_names()
+
+        # Confirm that the suffix of the `id` of each `WorkflowExecution` conforms to the new schema.
+        self.adapter.do_for_each_document(
+            collection_name="workflow_execution_set",
+            action=self.validate_workflow_execution_id_suffix,
+        )
 
     def validate_study_fields_containing_dois(self, study: dict) -> None:
         r"""
@@ -194,3 +209,37 @@ class Migrator(MigratorBase):
             if len(duplicate_biosample_names) > 0:
                 sorted_names: list = sorted(duplicate_biosample_names)  # sorting helps with testing
                 raise ValueError(f"Study {study_id} has duplicate biosample names: {sorted_names}")
+
+    def validate_workflow_execution_id_suffix(self, workflow_execution: dict) -> None:
+        r"""
+        Validates that the suffix of the `id` of the specified `WorkflowExecution` conforms to the
+        new schema, which says that the first digit of the suffix cannot be 0.
+
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> database = {'workflow_execution_set': [
+        ...     {'id': 'nmdc:wfe-00-1'},
+        ...     {'id': 'nmdc:wfe-00-1.1'},
+        ...     {'id': 'nmdc:wfe-00-1.2'},
+        ...     {'id': 'nmdc:wfe-00-1.0'},
+        ...     {'id': 'nmdc:wfe-00-1.01'},
+        ...     {'id': 'nmdc:wfe-00-1.10'},
+        ... ]}
+        >>> m = Migrator(adapter=DictionaryAdapter(database=database))
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][0])  # invalid: no suffix
+        Traceback (most recent call last):
+        ...
+        ValueError: WorkflowExecution nmdc:wfe-00-1 has an invalid ID
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][1])  # valid
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][2])  # valid
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][3])  # invalid: suffix has 0 as first digit
+        Traceback (most recent call last):
+        ...
+        ValueError: WorkflowExecution nmdc:wfe-00-1.0 has an invalid ID
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][4])  # invalid: suffix has 0 as first digit
+        Traceback (most recent call last):
+        ...
+        ValueError: WorkflowExecution nmdc:wfe-00-1.01 has an invalid ID
+        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][5])  # valid
+        """
+        if not re.match(self._target_workflow_execution_id_pattern, workflow_execution["id"]):
+            raise ValueError(f"WorkflowExecution {workflow_execution['id']} has an invalid ID")

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -19,7 +19,8 @@ class Migrator(MigratorBase):
     # "picky" about the last part of the `id` value (i.e. the suffix).
     #
     # Reference: The definition of the `id_version` "settings" item, and the
-    #            materialized pattern used for `MetagenomeAnnotation.id`.
+    #            materialized pattern used for the `id` slot of a class that
+    #            inherits from `WorkflowExecution` (e.g. `MetagenomeAnnotation`).
     #
     _target_workflow_execution_id_pattern = r"^.+\.[1-9]{1}[0-9]{0,}$"
 

--- a/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_17_1_to_11_18_0.py
@@ -225,21 +225,21 @@ class Migrator(MigratorBase):
         ...     {'id': 'nmdc:wfe-00-1.10'},
         ... ]}
         >>> m = Migrator(adapter=DictionaryAdapter(database=database))
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][0])  # invalid: no suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][0])  # invalid: no suffix
         Traceback (most recent call last):
         ...
-        ValueError: WorkflowExecution nmdc:wfe-00-1 has an invalid ID
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][1])  # valid
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][2])  # valid
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][3])  # invalid: suffix has 0 as first digit
+        ValueError: WorkflowExecution nmdc:wfe-00-1 has an invalid ID suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][1])  # valid
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][2])  # valid
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][3])  # invalid: suffix has 0 as first digit
         Traceback (most recent call last):
         ...
-        ValueError: WorkflowExecution nmdc:wfe-00-1.0 has an invalid ID
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][4])  # invalid: suffix has 0 as first digit
+        ValueError: WorkflowExecution nmdc:wfe-00-1.0 has an invalid ID suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][4])  # invalid: suffix has 0 as first digit
         Traceback (most recent call last):
         ...
-        ValueError: WorkflowExecution nmdc:wfe-00-1.01 has an invalid ID
-        >>> m.validate_workflow_execution_id(database['workflow_execution_set'][5])  # valid
+        ValueError: WorkflowExecution nmdc:wfe-00-1.01 has an invalid ID suffix
+        >>> m.validate_workflow_execution_id_suffix(database['workflow_execution_set'][5])  # valid
         """
         if not re.match(self._target_workflow_execution_id_pattern, workflow_execution["id"]):
-            raise ValueError(f"WorkflowExecution {workflow_execution['id']} has an invalid ID")
+            raise ValueError(f"WorkflowExecution {workflow_execution['id']} has an invalid ID suffix")

--- a/src/data/invalid/MagsAnalysis-invalid-id-suffix-begins-with-0.yaml
+++ b/src/data/invalid/MagsAnalysis-invalid-id-suffix-begins-with-0.yaml
@@ -1,0 +1,42 @@
+# This example document is invalid because its `id` ends with ".0", whereas the schema requires that the first digit of the suffix be 1-9.
+id: nmdc:wfmag-11-547rwq94.0
+ended_at_time: '2021-09-15T10:13:20+00:00'
+execution_resource: NERSC-Perlmutter
+git_url: git_url1
+name: MAG analysis for project ABCD
+started_at_time: '2021-08-05T14:48:51+00:00'
+type: nmdc:MagsAnalysis
+was_informed_by: "nmdc:omprc-11-547rwq95"
+has_input:
+  - "nmdc:dobj-11-547rwq96"
+has_output:
+  - "nmdc:dobj-11-547rwq97"
+  - "nmdc:dobj-11-547rwq98"
+mags_list:
+- bin_name: bins.40
+  number_of_contig: 20
+  completeness: 97.3
+  contamination: 3.38
+  total_bases: 0
+  gene_count: 20
+  type: nmdc:MagBin
+  bin_quality: MQ
+  num_16s: 0
+  num_5s: 0
+  num_23s: 0
+  gtdbtk_domain: Bacteria
+  gtdbtk_phylum: Verrucomicrobiota
+  gtdbtk_class: Verrucomicrobiae
+  gtdbtk_order: Pedosphaerales
+  gtdbtk_family: UBA11358
+  gtdbtk_genus: UBA11358
+  gtdbtk_species: UBA11358 abc
+  members_id:
+  - nmdc:wfmgas-13-56028x05.1_7_c1
+  - nmdc:wfmgas-13-56028x05.1_9_c1
+  eukaryotic_evaluation:
+      type: nmdc:EukEval
+      completeness: 14.71
+      contamination: 8.82
+      ncbi_lineage_tax_ids: "1-131567-2759-2611352-33682-191814-2603949"
+      ncbi_lineage: "root,cellular organisms,Eukaryota,Discoba,Euglenozoa,Diplonemea,Diplonemidae" 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -138,7 +138,7 @@ settings:
   id_nmdc_prefix: "^(nmdc)"
   id_shoulder: "([0-9][a-z]{0,6}[0-9])"
   id_blade: "([A-Za-z0-9]{1,})"
-  id_version: "(\\.[0-9]{1,})"
+  id_version: "(\\.[1-9]{1}[0-9]{0,})"  # first digit must be > 0;  e.g. ".1", ".2", ".10"
   id_locus: "(_[A-Za-z0-9_\\.-]+)?$"
   # MIxS structured_pattern settings for pattern interpolation.
   # These settings define regex patterns for placeholders like {scientific_float}, {text}, {URL}


### PR DESCRIPTION
On this branch, I modified the schema 👀🕺 so that it says the first digits of the "dot integer" suffix of a `WorkflowExecution` `id` cannot be `0`. I updated the migrator and example data accordingly.

Fixes #2914 