### PR TITLE
Loosen version constraints for linkml dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6377,4 +6377,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "2ed4651e6e680f27faf124f4072e6ab4b52a2c58779659e7ecae5d95528ec554"
+content-hash = "cc2bf01ed35b58e53a045e7ad7e72f1a7800de8ea9eeb54e2b555caf7612c56d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "jsonschema>=4.0.0,<5.0.0",
     # linkml and linkml-runtime versions must be paired — e.g. runtime
     # 1.10.0 removed Format.JSON which linkml 1.9.x references. See #2985.
-    "linkml>=1.10.0,<2.0.0",
-    "linkml-runtime>=1.10.0,<2.0.0",
+    "linkml>=1.9.0,<2.0.0",
+    "linkml-runtime>=1.9.0,<2.0.0",
     "python-dotenv>=0.21.0,<2.0.0",
     "pyyaml>=6.0.0,<7.0.0",
     "rdflib>=6.2.0,<8.0.0",


### PR DESCRIPTION
This is essentially the same as #2900.

The [underlying bug](https://github.com/linkml/linkml/issues/3314) that affects `submission-schema` has been fixed but not released. https://github.com/microbiomedata/nmdc-schema/pull/2986 prematurely brought the `linkml` version constraints back up to 1.10.x. These changes undo that so that `submission-schema` can install the latest `nmdc-schema` and build.