### PR TITLE
Bump pytest from 9.0.2 to 9.0.3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4542,14 +4542,14 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
-    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Addresses Dependabot alert #39 (medium severity): vulnerable tmpdir handling, fixed in 9.0.3.

`uv.lock` already had 9.0.3 from the recent lxml bump PR (#3006). This aligns `poetry.lock`.

Only `poetry.lock` changes — no schema, no generated artifacts.