### PR TITLE
Add exact_mapping BFO:0000040 to MaterialEntity

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -114,6 +114,8 @@ classes:
       - Physical entity
     is_a: NamedThing
     title: Material Entity
+    exact_mappings:
+      - BFO:0000040
   Instrument:
     class_uri: nmdc:Instrument
     description: A material entity that is designed to perform a function in a scientific investigation, but is not a reagent. This class models the make and model of the instrument, not the specific instance of the instrument.


### PR DESCRIPTION
## Summary
- Adds `exact_mappings: [BFO:0000040]` to MaterialEntity, grounding it to BFO's material entity (also used by COB)
- Uses exact_mappings rather than changing class_uri to avoid breaking downstream RDF consumers

Closes #2989