### PR TITLE
Add new chemical entity permissible values for material processing metadata

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -157,6 +157,8 @@ enums:
         meaning: CHEBI:62947
       ammonium_bicarbonate:
         meaning: CHEBI:184335
+      ammonium_formate:
+        meaning: CHEBI:63050
       amitriptyline:
         meaning: CHEBI:2666
       Arg-C:
@@ -215,8 +217,14 @@ enums:
         meaning: CHEBI:43945
         comments:
           - A 1,1-bis(phosphonic acid) consisting of methane substituted by two phosphonic acid groups, also known as methylenediphosphonic acid
+      potassium_chloride:
+        meaning: CHEBI:32588
+      phosphate_buffered_saline:
+        meaning: OBI:0100046
       phosphoric_acid:
         meaning: CHEBI:26078
+      trichloroacetic_acid:
+        meaning: CHEBI:30956
       trimethylchlorosilane:
         meaning: CHEBI:85069
       trypsin:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -181,6 +181,8 @@ enums:
           - >-
             A serine protease that hydrolyzes peptide bonds at the C-terminus of tryptophan, leucine, tyrosine,
             and phenylalanine.
+      disodium_hydrogenphosphate_dihydrate:
+        meaning: CHEBI:91258
       ethanol:
         meaning: CHEBI:16236
       formic_acid:
@@ -221,10 +223,12 @@ enums:
           - A 1,1-bis(phosphonic acid) consisting of methane substituted by two phosphonic acid groups, also known as methylenediphosphonic acid
       potassium_chloride:
         meaning: CHEBI:32588
-      phosphate_buffered_saline:
-        meaning: OBI:0100046
+      potassium_dihydrogen_phosphate:
+        meaning: CHEBI:63036
       phosphoric_acid:
         meaning: CHEBI:26078
+      sodium_chloride:
+        meaning: CHEBI:26710
       trichloroacetic_acid:
         meaning: CHEBI:30956
       trimethylchlorosilane:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -147,6 +147,8 @@ enums:
         meaning: CHEBI:38472
       acetic_acid:
         meaning: CHEBI:15366
+      acetone:
+        meaning: CHEBI:15347
       alphaLP:
         meaning: EC:3.4.21.12
         see_also:


### PR DESCRIPTION
This PR adds five permissible values to `ChemicalEntityEnum` to accommodate material processing metadata for a new study/new protocols.