### PR TITLE
Add descriptions to MaterialEntity and PlannedProcess

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -109,7 +109,7 @@ classes:
   MaterialEntity:
     class_uri: nmdc:MaterialEntity
     description: >-
-      A physical entity that occupies space, has mass, and persists through time.
+      An entity that occupies space and has mass.
     abstract: true
     aliases:
       - Material

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -109,7 +109,7 @@ classes:
   MaterialEntity:
     class_uri: nmdc:MaterialEntity
     description: >-
-      An entity that occupies space and has mass.
+      A named thing that occupies space and has mass.
     abstract: true
     aliases:
       - Material
@@ -140,7 +140,7 @@ classes:
           interpolated: true
   PlannedProcess:
     description: >-
-      A process that is executed according to a plan.
+      A named thing that is executed according to a plan.
     abstract: true
     class_uri: OBI:0000011
     is_a: NamedThing

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -110,7 +110,6 @@ classes:
     class_uri: nmdc:MaterialEntity
     description: >-
       A physical entity that occupies space, has mass, and persists through time.
-      In NMDC this includes organisms, samples, instruments, and sites.
     abstract: true
     aliases:
       - Material
@@ -141,9 +140,7 @@ classes:
           interpolated: true
   PlannedProcess:
     description: >-
-      A process that is executed according to a plan. In NMDC this includes
-      sample collection, material processing, data generation, and
-      computational analysis workflows.
+      A process that is executed according to a plan.
     abstract: true
     class_uri: OBI:0000011
     is_a: NamedThing

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -108,6 +108,9 @@ classes:
 
   MaterialEntity:
     class_uri: nmdc:MaterialEntity
+    description: >-
+      A physical entity that occupies space, has mass, and persists through time.
+      In NMDC this includes organisms, samples, instruments, and sites.
     abstract: true
     aliases:
       - Material
@@ -137,6 +140,10 @@ classes:
           syntax: "{id_nmdc_prefix}:inst-{id_shoulder}-{id_blade}$"
           interpolated: true
   PlannedProcess:
+    description: >-
+      A process that is executed according to a plan. In NMDC this includes
+      sample collection, material processing, data generation, and
+      computational analysis workflows.
     abstract: true
     class_uri: OBI:0000011
     is_a: NamedThing


### PR DESCRIPTION
## Summary
- MaterialEntity and PlannedProcess are the only NamedThing children without descriptions
- Adds concise descriptions that explain what belongs under each, referencing NMDC-specific subclasses

Related: #2989, #2990

Closes #2991