### PR TITLE
Fix bare except and reused loop variable (CodeQL findings)

### DIFF
--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -87,15 +87,15 @@ def main(schema_path, input_path, output_path, migrator_name):
         s_range = sv.range
         if s_range == "uriorcurie":
             slot_descendants = view.slot_descendants(sk)
-            for i in slot_descendants:
-                curie_slots.add(i)
+            for slot in slot_descendants:
+                curie_slots.add(slot)
         elif s_range:
             range_type_name = type(view.get_element(s_range)).class_name
             if range_type_name == "class_definition":
                 if view.get_identifier_slot(s_range):
                     slot_descendants = view.slot_descendants(sk)
-                    for i in slot_descendants:
-                        curie_slots.add(i)
+                    for slot in slot_descendants:
+                        curie_slots.add(slot)
 
     logger.info(curie_slots)
 

--- a/nmdc_schema/migrators/partials/migrator_from_11_9_1_to_11_10_0/migrator_from_11_9_1_to_11_10_0_part_1.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_9_1_to_11_10_0/migrator_from_11_9_1_to_11_10_0_part_1.py
@@ -68,8 +68,8 @@ def _collection_could_contain_quantity_values(schema_view, range_class: str) -> 
         descendants = schema_view.class_descendants(range_class)
         for desc_class in descendants:
             desc_slots = schema_view.class_induced_slots(desc_class)
-            for slot_def in desc_slots:
-                if slot_def.range == "QuantityValue":
+            for desc_slot_def in desc_slots:
+                if desc_slot_def.range == "QuantityValue":
                     return True
     return False
 

--- a/nmdc_schema/migrators/partials/migrator_from_11_9_1_to_11_10_0/migrator_from_11_9_1_to_11_10_0_part_1.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_9_1_to_11_10_0/migrator_from_11_9_1_to_11_10_0_part_1.py
@@ -372,7 +372,7 @@ class Migrator(MigratorBase):
                         for slot_def in subclass_induced_slots:
                             if slot_def.range == "QuantityValue":
                                 subclass_slots.add(slot_def.name)
-                except:
+                except Exception:
                     # If class_descendants doesn't exist, skip subclass processing
                     pass
                 


### PR DESCRIPTION
Two real CodeQL findings in source code (not generated files):

**1. `migration_recursion.py`** — two inner `for i in slot_descendants:` loops inside the same outer loop; renamed `i` → `slot` for clarity and to resolve the nested-same-variable finding.

**2. `migrator_from_11_9_1_to_11_10_0_part_1.py:375`** — bare `except:` silently catches `KeyboardInterrupt` and `SystemExit`; narrowed to `except Exception:`.

The remaining open findings (482 × 'first parameter not named self', 349 × 'implicit string concatenation', and several others) are all in generated files (`nmdc_pydantic.py`, `nmdc.py`) and should be dismissed on the security/quality page rather than fixed in code.