### PR TITLE
Fix grammar in `calibration_object` slot description

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1168,7 +1168,7 @@ slots:
 
   calibration_object:
     range: DataObject
-    description: the file containing calibration data object
+    description: the file containing the calibration data object
     structured_pattern:
       syntax: "{id_nmdc_prefix}:dobj-{id_shoulder}-{id_blade}$"
       interpolated: true


### PR DESCRIPTION
Closes #2874.

Adds the missing definite article: `"the file containing calibration data object"` → `"the file containing the calibration data object"`.

Picked the singular form (one of 4 alternatives the issue proposed) because the slot is single-valued (`range: DataObject`, no `multivalued: true`).

## Test plan

- [x] One-character grammar fix in `src/schema/nmdc.yaml`; no functional or schema-shape change.