### PR TITLE
Guard against hand-written docs in build output directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,10 @@ git-status:
 	touch $@
 
 clean:
+	@# Warn if docs/ contains tracked files not originating from src/docs/
+	@comm -23 <(git ls-files 'docs/*.md' 2>/dev/null | xargs -I{} basename {} | sort) \
+		<(ls src/docs/*.md 2>/dev/null | xargs -I{} basename {} | sort) \
+		| while read f; do echo "WARNING: docs/$$f is tracked but has no source in src/docs/. It will be deleted by clean."; done
 	rm -rf $(DEST)
 	rm -rf tmp
 	rm -rf docs/*.md

--- a/Makefile
+++ b/Makefile
@@ -285,9 +285,12 @@ git-status:
 
 clean:
 	@# Warn if docs/ contains tracked files not originating from src/docs/
-	@comm -23 <(git ls-files 'docs/*.md' 2>/dev/null | xargs -I{} basename {} | sort) \
-		<(ls src/docs/*.md 2>/dev/null | xargs -I{} basename {} | sort) \
-		| while read f; do echo "WARNING: docs/$$f is tracked but has no source in src/docs/. It will be deleted by clean."; done
+	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+		for f in $$(comm -23 <(git ls-files 'docs/*.md' 2>/dev/null | xargs -I{} basename {} | sort) \
+			<(ls src/docs/*.md 2>/dev/null | xargs -I{} basename {} | sort)); do \
+			echo "WARNING: docs/$$f is tracked but has no source in src/docs/. It will be deleted by clean."; \
+		done; \
+	fi
 	rm -rf $(DEST)
 	rm -rf tmp
 	rm -rf docs/*.md

--- a/src/docs/developer-docs.md
+++ b/src/docs/developer-docs.md
@@ -24,9 +24,10 @@ config, CLI/YAML flag mapping, portal submission guidance, and upcoming LinkML c
 ### Where should I put hand-written documentation?
 
 The `docs/` directory is a **build output directory** — `make clean` deletes
-`docs/*.md` and `docs/*.html`. Any hand-written markdown placed directly in
-`docs/` will be silently destroyed. Place all hand-written documentation in
-`src/docs/` instead; the build copies it into `docs/` automatically.
+`docs/*.md` and `docs/*.html`. Tracked files in `docs/` that have no
+counterpart in `src/docs/` will trigger a warning during `make clean`, but
+untracked files will be silently removed. Place all hand-written documentation
+in `src/docs/` instead; the build copies it into `docs/` automatically.
 
 ### What are LinkML readonly metaslots and why shouldn't I assert them?
 

--- a/src/docs/developer-docs.md
+++ b/src/docs/developer-docs.md
@@ -21,6 +21,13 @@ Some frequently asked questions about developing the NMDC Schema.
 [OWL Generation](owl-generation.md) -- covers current build process, recommended
 config, CLI/YAML flag mapping, portal submission guidance, and upcoming LinkML changes.
 
+### Where should I put hand-written documentation?
+
+The `docs/` directory is a **build output directory** — `make clean` deletes
+`docs/*.md` and `docs/*.html`. Any hand-written markdown placed directly in
+`docs/` will be silently destroyed. Place all hand-written documentation in
+`src/docs/` instead; the build copies it into `docs/` automatically.
+
 ### What are LinkML readonly metaslots and why shouldn't I assert them?
 
 The LinkML metamodel defines 12 **readonly** slots that are automatically populated


### PR DESCRIPTION
## Summary
- Add a warning to the `clean` Makefile target that detects tracked `docs/*.md` files with no corresponding source in `src/docs/`, alerting developers before deletion.
- Add a developer FAQ entry in `src/docs/developer-docs.md` explaining that `docs/` is build output and hand-written documentation belongs in `src/docs/`.

Closes #2962

## Test plan
- [ ] Run `make clean` and verify no spurious warnings appear when all `docs/*.md` files have sources in `src/docs/`
- [ ] Manually create a tracked `docs/test.md` without a `src/docs/test.md` counterpart and confirm the warning fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)