### PR TITLE
Edit `Biosample.name` slot description to say it must be unique within a study

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -913,10 +913,10 @@ classes:
         required: true
         description: >-
           A local identifier or name for the material sample collected.
-          It can have any format, but we suggest that you make it concise, unique, and consistent within your lab, and as informative as possible.
-          For NMDC this should be unique within a study.
+          We recommend it be informative, concise, and consistent within your lab.
+          It must be unique within a study.
           International Nucleotide Sequence Database Collaboration (INSDC) requires every sample name from a single submitter to be unique.
-          Use of a globally unique identifier for the field source_mat_id is recommended in addition to the name slot.
+          We recommend that, in addition to populating this field, you populate the `source_mat_id` field with a globally-unique identifier.
         examples:
           - value: "BW-H-17-M"
       


### PR DESCRIPTION
On this branch, I edited the description of the `name` slot of the `Biosample` class, to reflect the fact that (once [this nmdc-runtime PR](https://github.com/microbiomedata/nmdc-runtime/pull/1430) gets merged in) the MongoDB database will not allow more than one biosample associated with a given study to have a given name.

For example, if biosample B is associated with Study S, and biosample B has name "bob", the MongoDB database will not allow someone to insert a biosample C that is associated with Study S if biosample C's name is also "bob".

While editing the description in that way, I also made some other edits:
- refrain from simultaneously saying both "concise" and "as informative as possible" (seems contradictory to me)
- rephrase final sentence

Fixes #2987 

Related to https://github.com/microbiomedata/nmdc-schema/issues/2878

Here's what the YAML looks like on the rendered docs preview site:

<img width="938" height="288" alt="image" src="https://github.com/user-attachments/assets/20567f38-010c-4492-9b90-b9b3fb314896" />
