### PR TITLE
fix: stop CodeQL false-positives on Ruby and JS scans

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.ru linguist-language=SPARQL
+assets/units-sparql/*.ru linguist-language=SPARQL
 assets/mongodb_queries/** linguist-detectable=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.ru linguist-language=SPARQL
+assets/mongodb_queries/** linguist-detectable=false


### PR DESCRIPTION
The CodeQL default-setup scan was producing two recurring problems on every run:

1. **Ruby scan failing** with "No Ruby code found." Linguist defaults `*.ru` (Rack config) to Ruby, and `assets/units-sparql/fix-units-update-v2.ru` is actually a SPARQL update file. Its 6562 bytes accounted for the entire Ruby footprint reported by `gh api .../languages`.
2. **JS/TS scan warning** "Could not process some files due to syntax errors." The MongoDB shell scripts under `assets/mongodb_queries/` aren't standard JavaScript; one (`data_qc/functional_annotation_agg_metagenome_metatranscriptome_annotation_id.js`) has an actual syntax bug that aborts parsing.

`.gitattributes` reclassifies `*.ru` as SPARQL and marks `assets/mongodb_queries/**` as non-detectable so Linguist (and therefore CodeQL) skip them. Real JS like `docs/javascripts/tablesort.js` is still scanned.

The bug in the mongodb_queries file is left as-is; it's a separate concern from CodeQL noise.