### PR TITLE
Add description for GTDBTK Summary json

### DIFF
--- a/src/data/valid/Database-mags.yaml
+++ b/src/data/valid/Database-mags.yaml
@@ -117,4 +117,11 @@ workflow_execution_set:
         num_16s: 0
         num_5s: 0
         num_23s: 0
-        num_t_rna: 7
+        num_t_rna: 7 
+
+data_object_set:
+  - id: nmdc:dobj-11-0abycm53
+    file_size_bytes: 4002
+    name: nmdc_wfmag-11-0abycm66.1_gtdbtk.json
+    data_object_type: GTDBTK Summary json
+    data_category: processed_data

--- a/src/data/valid/Database-mags.yaml
+++ b/src/data/valid/Database-mags.yaml
@@ -125,3 +125,5 @@ data_object_set:
     name: nmdc_wfmag-11-0abycm66.1_gtdbtk.json
     data_object_type: GTDBTK Summary json
     data_category: processed_data
+    type: nmdc:DataObject
+    description: GTDBTK Summary json for nmdc:wfmag-11-0abycm66.1

--- a/src/data/valid/Database-mags.yaml
+++ b/src/data/valid/Database-mags.yaml
@@ -117,13 +117,12 @@ workflow_execution_set:
         num_16s: 0
         num_5s: 0
         num_23s: 0
-        num_t_rna: 7 
-
+        num_t_rna: 7
 data_object_set:
   - id: nmdc:dobj-11-0abycm53
     file_size_bytes: 4002
     name: nmdc_wfmag-11-0abycm66.1_gtdbtk.json
-    data_object_type: GTDBTK Summary json
+    data_object_type: GTDBTK Summary JSON
     data_category: processed_data
     type: nmdc:DataObject
-    description: GTDBTK Summary json for nmdc:wfmag-11-0abycm66.1
+    description: GTDBTK Summary JSON for nmdc:wfmag-11-0abycm66.1

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -681,7 +681,10 @@ enums:
 
       GTDBTK Archaeal Summary:
         description: GTDBTK archaeal summary
-
+      
+      GTDBTK Summary json:
+        description: GTDBTK bacterial and archaeal summary in json format
+        
       GOTTCHA2 Krona Plot:
         description: GOTTCHA2 krona plot HTML file
 

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -682,8 +682,8 @@ enums:
       GTDBTK Archaeal Summary:
         description: GTDBTK archaeal summary
       
-      GTDBTK Summary json:
-        description: GTDBTK bacterial and archaeal summary in json format
+      GTDBTK Summary JSON:
+        description: GTDBTK bacterial and archaeal summary in JSON format
         see_also:
           - https://ecogenomics.github.io/GTDBTk/
         annotations:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -684,6 +684,13 @@ enums:
       
       GTDBTK Summary json:
         description: GTDBTK bacterial and archaeal summary in json format
+        see_also:
+          - https://ecogenomics.github.io/GTDBTk/
+        annotations:
+          file_name_pattern:
+            value: "[mag_wf_activity_id]_gtdbtk.json"
+        examples:
+          - value: nmdc_wfmag-11-0abycm66.1_gtdbtk.json
         
       GOTTCHA2 Krona Plot:
         description: GOTTCHA2 krona plot HTML file


### PR DESCRIPTION
This PR adds GTDBTK Summary json as a permissible value to FileTypeEnum and updates example valid data.
This is a new output file produced by the Semibin2 [MagsAnalysis](https://microbiomedata.github.io/nmdc-schema/MagsAnalysis/) workflow.