### PR TITLE
Fix broken ontology links in `samp_collec_device` slot description

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -15,11 +15,31 @@
 '.slots.samp_collec_device.structured_aliases = [{"literal_form": "samp_collect_device", "contexts": ["https://github.com/GenomicsStandardsConsortium/mixs/releases/tag/v6.2.2"]}]'
 '.slots.samp_collec_method.structured_aliases = [{"literal_form": "samp_collect_method", "contexts": ["https://github.com/GenomicsStandardsConsortium/mixs/releases/tag/v6.2.2"]}]'
 
-# Fix broken ontology links in samp_collec_device slot description
-# Upstream MIxS text references two URLs that no longer resolve correctly:
-#   - http://purl.obolibrary.org/obo/ENVO -> 404 (OBO PURL for the ENVO root returns 404)
-#   - http://purl.obolibrary.org/obo/GENEPIO_0002094 -> obsolete term; moved to OBI_0002814
-'.slots.samp_collec_device.description |= "The device used to collect an environmental sample. This field accepts terms listed under the ENVO ontology (https://www.ebi.ac.uk/ols4/ontologies/envo). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/OBI_0002814)."'
+# Tighten samp_collec_device — see PR #3005 / issue #1480
+# Upstream MIxS description has broken links (ENVO root 404; GENEPIO_0002094 obsolete).
+# Fixes applied here:
+#   - Description anchored on OBI:0002814 (the real grouping class). ENVO has no
+#     device classes; GENEPIO carries the environmental sampling device subtree
+#     under OBI:0002814.
+#   - Strip decorative metadata: Expected_value annotation, string_serialization,
+#     and structured_aliases (slot_uri MIXS:0000002 already provides the GSC crosswalk).
+#   - Add validatable examples (1 OBI + 1 GENEPIO + 1 free text legacy).
+#   - Add comments naming the GENEPIO grouping classes and warning off ENVO.
+#   - Add a permissive pattern: free text without brackets, OR "label [PREFIX:LOCALID]".
+#     Tested against all 28 distinct biosample_set values (6,327 populated docs);
+#     none break. Future submissions encouraged toward the bracketed-CURIE form.
+'.slots.samp_collec_device.description |= "The device used to collect an environmental sample. Recommended values are subclasses of specimen collection device (http://purl.obolibrary.org/obo/OBI_0002814). OBI itself contains only swab/wipe subclasses; environmental sampling devices (corers, grab samplers, passive samplers, etc.) are defined in GENEPIO under the same OBI:0002814 parent. Free-text values are accepted for backward compatibility; new submissions should prefer the form: label [PREFIX:LOCALID]."'
+
+'del(.slots.samp_collec_device.annotations.Expected_value)'
+'del(.slots.samp_collec_device.string_serialization)'
+'del(.slots.samp_collec_device.structured_aliases)'
+
+'del(.slots.samp_collec_device.examples)'
+'.slots.samp_collec_device.examples = [{"value": "specimen collection swab stick [OBI:0002820]"}, {"value": "PONAR grab sampler [GENEPIO:0100929]"}, {"value": "trowel"}]'
+
+'.slots.samp_collec_device.comments = ["GENEPIO'\''s subtree of OBI:0002814 includes grouping classes such as GENEPIO:0100941 (grab sampling device), GENEPIO:0100942 (composite sampling device), GENEPIO:0100943 (core sampling device), and GENEPIO:0100948 (passive sampling device).", "ENVO has no device classes; do not use ENVO terms here.", "Existing NMDC biosamples populate this slot with free text (e.g., \"corer\", \"Van Dorn\"). New submissions are encouraged to use the form: label [PREFIX:LOCALID]."]'
+
+'.slots.samp_collec_device.pattern |= "^([^\\[\\]]+|.+ \\[[A-Za-z][A-Za-z0-9_]*:[A-Za-z0-9_]+\\])$"'
 
 '.slots.env_broad_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_local_scale.is_a |= "mixs_env_triad_field"'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -15,6 +15,12 @@
 '.slots.samp_collec_device.structured_aliases = [{"literal_form": "samp_collect_device", "contexts": ["https://github.com/GenomicsStandardsConsortium/mixs/releases/tag/v6.2.2"]}]'
 '.slots.samp_collec_method.structured_aliases = [{"literal_form": "samp_collect_method", "contexts": ["https://github.com/GenomicsStandardsConsortium/mixs/releases/tag/v6.2.2"]}]'
 
+# Fix broken ontology links in samp_collec_device slot description
+# Upstream MIxS text references two URLs that no longer resolve correctly:
+#   - http://purl.obolibrary.org/obo/ENVO -> 404 (OBO PURL for the ENVO root returns 404)
+#   - http://purl.obolibrary.org/obo/GENEPIO_0002094 -> obsolete term; moved to OBI_0002814
+'.slots.samp_collec_device.description |= "The device used to collect an environmental sample. This field accepts terms listed under the ENVO ontology (https://www.ebi.ac.uk/ols4/ontologies/envo). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/OBI_0002814)."'
+
 '.slots.env_broad_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_local_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_medium.is_a |= "mixs_env_triad_field"'

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7104,7 +7104,7 @@ slots:
   samp_collec_device:
     annotations:
       Expected_value: device name
-    description: The device used to collect an environmental sample. This field accepts terms listed under environmental sampling device (http://purl.obolibrary.org/obo/ENVO). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/GENEPIO_0002094)
+    description: The device used to collect an environmental sample. This field accepts terms listed under the ENVO ontology (https://www.ebi.ac.uk/ols4/ontologies/envo). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/OBI_0002814).
     title: sample collection device
     keywords:
       - device

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7102,19 +7102,22 @@ slots:
       interpolated: true
       partial_match: true
   samp_collec_device:
-    annotations:
-      Expected_value: device name
-    description: The device used to collect an environmental sample. This field accepts terms listed under the ENVO ontology (https://www.ebi.ac.uk/ols4/ontologies/envo). This field also accepts terms listed under specimen collection device (http://purl.obolibrary.org/obo/OBI_0002814).
+    annotations: {}
+    description: 'The device used to collect an environmental sample. Recommended values are subclasses of specimen collection device (http://purl.obolibrary.org/obo/OBI_0002814). OBI itself contains only swab/wipe subclasses; environmental sampling devices (corers, grab samplers, passive samplers, etc.) are defined in GENEPIO under the same OBI:0002814 parent. Free-text values are accepted for backward compatibility; new submissions should prefer the form: label [PREFIX:LOCALID].'
     title: sample collection device
     keywords:
       - device
       - sample
-    string_serialization: '{termLabel} [{termID}]|{text}'
     slot_uri: MIXS:0000002
-    structured_aliases:
-      - literal_form: samp_collect_device
-        contexts:
-          - https://github.com/GenomicsStandardsConsortium/mixs/releases/tag/v6.2.2
+    examples:
+      - value: specimen collection swab stick [OBI:0002820]
+      - value: PONAR grab sampler [GENEPIO:0100929]
+      - value: trowel
+    comments:
+      - GENEPIO's subtree of OBI:0002814 includes grouping classes such as GENEPIO:0100941 (grab sampling device), GENEPIO:0100942 (composite sampling device), GENEPIO:0100943 (core sampling device), and GENEPIO:0100948 (passive sampling device).
+      - ENVO has no device classes; do not use ENVO terms here.
+      - 'Existing NMDC biosamples populate this slot with free text (e.g., "corer", "Van Dorn"). New submissions are encouraged to use the form: label [PREFIX:LOCALID].'
+    pattern: ^([^\[\]]+|.+ \[[A-Za-z][A-Za-z0-9_]*:[A-Za-z0-9_]+\])$
     range: string
   samp_collec_method:
     description: The method employed for collecting the sample


### PR DESCRIPTION
In this PR we are updating the broken ontology links in the description for [samp_collec_device](https://microbiomedata.github.io/nmdc-schema/samp_collec_device/) slot.

We are making the following link replacements:
* http://purl.obolibrary.org/obo/ENVO –> https://www.ebi.ac.uk/ols4/ontologies/envo
* http://purl.obolibrary.org/obo/GENEPIO_0002094 –> http://purl.obolibrary.org/obo/OBI_0002814

Since `samp_collec_device` is a slot that we're "inheriting" from MIxS we need to use our `sheets-and-friends` machinery to apply any customization to it and the file that we want to modify is: `assets/yq-for-mixs-customizations.txt` where we can use `yq` to modify the slot description.