### PR TITLE
Fix broken/inaccessible ontology URLs in 3 inherited MIxS slot descriptions

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -48,7 +48,7 @@
 # plant_growth_med: EO_0007147 PURL returns 404 (EO migrated to PECO) → use PECO_0007147
 # plant_struc:     purl.bioontology.org returns 403 (auth-walled) → use OBO Foundry page
 '.slots.growth_facil.description |= "Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see https://cropontology.org/."'
-'.slots.plant_growth_med.description |= "Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from PECO:plant growth medium exposure (follow this link for terms http://purl.obolibrary.org/obo/PECO_0007147) or other controlled vocabulary."'
+'.slots.plant_growth_med.description |= "Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from the Plant Environment Ontology (PECO), plant growth medium exposure (http://purl.obolibrary.org/obo/PECO_0007147), or other controlled vocabulary."'
 '.slots.plant_struc.description |= "Name of plant structure the sample was obtained from; for Plant Ontology (PO) terms, see http://obofoundry.org/ontology/po.html, e.g. petiole epidermis (PO:0000051). If an individual flower is sampled, the sex of it can be recorded here."'
 
 '.slots.env_broad_scale.is_a |= "mixs_env_triad_field"'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -49,6 +49,7 @@
 # plant_struc:     purl.bioontology.org returns 403 (auth-walled) → use OBO Foundry page
 '.slots.growth_facil.description |= "Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see https://cropontology.org/."'
 '.slots.plant_growth_med.description |= "Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from the Plant Environment Ontology (PECO), plant growth medium exposure (http://purl.obolibrary.org/obo/PECO_0007147), or other controlled vocabulary."'
+'del(.slots.plant_growth_med.annotations)'
 '.slots.plant_struc.description |= "Name of plant structure the sample was obtained from; for Plant Ontology (PO) terms, see http://obofoundry.org/ontology/po.html, e.g. petiole epidermis (PO:0000051). If an individual flower is sampled, the sex of it can be recorded here."'
 
 '.slots.env_broad_scale.is_a |= "mixs_env_triad_field"'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -41,6 +41,16 @@
 
 '.slots.samp_collec_device.pattern |= "^([^\\[\\]]+|.+ \\[[A-Za-z][A-Za-z0-9_]*:[A-Za-z0-9_]+\\])$"'
 
+# Fix broken/inaccessible ontology URLs in inherited MIxS slot descriptions
+# (sister fixes to samp_collec_device above; same broken-link family as #1480).
+#
+# growth_facil:    cropontology.org subpath returns 404 → replace with the homepage
+# plant_growth_med: EO_0007147 PURL returns 404 (EO migrated to PECO) → use PECO_0007147
+# plant_struc:     purl.bioontology.org returns 403 (auth-walled) → use OBO Foundry page
+'.slots.growth_facil.description |= "Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see https://cropontology.org/."'
+'.slots.plant_growth_med.description |= "Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from PECO:plant growth medium exposure (follow this link for terms http://purl.obolibrary.org/obo/PECO_0007147) or other controlled vocabulary."'
+'.slots.plant_struc.description |= "Name of plant structure the sample was obtained from; for Plant Ontology (PO) terms, see http://obofoundry.org/ontology/po.html, e.g. petiole epidermis (PO:0000051). If an individual flower is sampled, the sex of it can be recorded here."'
+
 '.slots.env_broad_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_local_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_medium.is_a |= "mixs_env_triad_field"'

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -4482,9 +4482,7 @@ slots:
       interpolated: true
       partial_match: true
   plant_growth_med:
-    annotations:
-      Expected_value: EO or enumeration
-    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from PECO:0007147 ("plant growth medium exposure"; follow this link for terms http://purl.obolibrary.org/obo/PECO_0007147) or other controlled vocabulary.
+    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from the Plant Environment Ontology (PECO), plant growth medium exposure (http://purl.obolibrary.org/obo/PECO_0007147), or other controlled vocabulary.
     title: plant growth medium
     keywords:
       - growth

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -4484,7 +4484,7 @@ slots:
   plant_growth_med:
     annotations:
       Expected_value: EO or enumeration
-    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from PECO:plant growth medium exposure (follow this link for terms http://purl.obolibrary.org/obo/PECO_0007147) or other controlled vocabulary.
+    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from PECO:0007147 ("plant growth medium exposure"; follow this link for terms http://purl.obolibrary.org/obo/PECO_0007147) or other controlled vocabulary.
     title: plant growth medium
     keywords:
       - growth

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -2960,7 +2960,7 @@ slots:
   growth_facil:
     annotations:
       Expected_value: free text or CO
-    description: 'Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see http://www.cropontology.org/ontology/CO_715/Crop%20Research'
+    description: 'Type of facility where the sampled plant was grown; controlled vocabulary: growth chamber, open top chamber, glasshouse, experimental garden, field. Alternatively use Crop Ontology (CO) terms, see https://cropontology.org/.'
     title: growth facility
     examples:
       - value: Growth chamber [CO_715:0000189]
@@ -4484,7 +4484,7 @@ slots:
   plant_growth_med:
     annotations:
       Expected_value: EO or enumeration
-    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from EO:plant growth medium (follow this link for terms http://purl.obolibrary.org/obo/EO_0007147) or other controlled vocabulary
+    description: Specification of the media for growing the plants or tissue cultured samples, e.g. soil, aeroponic, hydroponic, in vitro solid culture medium, in vitro liquid culture medium. Recommended value is a specific value from PECO:plant growth medium exposure (follow this link for terms http://purl.obolibrary.org/obo/PECO_0007147) or other controlled vocabulary.
     title: plant growth medium
     keywords:
       - growth
@@ -4514,7 +4514,7 @@ slots:
     slot_uri: MIXS:0001059
     range: PlantSexEnum
   plant_struc:
-    description: Name of plant structure the sample was obtained from; for Plant Ontology (PO) (v releases/2017-12-14) terms, see http://purl.bioontology.org/ontology/PO, e.g. petiole epidermis (PO_0000051). If an individual flower is sampled, the sex of it can be recorded here
+    description: Name of plant structure the sample was obtained from; for Plant Ontology (PO) terms, see http://obofoundry.org/ontology/po.html, e.g. petiole epidermis (PO:0000051). If an individual flower is sampled, the sex of it can be recorded here.
     title: plant structure
     examples:
       - value: epidermis [PO:0005679]


### PR DESCRIPTION
Sister to PR #3005 / issue #1480 (`samp_collec_device`). Same broken-link family in MIxS-inherited slot descriptions; batched into one PR.

## URLs audited and verified

| Slot | Old URL | Status | Replacement |
|---|---|---|---|
| `growth_facil` | `http://www.cropontology.org/ontology/CO_715/Crop%20Research` | 404 | `https://cropontology.org/` (homepage works) |
| `plant_growth_med` | `http://purl.obolibrary.org/obo/EO_0007147` | 404 (EO migrated to PECO) | `http://purl.obolibrary.org/obo/PECO_0007147` ("plant growth medium exposure"; same intent — verified in OLS4) |
| `plant_struc` | `http://purl.bioontology.org/ontology/PO` | 403 (BioPortal auth wall) | `http://obofoundry.org/ontology/po.html` (200; stable, no auth) |

Other MIxS-inherited slots audited and confirmed OK: `host_body_product`, `host_body_site`, `host_phenotype`, `samp_type`, `soil_type`, `experimental_factor`, `host_disease_stat` (no broken URLs in their descriptions).

## Implementation

Same yq pipeline as #3005:
- `assets/yq-for-mixs-customizations.txt` — three `description |=` lines, one per slot
- `src/schema/mixs.yaml` — regenerated via `make src/schema/mixs.yaml`

No `nmdc_schema/*` regenerated artifacts committed (per CLAUDE.md feature-PR policy).

## Test plan

- [x] `curl -L` confirms each new URL returns 200
- [x] `curl -L` confirms old URLs were 404/403
- [x] `make src/schema/mixs.yaml` regenerated cleanly; diff shows only the 3 description changes