### PR TITLE
Ignore AI coding tool artifacts and ruff cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,13 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# ruff
+.ruff_cache/
+
+# AI coding tools
+.claude/
+.aider*
+.copilot/
+.github/copilot-instructions.md
+AGENTS.md


### PR DESCRIPTION
Addresses #2966 (agent-related additions only).

Adds to `.gitignore`:
- `.claude/`, `.aider*`, `.copilot/`, `.github/copilot-instructions.md`, `AGENTS.md` — accumulate locally during AI coding assistant sessions
- `.ruff_cache/` — modern Python tooling, currently untracked

Scoped narrowly per the issue's own "Suggested priority" guidance. The general cleanup opportunities (redundant entries like `project` vs `project/`, stale framework templates) are left for a separate PR. `uv.lock` is already tracked alongside `poetry.lock`, so the conditional suggestion to ignore it doesn't apply.

## Test plan

- [x] `git status` shows no untracked AI tool dirs after change
- [x] No previously-tracked files newly ignored (verified — none of the new patterns match anything in `git ls-files`)