### PR TITLE
Type sample_isolated_from / sample_collection_site / sample_growth_conditions with closed enums (closes #3054)

### DIFF
--- a/src/data/valid/Database-isolate-from-culture-collection.yaml
+++ b/src/data/valid/Database-isolate-from-culture-collection.yaml
@@ -48,7 +48,8 @@ organism_sample_set:
     source_mat_id:
       type: nmdc:TextValue
       has_raw_value: dsmz:DSM-6125
-    sample_isolated_from: DSMZ catalog vial
+    sample_collection_site: culture_collection
+    sample_growth_conditions: culture_collection_purchase
     sample_isolation_method: Culture purchased from DSMZ; no in-house isolation step.
   # Expanded culture grown from the catalog cells.
   - id: nmdc:osm-99-3sr885

--- a/src/data/valid/Database-isolate-from-soil-workflow.yaml
+++ b/src/data/valid/Database-isolate-from-soil-workflow.yaml
@@ -15,7 +15,12 @@
 # Organism is a richly-annotated, long-public GOLD reference: Bacillus subtilis
 # 168 (GOLD Go0000781, NCBI Taxonomy 224308, ATCC 6051). Type strain, soil
 # isolate, complete published genome. Selected because it is a canonical soil
-# bacterium with unambiguous non-embargoed public provenance.
+# bacterium with unambiguous non-embargoed public provenance
+# (GOLD organism_v2 is_public='Yes', active='Yes', is_test='No').
+#
+# sample_isolated_from / sample_collection_site values preview the enum PVs
+# proposed in #3054. The slot range is still `string`; PV names are
+# forward-compatible when the enum lands.
 
 biosample_set:
   - id: nmdc:bsm-99-dss5dg
@@ -62,7 +67,8 @@ organism_sample_set:
     associated_studies:
       - nmdc:sty-99-md8u3e
     expected_organism: nmdc:orgn-99-vsds2v
-    sample_isolated_from: Example soil isolation
+    sample_isolated_from: soil
+    sample_collection_site: field
   # Expanded culture after culturing
   - id: nmdc:osm-99-jss44u
     type: nmdc:OrganismSample

--- a/src/data/valid/Database-isolate-from-soil-workflow.yaml
+++ b/src/data/valid/Database-isolate-from-soil-workflow.yaml
@@ -18,9 +18,8 @@
 # bacterium with unambiguous non-embargoed public provenance
 # (GOLD organism_v2 is_public='Yes', active='Yes', is_test='No').
 #
-# sample_isolated_from / sample_collection_site values preview the enum PVs
-# proposed in #3054. The slot range is still `string`; PV names are
-# forward-compatible when the enum lands.
+# sample_isolated_from / sample_collection_site values use the enum PVs
+# introduced in #3054 at the relevant scope.
 
 biosample_set:
   - id: nmdc:bsm-99-dss5dg

--- a/src/data/valid/Database-jgi-isolate-submission.yaml
+++ b/src/data/valid/Database-jgi-isolate-submission.yaml
@@ -44,7 +44,7 @@ organism_sample_set:
       - gold:Go0000189
     samp_name: Shewanella_loihica_PV-4
     sample_isolation_method: Wizard Genomic DNA Purification Kit
-    sample_isolated_from: Iron-rich microbial mat from hydrothermal vent, 1325 m depth, Naha Vents, south rift of Loihi seamount, Hawaii
+    sample_isolated_from: microbial_mat
     collection_date:
       type: nmdc:TimestampValue
       has_raw_value: "1998-01-01"

--- a/src/data/valid/Database-leaf-clip.yaml
+++ b/src/data/valid/Database-leaf-clip.yaml
@@ -15,6 +15,9 @@ organism_set:
       - id: NCBITaxon:3702
         name: Arabidopsis thaliana
         type: nmdc:NcbiTaxon
+    organism_genus: Arabidopsis
+    organism_species: thaliana
+    strain_name: Ler-0
 
 organism_sample_set:
   - id: nmdc:osm-99-r6qkjb
@@ -25,8 +28,9 @@ organism_sample_set:
     ploidy: diploid
     gold_organism_identifiers:
       - gold:Go0590511
-    sample_isolated_from: Leaf tissue from Arabidopsis thaliana Ler-0
-    sample_growth_conditions: Greenhouse-grown
+    sample_isolated_from: leaf
+    sample_collection_site: greenhouse
+    sample_growth_conditions: cultivated_indoor
     collection_date:
       type: nmdc:TimestampValue
       has_raw_value: "2025-06-15"

--- a/src/data/valid/Database-mushroom-cap.yaml
+++ b/src/data/valid/Database-mushroom-cap.yaml
@@ -16,6 +16,9 @@ organism_set:
       - id: NCBITaxon:5353
         name: Lentinula edodes
         type: nmdc:NcbiTaxon
+    organism_genus: Lentinula
+    organism_species: edodes
+    strain_name: NBRC 111202
 
 organism_sample_set:
   - id: nmdc:osm-99-c3hw28
@@ -25,8 +28,11 @@ organism_sample_set:
     expected_organism: nmdc:orgn-99-tagdby
     gold_organism_identifiers:
       - gold:Go0372970
-    sample_isolated_from: Fruiting body cap of Lentinula edodes (shiitake)
-    sample_growth_conditions: Cultivated
+    source_mat_id:
+      type: nmdc:TextValue
+      has_raw_value: nbrc:111202
+    sample_isolated_from: fruiting_body
+    sample_growth_conditions: cultivated_indoor
     collection_date:
       type: nmdc:TimestampValue
       has_raw_value: "2025-09-20"

--- a/src/data/valid/Database-rhizosphere-isolate.yaml
+++ b/src/data/valid/Database-rhizosphere-isolate.yaml
@@ -1,24 +1,26 @@
 # Microbe-from-plant compound decomposition example.
 #
 # Demonstrates how a JGI/GOLD compound `sample_isolated_from` value
-# ("root surface of cotton") decomposes into NMDC typed slots:
-#   - `sample_isolated_from`: root      (PV from SampleIsolatedFromEnum)
-#   - `host_taxid`:           NCBITaxon:3635 (Gossypium hirsutum, cotton)
-#   - `sample_collection_site`: field   (cotton was field-grown)
-#   - `source_mat_id`:        atcc:BAA-477
+# ("root surface of cotton") decomposes into NMDC typed slots, and how the
+# host is captured as a first-class Organism reference rather than a bare
+# taxon ID. Compound decomposition:
+#   - `sample_isolated_from`: root           (PV from SampleIsolatedFromEnum)
+#   - `host_organism`:        cotton Organism record (with classified_as → NCBITaxon:3635)
+#   - `sample_collection_site`: field        (cotton was field-grown)
+#   - `source_mat_id`:        atcc:BAA-477   (catalog accession for the focal organism)
 #
-# Organism is a richly-annotated, long-public GOLD reference:
-# Pseudomonas protegens Pf-5 (GOLD Go0000479, NCBI Taxonomy 220664,
-# ATCC BAA-477). Famous biocontrol bacterium isolated by Charles Howell
-# from the rhizoplane of cotton (Gossypium hirsutum).
-# Verified in "gold-db-2 postgresql".gold.organism_v2 on 2026-05-14
-# with is_public='Yes', active='Yes', is_test='No', and ecosystem path
+# Focal organism: Pseudomonas protegens Pf-5 (GOLD Go0000479, NCBI Taxonomy
+# 220664, ATCC BAA-477). Famous biocontrol bacterium isolated by Charles
+# Howell from the rhizoplane of cotton (Gossypium hirsutum). Verified in
+# "gold-db-2 postgresql".gold.organism_v2 on 2026-05-14 with is_public='Yes',
+# active='Yes', is_test='No', and ecosystem path
 # Host-associated > Plants > Roots > Rhizoplane.
 #
 # Compares to Database-isolate-from-soil-workflow.yaml (environmental
 # isolation, no host) and Database-leaf-clip.yaml (plant as focal organism,
 # not host) — this fixture uniquely exercises the typed-host pattern where
-# a microbe (Pf-5) is isolated FROM a plant tissue (cotton root surface).
+# a microbe (Pf-5) is isolated FROM a plant tissue (cotton root surface),
+# with the host (cotton) modeled as its own Organism instance.
 
 study_set:
   - id: nmdc:sty-99-rhizosft
@@ -37,6 +39,15 @@ organism_set:
     organism_genus: Pseudomonas
     organism_species: protegens
     strain_name: Pf-5
+  - id: nmdc:orgn-99-cot0001
+    type: nmdc:Organism
+    name: Gossypium hirsutum
+    classified_as:
+      - id: NCBITaxon:3635
+        name: Gossypium hirsutum
+        type: nmdc:NcbiTaxon
+    organism_genus: Gossypium
+    organism_species: hirsutum
 
 organism_sample_set:
   - id: nmdc:osm-99-pf5root
@@ -46,17 +57,11 @@ organism_sample_set:
     associated_studies:
       - nmdc:sty-99-rhizosft
     expected_organism: nmdc:orgn-99-pf5rhiz
+    host_organism: nmdc:orgn-99-cot0001
     gold_organism_identifiers:
       - gold:Go0000479
     source_mat_id:
       type: nmdc:TextValue
       has_raw_value: atcc:BAA-477
-    host_taxid:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: NCBITaxon:3635
-      term:
-        type: nmdc:OntologyClass
-        id: NCBITaxon:3635
-        name: Gossypium hirsutum
     sample_isolated_from: root
     sample_collection_site: field

--- a/src/data/valid/Database-rhizosphere-isolate.yaml
+++ b/src/data/valid/Database-rhizosphere-isolate.yaml
@@ -1,0 +1,62 @@
+# Microbe-from-plant compound decomposition example.
+#
+# Demonstrates how a JGI/GOLD compound `sample_isolated_from` value
+# ("root surface of cotton") decomposes into NMDC typed slots:
+#   - `sample_isolated_from`: root      (PV from SampleIsolatedFromEnum)
+#   - `host_taxid`:           NCBITaxon:3635 (Gossypium hirsutum, cotton)
+#   - `sample_collection_site`: field   (cotton was field-grown)
+#   - `source_mat_id`:        atcc:BAA-477
+#
+# Organism is a richly-annotated, long-public GOLD reference:
+# Pseudomonas protegens Pf-5 (GOLD Go0000479, NCBI Taxonomy 220664,
+# ATCC BAA-477). Famous biocontrol bacterium isolated by Charles Howell
+# from the rhizoplane of cotton (Gossypium hirsutum).
+# Verified in "gold-db-2 postgresql".gold.organism_v2 on 2026-05-14
+# with is_public='Yes', active='Yes', is_test='No', and ecosystem path
+# Host-associated > Plants > Roots > Rhizoplane.
+#
+# Compares to Database-isolate-from-soil-workflow.yaml (environmental
+# isolation, no host) and Database-leaf-clip.yaml (plant as focal organism,
+# not host) — this fixture uniquely exercises the typed-host pattern where
+# a microbe (Pf-5) is isolated FROM a plant tissue (cotton root surface).
+
+study_set:
+  - id: nmdc:sty-99-rhizosft
+    type: nmdc:Study
+    name: Rhizosphere isolate example study
+    study_category: research_study
+
+organism_set:
+  - id: nmdc:orgn-99-pf5rhiz
+    type: nmdc:Organism
+    name: Pseudomonas protegens Pf-5
+    classified_as:
+      - id: NCBITaxon:220664
+        name: Pseudomonas protegens Pf-5
+        type: nmdc:NcbiTaxon
+    organism_genus: Pseudomonas
+    organism_species: protegens
+    strain_name: Pf-5
+
+organism_sample_set:
+  - id: nmdc:osm-99-pf5root
+    type: nmdc:OrganismSample
+    name: Pseudomonas protegens Pf-5 rhizoplane isolate
+    samp_name: Pprotegens_Pf-5_cottonRoot_01
+    associated_studies:
+      - nmdc:sty-99-rhizosft
+    expected_organism: nmdc:orgn-99-pf5rhiz
+    gold_organism_identifiers:
+      - gold:Go0000479
+    source_mat_id:
+      type: nmdc:TextValue
+      has_raw_value: atcc:BAA-477
+    host_taxid:
+      type: nmdc:ControlledIdentifiedTermValue
+      has_raw_value: NCBITaxon:3635
+      term:
+        type: nmdc:OntologyClass
+        id: NCBITaxon:3635
+        name: Gossypium hirsutum
+    sample_isolated_from: root
+    sample_collection_site: field

--- a/src/data/valid/Database-viral-isolate-with-host.yaml
+++ b/src/data/valid/Database-viral-isolate-with-host.yaml
@@ -52,6 +52,10 @@ organism_set:
       - id: NCBITaxon:10665
         name: Escherichia virus T4
         type: nmdc:NcbiTaxon
+    organism_genus: Tequatrovirus
+    organism_species: Escherichia virus T4
+    # strain_name omitted: T4 is the species-level name; phage taxonomy
+    # does not map cleanly to the JGI-form genus/species/strain trio.
 
 organism_sample_set:
   - id: nmdc:osm-99-vqkvad
@@ -60,5 +64,7 @@ organism_sample_set:
     associated_studies:
       - nmdc:sty-99-r5xs9t
     expected_organism: nmdc:orgn-99-pgw8nq
-    sample_isolated_from: Lysate from a phage-infected bacterial culture
-    sample_growth_conditions: E. coli K-12 MG1655 broth culture infected with phage T4
+    # No clean SampleIsolatedFromEnum PV for "phage lysate" — the
+    # sample_isolated_from slot is omitted. Host context is on host_taxid.
+    sample_collection_site: laboratory
+    sample_growth_conditions: liquid_culture

--- a/src/data/valid/Database-viral-isolate-with-host.yaml
+++ b/src/data/valid/Database-viral-isolate-with-host.yaml
@@ -1,10 +1,13 @@
 # Viral isolate scenario: a phage harvested from an E. coli K-12 lysate.
-# The phage is the focal Organism; its OrganismSample carries upstream
-# Biosample provenance where the host bacterium is identified via the
-# host_genus / host_species / host_strain slots (NMDC-native, sourced from
-# the JGI Isolate (NA) v19 form fields "Host Genus" / "Host Species" /
-# "Host Strain"). host_taxid (MIxS-imported) on the Biosample carries the
-# NCBI Taxonomy ID for the host when known.
+# The phage is the focal Organism; its OrganismSample identifies the host
+# bacterium via the typed `host_organism` reference (linked Organism record
+# for E. coli K-12 MG1655 in this fixture). This mirrors the focal-vs-host
+# pattern used in Database-rhizosphere-isolate.yaml.
+#
+# The accompanying Biosample (the bacterial lysate substrate) still carries
+# its legacy flat MIxS host slots (host_taxid / host_genus / host_species /
+# host_strain). Aligning Biosample to the same linked-data host pattern is
+# tracked separately as a follow-up; see #3075.
 #
 # Real organisms used as a placeholder reference:
 #   - Phage (focal): Enterobacteria phage T4 (NCBITaxon:10665)
@@ -56,6 +59,16 @@ organism_set:
     organism_species: Escherichia virus T4
     # strain_name omitted: T4 is the species-level name; phage taxonomy
     # does not map cleanly to the JGI-form genus/species/strain trio.
+  - id: nmdc:orgn-99-ecoli01
+    type: nmdc:Organism
+    name: Escherichia coli K-12 substr. MG1655
+    classified_as:
+      - id: NCBITaxon:511145
+        name: Escherichia coli str. K-12 substr. MG1655
+        type: nmdc:NcbiTaxon
+    organism_genus: Escherichia
+    organism_species: coli
+    strain_name: K-12 MG1655
 
 organism_sample_set:
   - id: nmdc:osm-99-vqkvad
@@ -64,7 +77,8 @@ organism_sample_set:
     associated_studies:
       - nmdc:sty-99-r5xs9t
     expected_organism: nmdc:orgn-99-pgw8nq
+    host_organism: nmdc:orgn-99-ecoli01
     # No clean SampleIsolatedFromEnum PV for "phage lysate" — the
-    # sample_isolated_from slot is omitted. Host context is on host_taxid.
+    # sample_isolated_from slot is omitted.
     sample_collection_site: laboratory
     sample_growth_conditions: liquid_culture

--- a/src/data/valid/OrganismSample-jgi-isolate-example.yaml
+++ b/src/data/valid/OrganismSample-jgi-isolate-example.yaml
@@ -10,7 +10,7 @@ name: Ruegeria pomeroyi DSS-3 isolate submission
 samp_name: Ruegeria_pomeroyi_DSS-3
 expected_organism: nmdc:orgn-99-6wrr79
 sample_isolation_method: Wizard Genomic DNA Purification Kit
-sample_isolated_from: Saltwater from water column off the Georgia coast, USA
+sample_isolated_from: sea_water
 collection_date:
   type: nmdc:TimestampValue
   has_raw_value: "1998-03-01"

--- a/src/docs/jgi-isolate-field-routing.md
+++ b/src/docs/jgi-isolate-field-routing.md
@@ -165,3 +165,47 @@ form e.g. `CIP 54.8` until prefixes are added):
 
 Adding bioregistry-resolvable prefixes for these is tracked in
 [#3036](https://github.com/microbiomedata/nmdc-schema/issues/3036).
+
+## Decomposing GOLD compound `sample_isolated_from` values into NMDC typed slots
+
+GOLD's `dw_samples.sample_isolated_from` is a single free-text column historically populated with values that conflate origin matrix, collection site, growth conditions, and host context. Per [#3054](https://github.com/microbiomedata/nmdc-schema/issues/3054), NMDC splits these concepts into typed slots on `OrganismSample`:
+
+- `sample_isolated_from` — origin matrix (the *what*), enum-typed
+- `sample_collection_site` — site category (the *where*), enum-typed
+- `sample_growth_conditions` — lab maintenance (interim free-text; full decomposition in [#3027](https://github.com/microbiomedata/nmdc-schema/issues/3027) / [#3065](https://github.com/microbiomedata/nmdc-schema/issues/3065))
+- `host_taxid` — host NCBI Taxonomy ID
+
+On export back to GOLD/JGI, the typed slots recombine into the legacy flat string.
+
+### Worked examples
+
+| GOLD source value | `sample_isolated_from` | `sample_collection_site` | `host_taxid` | `geo_loc_name` | Notes |
+|---|---|---|---|---|---|
+| `leaf` / `Leaf` / `Leaves` | `leaf` | — | — | — | Case/plural variants all map to single PV; structured_aliases attribute the originals |
+| `Sorghum bicolor - root` | `root` | — | `NCBITaxon:4558` | — | Host + tissue compound: host goes to `host_taxid`, tissue to origin matrix |
+| `maize rhizosphere soils` | `rhizosphere` | — | `NCBITaxon:4577` | — | Same pattern; rhizosphere is the matrix, maize is the host |
+| `Switchgrass Roots` | `root` | — | `NCBITaxon:38727` | — | Plant-host isolate from root tissue |
+| `Iron-rich microbial mat from hydrothermal vent` | `microbial_mat` | — | — | — | Narrative GOLD value collapses to single PV; remaining geo context goes to `geo_loc_name` / `lat_lon` |
+| `seawater` | `sea_water` | — | — | — | Case-normalized |
+| `DSMZ catalog vial` | — | `culture_collection` | — | — | No origin matrix; site is "culture_collection"; catalog accession on `source_mat_id` |
+| `Greenhouse` (alone) | — | `greenhouse` | — | — | Site-only value, no matrix |
+| `Field-grown common garden of wild sourced seedlots, near Greytown, KZN, South Africa` | — | `field` | — | `South Africa` | Narrative site description: site category → enum PV, place name → `geo_loc_name` |
+| `Liquid culture from a frozen stock` | — | — | — | — | Growth-state value: routes to `sample_growth_conditions` PV `liquid_culture` |
+| `single colony isolate` | — | — | — | — | Routes to `sample_isolation_method` (the *how*), not to any of the three new slots |
+
+### Mapping advice for the JGI/GOLD round-trip
+
+**NMDC → JGI field 44 (Sample Isolated From\*)**: the PV's label for `sample_isolated_from` (e.g., `leaf` → "leaf"). If the matrix is host-tissue, optionally prepend host common name from `host_taxid` lookup for JGI's preferred display ("Sorghum bicolor - root").
+
+**NMDC → JGI field 45 (Collection Site or Growth Conditions\*)**: prefer the populated slot. If `sample_growth_conditions` is set, emit its label. If `sample_collection_site` is set, emit its label (optionally suffixed by `geo_loc_name`).
+
+**NMDC → GOLD `dw_samples.sample_isolated_from`**: concatenate matrix + site + growth + host in whatever order GOLD historically uses, semicolon-separated, with empty parts elided. The unit tests for the exporter should round-trip the worked examples above.
+
+### What does NOT belong in any of these three slots
+
+- Sample names ("S1321") → `samp_name`
+- Submitter notes / project descriptions → `description` (inherited)
+- Sample-to-sample provenance ("Y was isolated from X") → `sample_link` / typed link (see [#3033](https://github.com/microbiomedata/nmdc-schema/issues/3033))
+- Specific lat/lon → `lat_lon`; elevation → `elev`; country → `geo_loc_name`
+- Collection date → `collection_date`
+- DNA extraction kit / protocol → `sample_isolation_method` (the *how*, not the *what* or *where*)

--- a/src/docs/jgi-isolate-field-routing.md
+++ b/src/docs/jgi-isolate-field-routing.md
@@ -173,9 +173,10 @@ Adding bioregistry-resolvable prefixes for these is tracked in
 
 GOLD's `dw_samples.sample_isolated_from` is a single free-text column historically populated with values that conflate origin matrix, collection site, growth conditions, and host context. Per [#3054](https://github.com/microbiomedata/nmdc-schema/issues/3054), NMDC splits these concepts into typed slots on `OrganismSample`:
 
-- `sample_isolated_from` — origin matrix (the *what*), enum-typed
+- `sample_isolated_from` — origin matrix (the *what*); on `OrganismSample`, range is `any_of: [SampleIsolatedFromEnum, string]` with a `structured_pattern` accepting either a PV name (`leaf`) or env_medium-style bracket form (`leaf [PO:0025034]`)
 - `sample_collection_site` — site category (the *where*), enum-typed
 - `sample_growth_conditions` — lab maintenance (interim free-text; full decomposition in [#3027](https://github.com/microbiomedata/nmdc-schema/issues/3027) / [#3065](https://github.com/microbiomedata/nmdc-schema/issues/3065))
+- `isolation_details` — free-text fallback (`recommended: false`) for any isolation-provenance content that does not fit the three typed slots above; catches the long tail of narrative descriptions observed in GOLD `dw_samples.sample_isolated_from`
 - `host_organism` — typed reference to an `Organism` instance whose `classified_as` carries the host's NCBI Taxonomy CURIE
 
 On export back to GOLD/JGI, the typed slots recombine into the legacy flat string. For the host string fields (JGI v19 fields Host Genus / Species / Strain), traverse `host_organism.organism_genus` / `host_organism.organism_species` / `host_organism.strain_name`.

--- a/src/docs/jgi-isolate-field-routing.md
+++ b/src/docs/jgi-isolate-field-routing.md
@@ -27,31 +27,34 @@ to nmdc-schema classes, submission-schema, or deferred.
 | 48-49 | Depth/Max depth* | (deferred — removed from OrganismSample in PR #2977 review pass; see review thread for retain-vs-drop discussion) | MIxS (existing) |
 | 50-51 | Elevation/Max elevation* | `elev` | MIxS (existing) |
 | 52 | Country* | `geo_loc_name` | MIxS (existing) |
-| — | Expected organism | `expected_organism` | NMDC-native (new) |
-| 19 | Host NCBI Tax ID* | `host_taxid` (also on `Biosample`) | MIxS (existing) |
+| — | Expected organism | `expected_organism` | NMDC-native |
+| 19 | Host NCBI Tax ID* (and host name) | `host_organism` (on `OrganismSample`); same pattern as `expected_organism` — a typed reference to an `Organism` instance, whose `classified_as` carries the NCBI Taxonomy CURIE and whose `organism_genus / organism_species / strain_name` carry the JGI-form host-name text fields | NMDC-native (new in #3054) |
 
-### Note on host_taxid and the JGI viral-isolate use case
+### Note on `host_organism` vs the legacy `host_taxid` slot
 
-The JGI form labels field 19 ("Host NCBI Tax ID") as *for viral isolates only*.
-That framing is **not** baked into nmdc-schema. `host_taxid` is the general
-MIxS slot (`MIXS:0000250`) describing the host of a sample, applicable to any
-host-associated submission — viral, host-microbiome, parasite, etc. The
-sample-level placement (Biosample, OrganismSample) is the only structural
-constraint at the schema layer.
+`OrganismSample` uses `host_organism` (range: `Organism`) rather than the
+flat MIxS `host_taxid` slot. The pattern mirrors `expected_organism`:
+`OrganismSample → host_organism → Organism → classified_as → NcbiTaxon`,
+with `Organism.organism_genus / organism_species / strain_name` providing
+the text-level redundancy the JGI Isolate v19 form expects (Host Genus /
+Host Species / Host Strain).
 
-The viral-specific framing is a **submission-schema concern**. Whether
-`host_taxid` is required, what label/help-text it carries, and what input
-controls validate it for a given submission are decided by submission-schema
-interfaces / templates / slot_usage — for example a `JgiViralIsolateInterface`
-in submission-schema can mark `host_taxid` required and label it "Host NCBI
-Tax ID (required for viral isolates)" without nmdc-schema needing a
-viral-specific slot.
+This is the same pattern used for the focal organism; reusing it for the
+host avoids parallel ID-only and name-only host slots on OrganismSample.
+The Pf-5-from-cotton example (`Database-rhizosphere-isolate.yaml`) is the
+canonical demonstration: a cotton `Organism` record carries
+`classified_as: NCBITaxon:3635`, `organism_genus: Gossypium`,
+`organism_species: hirsutum`, and the bacterial-isolate `OrganismSample`
+references it via `host_organism: nmdc:orgn-99-cot0001`.
+
+`Biosample` continues to use the legacy flat `host_taxid` /
+`host_genus` / `host_species` / `host_strain` slots; aligning Biosample to
+the same linked-data pattern is out of scope for #3054 and is tracked as
+a follow-up.
 
 Broader normalization of taxon-bearing slots to use `NcbiTaxon` as their
 range (rather than strings or CURIEs in `has_raw_value`) is tracked in
-[#3000](https://github.com/microbiomedata/nmdc-schema/issues/3000). `host_taxid`
-is a likely first concrete migration target once `ontology_class_set` is
-loaded with NcbiTaxon from semantic-sql / OWL.
+[#3000](https://github.com/microbiomedata/nmdc-schema/issues/3000).
 
 ## Organism (orgn)
 
@@ -173,18 +176,18 @@ GOLD's `dw_samples.sample_isolated_from` is a single free-text column historical
 - `sample_isolated_from` — origin matrix (the *what*), enum-typed
 - `sample_collection_site` — site category (the *where*), enum-typed
 - `sample_growth_conditions` — lab maintenance (interim free-text; full decomposition in [#3027](https://github.com/microbiomedata/nmdc-schema/issues/3027) / [#3065](https://github.com/microbiomedata/nmdc-schema/issues/3065))
-- `host_taxid` — host NCBI Taxonomy ID
+- `host_organism` — typed reference to an `Organism` instance whose `classified_as` carries the host's NCBI Taxonomy CURIE
 
-On export back to GOLD/JGI, the typed slots recombine into the legacy flat string.
+On export back to GOLD/JGI, the typed slots recombine into the legacy flat string. For the host string fields (JGI v19 fields Host Genus / Species / Strain), traverse `host_organism.organism_genus` / `host_organism.organism_species` / `host_organism.strain_name`.
 
 ### Worked examples
 
-| GOLD source value | `sample_isolated_from` | `sample_collection_site` | `host_taxid` | `geo_loc_name` | Notes |
+| GOLD source value | `sample_isolated_from` | `sample_collection_site` | `host_organism.classified_as` | `geo_loc_name` | Notes |
 |---|---|---|---|---|---|
 | `leaf` / `Leaf` / `Leaves` | `leaf` | — | — | — | Case/plural variants all map to single PV; structured_aliases attribute the originals |
-| `Sorghum bicolor - root` | `root` | — | `NCBITaxon:4558` | — | Host + tissue compound: host goes to `host_taxid`, tissue to origin matrix |
-| `maize rhizosphere soils` | `rhizosphere` | — | `NCBITaxon:4577` | — | Same pattern; rhizosphere is the matrix, maize is the host |
-| `Switchgrass Roots` | `root` | — | `NCBITaxon:38727` | — | Plant-host isolate from root tissue |
+| `Sorghum bicolor - root` | `root` | — | `NCBITaxon:4558` (via Sorghum Organism record) | — | Host + tissue compound: host goes to a typed Organism reference, tissue to origin matrix |
+| `maize rhizosphere soils` | `rhizosphere` | — | `NCBITaxon:4577` (via Zea Organism record) | — | Same pattern; rhizosphere is the matrix, maize is the host |
+| `Switchgrass Roots` | `root` | — | `NCBITaxon:38727` (via Panicum Organism record) | — | Plant-host isolate from root tissue |
 | `Iron-rich microbial mat from hydrothermal vent` | `microbial_mat` | — | — | — | Narrative GOLD value collapses to single PV; remaining geo context goes to `geo_loc_name` / `lat_lon` |
 | `seawater` | `sea_water` | — | — | — | Case-normalized |
 | `DSMZ catalog vial` | — | `culture_collection` | — | — | No origin matrix; site is "culture_collection"; catalog accession on `source_mat_id` |
@@ -195,7 +198,7 @@ On export back to GOLD/JGI, the typed slots recombine into the legacy flat strin
 
 ### Mapping advice for the JGI/GOLD round-trip
 
-**NMDC → JGI field 44 (Sample Isolated From\*)**: the PV's label for `sample_isolated_from` (e.g., `leaf` → "leaf"). If the matrix is host-tissue, optionally prepend host common name from `host_taxid` lookup for JGI's preferred display ("Sorghum bicolor - root").
+**NMDC → JGI field 44 (Sample Isolated From\*)**: the PV's label for `sample_isolated_from` (e.g., `leaf` → "leaf"). If the matrix is host-tissue, optionally prepend the host's organism name from `host_organism.name` for JGI's preferred display ("Sorghum bicolor - root").
 
 **NMDC → JGI field 45 (Collection Site or Growth Conditions\*)**: prefer the populated slot. If `sample_growth_conditions` is set, emit its label. If `sample_collection_site` is set, emit its label (optionally suffixed by `geo_loc_name`).
 

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -1537,3 +1537,276 @@ enums:
           the named ploidy classes. The original free-text qualifier should be
           preserved upstream (e.g. in a sample-level note) when it carries
           information beyond the bare classification.
+
+  SampleIsolatedFromEnum:
+    description: >-
+      Origin matrix from which an OrganismSample was isolated — the *what*
+      it came out of.
+    comments:
+      - >-
+        PV names follow snake_case. `meaning:` annotations prefer GOLDVOCAB
+        where the GOLD ecosystem vocabulary has clean coverage, falling back
+        to ENVO / PO / UBERON otherwise. PVs without `meaning:` (e.g.
+        `fruiting_body`) reflect documented gaps in OBO coverage.
+      - >-
+        The `other` permissible value is the escape hatch for genuinely
+        out-of-list values. Recurring `other` captures should be reviewed
+        and promoted to new PVs.
+      - >-
+        Geographic / site context routes to `sample_collection_site`;
+        lab-maintenance context routes to `sample_growth_conditions`.
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
+    permissible_values:
+      leaf:
+        description: Plant leaf tissue
+        meaning: PO:0025034
+        aliases: [leaves]
+        structured_aliases:
+          - literal_form: Leaf
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: EXACT_SYNONYM
+          - literal_form: Leaves
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: EXACT_SYNONYM
+          - literal_form: silica dried leaf tissue
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      root:
+        description: Plant root tissue
+        meaning: PO:0009005
+        aliases: [roots]
+        structured_aliases:
+          - literal_form: Roots
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: EXACT_SYNONYM
+          - literal_form: root surface of cotton
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      root_nodule:
+        description: Root nodule (N-fixing symbiosis structure on legume root)
+        meaning: PO:0003023
+      stem:
+        description: Plant stem tissue
+        meaning: PO:0009047
+      flower:
+        description: Plant flower tissue
+        meaning: PO:0009046
+      xylem:
+        description: Vascular xylem
+        meaning: PO:0005352
+      rhizosphere:
+        description: Soil region influenced by plant roots
+        meaning: GOLDVOCAB:Rhizosphere
+        structured_aliases:
+          - literal_form: maize rhizosphere soil
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+          - literal_form: maize rhizosphere soils
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      soil:
+        description: Soil
+        meaning: GOLDVOCAB:Soil
+        aliases: [soils]
+        structured_aliases:
+          - literal_form: Soil
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: EXACT_SYNONYM
+          - literal_form: garden soil
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      peat:
+        description: Peat / peat soil
+        meaning: GOLDVOCAB:Peat
+      sediment:
+        description: Sediment (unqualified)
+        meaning: ENVO:00002007
+      marine_sediment:
+        description: Marine sediment
+        meaning: GOLDVOCAB:Marine-sediment
+      mud:
+        description: Mud
+        meaning: GOLDVOCAB:Mud
+      sea_water:
+        description: Sea water (marine)
+        meaning: GOLDVOCAB:Sea-water
+        aliases: [seawater]
+        structured_aliases:
+          - literal_form: Seawater
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: EXACT_SYNONYM
+      fresh_water:
+        description: Fresh water (lake, river, pond, spring)
+        meaning: ENVO:00002011
+        structured_aliases:
+          - literal_form: Freshwater Lake
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      wastewater:
+        description: Wastewater (industrial, municipal, agricultural)
+        meaning: GOLDVOCAB:Wastewater
+      sludge:
+        description: Sludge (activated, anaerobic, biological)
+        meaning: GOLDVOCAB:Sludge
+      microbial_mat:
+        description: Microbial mat
+        meaning: ENVO:01000008
+        structured_aliases:
+          - literal_form: iron-rich microbial mat from hydrothermal vent
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      hot_spring:
+        description: Hot spring environment
+        meaning: ENVO:00000051
+      air:
+        description: Air
+        meaning: GOLDVOCAB:Air
+      feces:
+        description: Feces / fecal material
+        meaning: GOLDVOCAB:Feces
+        aliases: [stool]
+        structured_aliases:
+          - literal_form: Human feces
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      fruiting_body:
+        description: Fungal fruiting body (mushroom cap, conk, sporocarp, etc.).
+        comments:
+          - >-
+            `meaning:` omitted: no clean OBO anatomy term identified. PO is
+            plant-only; GO `fruiting body development` (GO:0030582) is a
+            process term, not anatomy.
+      host_tissue_other:
+        description: Generic host tissue (use only when no more specific PV applies).
+        meaning: UBERON:0000479
+      other:
+        description: Origin matrix that is genuinely outside the closed list.
+        comments:
+          - >-
+            Recurring `other` captures should be reviewed and promoted to
+            new permissible values.
+
+  SampleCollectionSiteEnum:
+    description: >-
+      Site category where an OrganismSample (or its host) was collected.
+    comments:
+      - >-
+        Distinct from environmental biome (which goes on Biosample via
+        `env_broad_scale`) and lab maintenance (`sample_growth_conditions`).
+      - >-
+        PVs without `meaning:` reflect concepts that have no clean ENVO /
+        GOLDVOCAB / OBO term at the time of writing (e.g. `growth_room`,
+        `experimental_garden`, `open_top_chamber`, `culture_collection`).
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
+    permissible_values:
+      field:
+        description: Outdoor field site (agricultural or natural).
+        meaning: ENVO:01000352
+        structured_aliases:
+          - literal_form: Field
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: EXACT_SYNONYM
+          - literal_form: Field-grown common garden of wild sourced seedlots
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      greenhouse:
+        description: Greenhouse cultivation site.
+        meaning: GOLDVOCAB:Greenhouse
+        aliases: [glasshouse]
+      growth_chamber:
+        description: Controlled-environment plant growth chamber, bench- or stack-scale.
+        meaning: GOLDVOCAB:Plant-growth-chamber
+      growth_room:
+        description: >-
+          Walk-in growth room (e.g., phytotron room) that accommodates plants
+          at full height.
+        comments:
+          - Distinct from `growth_chamber`, which is bench- or stack-scale.
+          - "`meaning:` omitted: no clean ontology term identified."
+      experimental_garden:
+        description: Experimental or common garden.
+        comments:
+          - "`meaning:` omitted: no clean ontology term identified."
+      open_top_chamber:
+        description: Open-top experimental field chamber (CO2 / UV manipulation studies).
+        comments:
+          - "`meaning:` omitted: no clean ontology term identified."
+      laboratory:
+        description: Lab bench / lab-derived sample.
+        meaning: GOLDVOCAB:Laboratory-developed
+      culture_collection:
+        description: Sample received from a culture collection catalog (DSMZ, ATCC, etc.).
+        comments:
+          - The catalog identifier itself belongs on `source_mat_id`.
+          - "`meaning:` omitted: no clean ontology term identified."
+      deep_subsurface:
+        description: Deep subsurface / well / aquifer.
+        meaning: GOLDVOCAB:Deep-subsurface
+        aliases: ["deep well"]
+        structured_aliases:
+          - literal_form: Deep well
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      other:
+        description: Collection site that is genuinely outside the closed list.
+        comments:
+          - >-
+            Recurring `other` captures should be reviewed and promoted to
+            new permissible values.
+
+  SampleGrowthConditionsEnum:
+    description: >-
+      In-vitro growth / maintenance context for an OrganismSample.
+    comments:
+      - >-
+        Interim coarse classification. Most PVs lack `meaning:` because OBI /
+        PATO / GO do not cover these maintenance states as discrete classes.
+      - >-
+        Full decomposition into typed sub-slots (media, temperature, atmosphere,
+        time) is deferred to the Isolation / Culturing class redesign.
+    todos:
+      - >-
+        When the Culturing class redesign lands, revisit whether the values
+        here move to typed Culturing sub-slots and this enum is retired
+        or narrowed.
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
+      - https://github.com/microbiomedata/nmdc-schema/issues/3027
+      - https://github.com/microbiomedata/nmdc-schema/issues/3065
+    permissible_values:
+      liquid_culture:
+        description: Maintained in liquid culture broth.
+        structured_aliases:
+          - literal_form: Liquid culture from a frozen stock
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      solid_plate:
+        description: Maintained on solid agar plate (e.g., single-colony pick).
+        structured_aliases:
+          - literal_form: single colony isolate
+            contexts: [https://gold.jgi.doe.gov/]
+            predicate: NARROW_SYNONYM
+      frozen_stock:
+        description: Sample derived from a frozen glycerol or DMSO stock.
+      clonal_line:
+        description: Maintained as a clonal cell line.
+      cultivated_indoor:
+        description: Cultivated in an indoor controlled environment (greenhouse, chamber, room).
+        comments:
+          - The specific facility category is captured by `sample_collection_site`.
+      cultivated_outdoor:
+        description: Cultivated in an outdoor controlled environment (field, garden, open-top chamber).
+      culture_collection_purchase:
+        description: Received from a culture collection with no in-house growth step.
+        comments:
+          - Pair with `source_mat_id` for the catalog identifier.
+      not_recorded:
+        description: Growth or maintenance context not recorded by the submitter.
+      other:
+        description: Growth context that is genuinely outside the closed list.
+        comments:
+          - >-
+            Recurring `other` captures should be reviewed and promoted to
+            new permissible values.

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -163,22 +163,53 @@ slots:
     range: string
 
   sample_collection_site:
-    description: >-
-      Free-text description of the place where the sample was collected — the
-      geographic / environmental site or named location.
+    range: string
+    description: Place where the sample was collected.
     comments:
       - >-
-        On `OrganismSample`, this slot routes the collection-site half of JGI
-        Isolate (NA) v19 form field 45 ("Collection Site or Growth Conditions").
-        The growth-conditions half routes to `sample_growth_conditions`. The
-        submitter populates one or the other depending on whether the sample
-        came from a field collection or from in-vitro maintenance.
+        On Biosample, used historically as a free-text place / locality
+        descriptor (e.g. "Lithgow State Coal Mine").
+      - >-
+        On OrganismSample, the range is narrowed via `slot_usage` to
+        `SampleCollectionSiteEnum` for the closed site-category vocabulary
+        (field, greenhouse, growth_chamber, etc.). See #3054.
+      - >-
+        Geographic place names (countries, regions, specific localities) go
+        to `geo_loc_name` and `lat_lon`, not here.
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
     structured_aliases:
       - literal_form: Collection Site or Growth Conditions
         contexts:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: NARROW_SYNONYM    # JGI label bundles two concepts; this slot covers only the collection-site half
-    range: string
+    examples:
+      # The values below preview the closed enum proposed in #3054 (SampleCollectionSiteEnum).
+      - value: field
+        description: >-
+          Maps to enum PV `field` (meaning ENVO:01000352). GOLD narrative values like
+          "Field-grown common garden of wild sourced seedlots, near Greytown, KZN,
+          South Africa" decompose: site → here, place name → `geo_loc_name`.
+      - value: greenhouse
+        description: >-
+          Maps to enum PV `greenhouse` (meaning GOLDVOCAB:Greenhouse). Real public
+          exemplar: GOLD Go0590511 (Arabidopsis thaliana Ath.Ler-0.Leaf.1, grown in
+          greenhouse).
+      - value: culture_collection
+        description: >-
+          Maps to enum PV `culture_collection`. The catalog accession itself
+          belongs on `source_mat_id` (CURIE form, e.g. `dsmz:DSM-6125`). Real
+          public exemplar: GOLD Go0001112 (Pseudomonas putida KT2440, DSMZ DSM 6125).
+      - value: laboratory
+        description: >-
+          Maps to enum PV `laboratory` (meaning GOLDVOCAB:Laboratory-developed). Real
+          public exemplar: T4 phage harvested from an E. coli K-12 MG1655 lab broth
+          culture (see `Database-viral-isolate-with-host.yaml`).
+      - value: deep_subsurface
+        description: >-
+          Maps to enum PV `deep_subsurface` (meaning GOLDVOCAB:Deep-subsurface). GOLD
+          case variant `Deep well` collapses here.
+      # See #3054 for the closed enum design and migration plan.
 
   salinity_category:
     description:
@@ -681,73 +712,132 @@ slots:
       - See also dna_isolate_meth in submission-schema for the equivalent portal field.
 
   sample_isolated_from:
+    range: SampleIsolatedFromEnum
     description: >-
-      Free-text description of the environmental or biological matrix from which the
-      organism sample was isolated — the *what* it came out of (e.g. iron-rich microbial
-      mat, leaf tissue, catalog vial). For the *where* (geographic / environmental site
-      of collection) see `sample_collection_site`; for in-vitro growth conditions (lab
-      maintenance, culture media, growth chambers) see `sample_growth_conditions`.
+      Origin matrix from which the organism sample was isolated — the *what*
+      it came out of.
     comments:
       - >-
-        Routes JGI Isolate (NA) v19 form field 44 ("Sample Isolated From"). Field 45
-        ("Collection Site or Growth Conditions") routes to `sample_collection_site` or
-        `sample_growth_conditions` depending on which half the submitter is reporting.
+        Routes JGI Isolate (NA) v19 form field 44 ("Sample Isolated From").
+        Field 45 ("Collection Site or Growth Conditions") routes to
+        `sample_collection_site` or `sample_growth_conditions` depending on
+        which half the submitter is reporting.
       - >-
-        Used when no upstream Biosample carries env-triad information (e.g. culture
-        collection orders, lab-derived samples). When a linked Biosample is available,
-        environmental provenance belongs there. Not a typed reference — future work
-        may add a structured slot or wrapper class for typed sample-to-sample links;
-        see #3033 and #3054.
+        Used when no upstream Biosample carries env-triad information (e.g.
+        culture collection orders, lab-derived samples). When a linked
+        Biosample is available, environmental provenance belongs there.
+      - >-
+        Typed sample-to-sample links ("Y was isolated from X") are out of
+        scope here; see #3033.
     in_subset:
       - jgi_isolate
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
+      - https://github.com/microbiomedata/nmdc-schema/issues/3033
     structured_aliases:
       - literal_form: Sample Isolated From
         contexts:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
-    todos:
-      - >-
-        Redesign in #3054 will sharpen the boundary between this slot and the
-        sample_collection_site / sample_growth_conditions siblings.
     examples:
-      - value: Iron-rich microbial mat from hydrothermal vent, Naha Vents, south rift of Loihi seamount, Hawaii
-        description: GOLD organism_v2 Go0000189 (Shewanella loihica PV-4, queried 2026-04-21)
-      - value: Saltwater from water column off the Georgia coast, USA
-        description: GOLD organism_v2 Go0000514 (Ruegeria pomeroyi DSS-3, queried 2026-04-21)
-      - value: DSMZ catalog vial (DSM 6125)
-        description: Catalog-collection origin — no environmental matrix upstream
+      # The values below preview the closed enum proposed in #3054 (SampleIsolatedFromEnum).
+      # PV names may shift before merge; the underlying public GOLD records are stable.
+      - value: microbial_mat
+        description: >-
+          Maps to enum PV `microbial_mat` (meaning ENVO:01000008). Real public exemplar:
+          GOLD Go0000189 (Shewanella loihica PV-4) — iron-rich microbial mat at the
+          Naha Vents, south rift of Loihi seamount, Hawaii. Queried from
+          "gold-db-2 postgresql".gold.organism_v2 on 2026-04-21.
+      - value: sea_water
+        description: >-
+          Maps to enum PV `sea_water` (meaning GOLDVOCAB:Sea-water). Real public exemplar:
+          GOLD Go0000514 (Ruegeria pomeroyi DSS-3) — saltwater from the water column
+          off the Georgia coast, USA. Case variants `seawater`, `Seawater` collapse here.
+      - value: marine_sediment
+        description: >-
+          Maps to enum PV `marine_sediment` (meaning GOLDVOCAB:Marine-sediment). Real
+          public exemplar: GOLD Go0013501 (Flavobacterium frigidarium DSM 17623) —
+          marine sediment, Adelaide Island, Antarctic.
+      - value: leaf
+        description: >-
+          Maps to enum PV `leaf` (meaning PO:0025034). GOLD case/plural variants
+          `Leaf` / `Leaves` / `leaves` collapse here. Use with `host_taxid` to capture
+          the host plant for plant-associated isolates.
+      - value: root
+        description: >-
+          Maps to enum PV `root` (meaning PO:0009005). GOLD compound values such as
+          "Sorghum bicolor - root" decompose: tissue → here, host species →
+          `host_taxid` (e.g., NCBITaxon:4558 for Sorghum bicolor).
+      - value: rhizosphere
+        description: >-
+          Maps to enum PV `rhizosphere` (meaning GOLDVOCAB:Rhizosphere). GOLD
+          "maize rhizosphere soils" / "maize rhizosphere soil" decompose here, with
+          `host_taxid` = NCBITaxon:4577 for the plant.
+      - value: soil
+        description: >-
+          Maps to enum PV `soil` (meaning GOLDVOCAB:Soil). Case variants `Soil`,
+          `soils` collapse here. Real public exemplar: GOLD Go0000781 (Bacillus
+          subtilis 168).
+      - value: fruiting_body
+        description: >-
+          Maps to enum PV `fruiting_body`. No clean OBO anatomy term for fungal
+          fruiting body; `meaning:` is omitted in the enum (gap documented). Real
+          public exemplar: GOLD Go0372970 (Lentinula edodes NBRC 111202).
+      # See #3054 for the closed enum design and migration plan.
 
   sample_growth_conditions:
+    range: SampleGrowthConditionsEnum
     description: >-
-      Free-text description of the in-vitro conditions under which the organism sample
-      was grown or maintained — culture media, growth chamber settings, facility type,
-      or other lab-controlled growth context. For environmental site context see
-      `sample_collection_site`; for the source matrix the organism came out of see
-      `sample_isolated_from`.
+      In-vitro conditions under which the organism sample was grown or maintained.
     comments:
       - >-
-        On `OrganismSample`, this slot routes the growth-conditions half of JGI
-        Isolate (NA) v19 form field 45 ("Collection Site or Growth Conditions"). The
-        collection-site half routes to `sample_collection_site`. The submitter populates
-        one or the other depending on whether the sample came from a field collection
-        or from in-vitro maintenance.
+        On `OrganismSample`, routes the growth-conditions half of JGI Isolate
+        (NA) v19 form field 45 ("Collection Site or Growth Conditions"). The
+        collection-site half routes to `sample_collection_site`.
       - >-
         Distinct from MIxS `isol_growth_condt` (MIXS:0000003), which expects a
-        publication reference (DOI/PMID/URL pattern), not free-text growth conditions.
+        publication reference (DOI / PMID / URL pattern) rather than a categorical
+        growth state.
+      - >-
+        Interim coarse classification. Finer decomposition into media,
+        temperature, atmosphere, and time is deferred to the Isolation /
+        Culturing class redesign.
     in_subset:
       - jgi_isolate
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
+      - https://github.com/microbiomedata/nmdc-schema/issues/3027
     structured_aliases:
       - literal_form: Collection Site or Growth Conditions
         contexts:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: NARROW_SYNONYM    # JGI label bundles two concepts; this slot covers only the growth-conditions half
     examples:
-      - value: Greenhouse-grown
-        description: Plant-tissue isolate maintained in greenhouse conditions
-      - value: Cultivated indoor; substrate logs of supplemented oak
-        description: Mushroom (Lentinula edodes) cultivation context
-      - value: E. coli K-12 MG1655 broth culture infected with phage T4
-        description: Viral-isolate growth context — host culture conditions
+      # The values below preview the interim SampleGrowthConditionsEnum proposed in #3054.
+      # Full decomposition (media, temperature, atmosphere, time) deferred to #3027 / #3065
+      # — most PVs lack ontology-anchored `meaning:` because OBI/PATO/GO don't cover
+      # these as discrete states.
+      - value: liquid_culture
+        description: >-
+          Maintained in liquid broth. GOLD `dw_samples` top value
+          "Liquid culture from a frozen stock" (n=5,560) collapses here.
+      - value: solid_plate
+        description: >-
+          Maintained on solid agar plate. GOLD "single colony isolate" (n=3,279)
+          collapses here.
+      - value: cultivated_indoor
+        description: >-
+          Indoor controlled growth (greenhouse, chamber, room). Real public exemplars:
+          GOLD Go0590511 (Arabidopsis thaliana Ler-0, greenhouse) and GOLD Go0372970
+          (Lentinula edodes, "Cultivated indoor; substrate logs of supplemented oak").
+      - value: culture_collection_purchase
+        description: >-
+          Received from a culture collection — no in-house growth step. Pair with
+          `source_mat_id` for the catalog identifier. Real public exemplar: GOLD
+          Go0001112 (Pseudomonas putida KT2440, DSMZ DSM 6125).
+      # Free-text examples retained as `description:` material for the enum PR; the
+      # enum design includes structured_aliases attributing the narrative variants
+      # back to GOLD `dw_samples.sample_isolated_from`.
 
   # --- Host-of-sample slots (from JGI Isolate v19 form) ---
 

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -682,6 +682,27 @@ slots:
       - value: nmdc:orgn-99-abc123
         description: Reference to an Organism instance in organism_set
 
+  host_organism:
+    range: Organism
+    description: >-
+      The host organism from which the sample's source material was obtained
+      or with which the sampled organism is associated (e.g. a plant whose
+      root yielded a bacterial isolate; an animal in which a parasite was
+      found).
+    comments:
+      - >-
+        Distinct from `expected_organism` (the focal organism being studied);
+        the same Organism class shape is reused for both roles. Host taxonomy
+        and naming follow the same path as the focal organism's:
+        `host_organism.classified_as` for NCBITaxon, plus
+        `host_organism.organism_genus / organism_species / strain_name` for the
+        text-level redundancy the JGI Isolate v19 form expects.
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
+    examples:
+      - value: nmdc:orgn-99-cot0001
+        description: Reference to a host Organism instance in organism_set (e.g. cotton, Gossypium hirsutum).
+
   sample_isolation_method:
     description: Method, protocol, or kit used to extract DNA/RNA from the sample.
     in_subset:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -184,32 +184,18 @@ slots:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: NARROW_SYNONYM    # JGI label bundles two concepts; this slot covers only the collection-site half
     examples:
-      # The values below preview the closed enum proposed in #3054 (SampleCollectionSiteEnum).
-      - value: field
+      # Base-slot range is `string` for Biosample backward compatibility.
+      # Examples below reflect that legacy free-text usage. For the closed
+      # enum applied on OrganismSample via slot_usage, see the examples block
+      # under `OrganismSample.slot_usage.sample_collection_site` in core.yaml.
+      - value: Lithgow State Coal Mine
         description: >-
-          Maps to enum PV `field` (meaning ENVO:01000352). GOLD narrative values like
-          "Field-grown common garden of wild sourced seedlots, near Greytown, KZN,
-          South Africa" decompose: site → here, place name → `geo_loc_name`.
-      - value: greenhouse
+          Free-text place name. Historical Biosample usage pattern (see
+          `Database-biosamples-1.yaml`, `Database-interleaved.yaml`).
+      - value: Mire fen
         description: >-
-          Maps to enum PV `greenhouse` (meaning GOLDVOCAB:Greenhouse). Real public
-          exemplar: GOLD Go0590511 (Arabidopsis thaliana Ath.Ler-0.Leaf.1, grown in
-          greenhouse).
-      - value: culture_collection
-        description: >-
-          Maps to enum PV `culture_collection`. The catalog accession itself
-          belongs on `source_mat_id` (CURIE form, e.g. `dsmz:DSM-6125`). Real
-          public exemplar: GOLD Go0001112 (Pseudomonas putida KT2440, DSMZ DSM 6125).
-      - value: laboratory
-        description: >-
-          Maps to enum PV `laboratory` (meaning GOLDVOCAB:Laboratory-developed). Real
-          public exemplar: T4 phage harvested from an E. coli K-12 MG1655 lab broth
-          culture (see `Database-viral-isolate-with-host.yaml`).
-      - value: deep_subsurface
-        description: >-
-          Maps to enum PV `deep_subsurface` (meaning GOLDVOCAB:Deep-subsurface). GOLD
-          case variant `Deep well` collapses here.
-      # See #3054 for the closed enum design and migration plan.
+          Free-text habitat / locality descriptor. Historical Biosample usage
+          (see `Database-nmdc-example.yaml`, `Database-interleaved.yaml`).
 
   salinity_category:
     description:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -725,51 +725,6 @@ slots:
         contexts:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
-    examples:
-      # The values below preview the closed enum proposed in #3054 (SampleIsolatedFromEnum).
-      # PV names may shift before merge; the underlying public GOLD records are stable.
-      - value: microbial_mat
-        description: >-
-          Maps to enum PV `microbial_mat` (meaning ENVO:01000008). Real public exemplar:
-          GOLD Go0000189 (Shewanella loihica PV-4) — iron-rich microbial mat at the
-          Naha Vents, south rift of Loihi seamount, Hawaii. Queried from
-          "gold-db-2 postgresql".gold.organism_v2 on 2026-04-21.
-      - value: sea_water
-        description: >-
-          Maps to enum PV `sea_water` (meaning GOLDVOCAB:Sea-water). Real public exemplar:
-          GOLD Go0000514 (Ruegeria pomeroyi DSS-3) — saltwater from the water column
-          off the Georgia coast, USA. Case variants `seawater`, `Seawater` collapse here.
-      - value: marine_sediment
-        description: >-
-          Maps to enum PV `marine_sediment` (meaning GOLDVOCAB:Marine-sediment). Real
-          public exemplar: GOLD Go0013501 (Flavobacterium frigidarium DSM 17623) —
-          marine sediment, Adelaide Island, Antarctic.
-      - value: leaf
-        description: >-
-          Maps to enum PV `leaf` (meaning PO:0025034). GOLD case/plural variants
-          `Leaf` / `Leaves` / `leaves` collapse here. Use with `host_taxid` to capture
-          the host plant for plant-associated isolates.
-      - value: root
-        description: >-
-          Maps to enum PV `root` (meaning PO:0009005). GOLD compound values such as
-          "Sorghum bicolor - root" decompose: tissue → here, host species →
-          `host_taxid` (e.g., NCBITaxon:4558 for Sorghum bicolor).
-      - value: rhizosphere
-        description: >-
-          Maps to enum PV `rhizosphere` (meaning GOLDVOCAB:Rhizosphere). GOLD
-          "maize rhizosphere soils" / "maize rhizosphere soil" decompose here, with
-          `host_taxid` = NCBITaxon:4577 for the plant.
-      - value: soil
-        description: >-
-          Maps to enum PV `soil` (meaning GOLDVOCAB:Soil). Case variants `Soil`,
-          `soils` collapse here. Real public exemplar: GOLD Go0000781 (Bacillus
-          subtilis 168).
-      - value: fruiting_body
-        description: >-
-          Maps to enum PV `fruiting_body`. No clean OBO anatomy term for fungal
-          fruiting body; `meaning:` is omitted in the enum (gap documented). Real
-          public exemplar: GOLD Go0372970 (Lentinula edodes NBRC 111202).
-      # See #3054 for the closed enum design and migration plan.
 
   sample_growth_conditions:
     range: SampleGrowthConditionsEnum
@@ -798,32 +753,6 @@ slots:
         contexts:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: NARROW_SYNONYM    # JGI label bundles two concepts; this slot covers only the growth-conditions half
-    examples:
-      # The values below preview the interim SampleGrowthConditionsEnum proposed in #3054.
-      # Full decomposition (media, temperature, atmosphere, time) deferred to #3027 / #3065
-      # — most PVs lack ontology-anchored `meaning:` because OBI/PATO/GO don't cover
-      # these as discrete states.
-      - value: liquid_culture
-        description: >-
-          Maintained in liquid broth. GOLD `dw_samples` top value
-          "Liquid culture from a frozen stock" (n=5,560) collapses here.
-      - value: solid_plate
-        description: >-
-          Maintained on solid agar plate. GOLD "single colony isolate" (n=3,279)
-          collapses here.
-      - value: cultivated_indoor
-        description: >-
-          Indoor controlled growth (greenhouse, chamber, room). Real public exemplars:
-          GOLD Go0590511 (Arabidopsis thaliana Ler-0, greenhouse) and GOLD Go0372970
-          (Lentinula edodes, "Cultivated indoor; substrate logs of supplemented oak").
-      - value: culture_collection_purchase
-        description: >-
-          Received from a culture collection — no in-house growth step. Pair with
-          `source_mat_id` for the catalog identifier. Real public exemplar: GOLD
-          Go0001112 (Pseudomonas putida KT2440, DSMZ DSM 6125).
-      # Free-text examples retained as `description:` material for the enum PR; the
-      # enum design includes structured_aliases attributing the narrative variants
-      # back to GOLD `dw_samples.sample_isolated_from`.
 
   # --- Host-of-sample slots (from JGI Isolate v19 form) ---
 

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -719,9 +719,9 @@ slots:
       - See also dna_isolate_meth in submission-schema for the equivalent portal field.
 
   sample_isolated_from:
-    range: SampleIsolatedFromEnum
+    range: string
     description: >-
-      Origin matrix from which the organism sample was isolated — the *what*
+      Origin matrix from which the organism sample was isolated; the *what*
       it came out of.
     comments:
       - >-
@@ -733,6 +733,12 @@ slots:
         Used when no upstream Biosample carries env-triad information (e.g.
         culture collection orders, lab-derived samples). When a linked
         Biosample is available, environmental provenance belongs there.
+      - >-
+        On OrganismSample, the range is narrowed via `slot_usage` to
+        `any_of: [SampleIsolatedFromEnum, string]`, mirroring the
+        env_broad_scale / env_local_scale / env_medium pattern used in
+        microbiomedata/submission-schema. Long-tail narrative content that
+        does not fit a PV routes to `isolation_details`.
       - >-
         Typed sample-to-sample links ("Y was isolated from X") are out of
         scope here; see #3033.
@@ -746,6 +752,35 @@ slots:
         contexts:
           - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+
+  isolation_details:
+    range: string
+    recommended: false
+    description: >-
+      Free-text fallback for isolation-provenance content that does not fit
+      the typed slots `sample_isolated_from` (origin matrix),
+      `sample_collection_site` (site category), or `sample_growth_conditions`
+      (in-vitro maintenance). Use only when no PV on the corresponding
+      closed enum applies; recurring patterns here are reviewed for
+      promotion to new PVs.
+    comments:
+      - >-
+        Catches the long tail of narrative descriptions observed in
+        GOLD `dw_samples.sample_isolated_from` (e.g. "Iron-rich microbial
+        mat from hydrothermal vent near 9°N EPR"). The typed slots remain
+        preferred: place names go to `geo_loc_name` / `lat_lon`;
+        matrix to `sample_isolated_from`; site to
+        `sample_collection_site`; in-vitro maintenance to
+        `sample_growth_conditions`. `isolation_details` is the residue.
+      - >-
+        Populating this slot is a tracked data-quality signal:
+        submissions whose `isolation_details` is non-empty while one or
+        more of the typed slots are empty flag candidate PVs for the
+        next vocabulary review on the relevant enum.
+    in_subset:
+      - jgi_isolate
+    see_also:
+      - https://github.com/microbiomedata/nmdc-schema/issues/3054
 
   sample_growth_conditions:
     range: SampleGrowthConditionsEnum

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1318,6 +1318,7 @@ classes:
       - samp_name
       - sample_isolation_method
       - sample_isolated_from
+      - isolation_details
       - sample_collection_site
       - sample_growth_conditions
       - ploidy
@@ -1336,6 +1337,31 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:orgn-{id_shoulder}-{id_blade}$"
           interpolated: true
+      sample_isolated_from:
+        any_of:
+          - range: SampleIsolatedFromEnum
+          - range: string
+        structured_pattern:
+          syntax: "^([a-z][a-z0-9_]*|.+ \\[(ENVO|PO|UBERON|GOLDVOCAB|FAO):[A-Za-z0-9_:\\-]+\\])$"
+        description: >-
+          Origin matrix on OrganismSample. Accepts either a permissible-value
+          name from `SampleIsolatedFromEnum` (e.g. `leaf`, `microbial_mat`) or
+          an env_medium-style bracket label anchoring an ontology / GOLD
+          vocabulary term (e.g. `leaf [PO:0025034]`,
+          `sea water [GOLDVOCAB:Sea-water]`). Long-tail narrative
+          descriptions that do not fit either form go to `isolation_details`.
+        comments:
+          - >-
+            Mirrors the `any_of: [<typed enum>, string]` + structured_pattern
+            shape used for `env_broad_scale` / `env_local_scale` / `env_medium`
+            in microbiomedata/submission-schema. Closed PV names cover the
+            head of the distribution; the bracket form lets submitters anchor
+            an ontology term outside the closed list without forfeiting
+            type safety.
+          - >-
+            The pattern allows GOLDVOCAB IDs (alphanumeric + dashes,
+            e.g. `Sea-water`, `Plant-growth-chamber`) alongside the standard
+            ENVO / PO / UBERON / FAO numeric IDs.
       sample_collection_site:
         range: SampleCollectionSiteEnum
         description: Site category where the OrganismSample (or its host) was collected.

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1332,6 +1332,14 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:orgn-{id_shoulder}-{id_blade}$"
           interpolated: true
+      sample_collection_site:
+        range: SampleCollectionSiteEnum
+        description: Site category where the OrganismSample (or its host) was collected.
+        comments:
+          - >-
+            Narrowed from the base slot's free-text range to the closed
+            `SampleCollectionSiteEnum` vocabulary for OrganismSample. Biosample
+            keeps the legacy free-text range. See #3054.
       source_mat_id:
         description: >-
           Culture collection identifier for the source of this organism sample.

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1340,31 +1340,6 @@ classes:
             Narrowed from the base slot's free-text range to the closed
             `SampleCollectionSiteEnum` vocabulary for OrganismSample. Biosample
             keeps the legacy free-text range. See #3054.
-        examples:
-          - value: field
-            description: >-
-              Maps to enum PV `field` (meaning ENVO:01000352). GOLD narrative values like
-              "Field-grown common garden of wild sourced seedlots, near Greytown, KZN,
-              South Africa" decompose: site → here, place name → `geo_loc_name`.
-          - value: greenhouse
-            description: >-
-              Maps to enum PV `greenhouse` (meaning GOLDVOCAB:Greenhouse). Real public
-              exemplar: GOLD Go0590511 (Arabidopsis thaliana Ath.Ler-0.Leaf.1, grown in
-              greenhouse).
-          - value: culture_collection
-            description: >-
-              Maps to enum PV `culture_collection`. The catalog accession itself
-              belongs on `source_mat_id` (CURIE form, e.g. `dsmz:DSM-6125`). Real
-              public exemplar: GOLD Go0001112 (Pseudomonas putida KT2440, DSMZ DSM 6125).
-          - value: laboratory
-            description: >-
-              Maps to enum PV `laboratory` (meaning GOLDVOCAB:Laboratory-developed). Real
-              public exemplar: T4 phage harvested from an E. coli K-12 MG1655 lab broth
-              culture (see `Database-viral-isolate-with-host.yaml`).
-          - value: deep_subsurface
-            description: >-
-              Maps to enum PV `deep_subsurface` (meaning GOLDVOCAB:Deep-subsurface). GOLD
-              case variant `Deep well` collapses here.
       source_mat_id:
         description: >-
           Culture collection identifier for the source of this organism sample.

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1309,13 +1309,13 @@ classes:
     slots:
       - associated_studies
       - expected_organism
+      - host_organism
       - embargoed
       - provenance_metadata
       - external_database_identifiers
       - gold_organism_identifiers
       - collection_date
       - samp_name
-      - host_taxid
       - sample_isolation_method
       - sample_isolated_from
       - sample_collection_site
@@ -1329,6 +1329,10 @@ classes:
           syntax: "{id_nmdc_prefix}:osm-{id_shoulder}-{id_blade}$"
           interpolated: true
       expected_organism:
+        structured_pattern:
+          syntax: "{id_nmdc_prefix}:orgn-{id_shoulder}-{id_blade}$"
+          interpolated: true
+      host_organism:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:orgn-{id_shoulder}-{id_blade}$"
           interpolated: true

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1340,6 +1340,31 @@ classes:
             Narrowed from the base slot's free-text range to the closed
             `SampleCollectionSiteEnum` vocabulary for OrganismSample. Biosample
             keeps the legacy free-text range. See #3054.
+        examples:
+          - value: field
+            description: >-
+              Maps to enum PV `field` (meaning ENVO:01000352). GOLD narrative values like
+              "Field-grown common garden of wild sourced seedlots, near Greytown, KZN,
+              South Africa" decompose: site → here, place name → `geo_loc_name`.
+          - value: greenhouse
+            description: >-
+              Maps to enum PV `greenhouse` (meaning GOLDVOCAB:Greenhouse). Real public
+              exemplar: GOLD Go0590511 (Arabidopsis thaliana Ath.Ler-0.Leaf.1, grown in
+              greenhouse).
+          - value: culture_collection
+            description: >-
+              Maps to enum PV `culture_collection`. The catalog accession itself
+              belongs on `source_mat_id` (CURIE form, e.g. `dsmz:DSM-6125`). Real
+              public exemplar: GOLD Go0001112 (Pseudomonas putida KT2440, DSMZ DSM 6125).
+          - value: laboratory
+            description: >-
+              Maps to enum PV `laboratory` (meaning GOLDVOCAB:Laboratory-developed). Real
+              public exemplar: T4 phage harvested from an E. coli K-12 MG1655 lab broth
+              culture (see `Database-viral-isolate-with-host.yaml`).
+          - value: deep_subsurface
+            description: >-
+              Maps to enum PV `deep_subsurface` (meaning GOLDVOCAB:Deep-subsurface). GOLD
+              case variant `Deep well` collapses here.
       source_mat_id:
         description: >-
           Culture collection identifier for the source of this organism sample.

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -34,7 +34,6 @@ prefixes:
   FMA: "http://purl.obolibrary.org/obo/FMA_"
   GENEPIO: "http://purl.obolibrary.org/obo/GENEPIO_" # for library_preparation_kit, contig identifier and count only
   GO: "http://purl.obolibrary.org/obo/GO_"
-  GOLDTERMS: "https://w3id.org/gold.path/"   # path-anchored GOLD ecosystem terms (semantic-sql bbop-sqlite/goldterms.db.gz)
   GOLDVOCAB: "https://w3id.org/gold.vocab/"  # name-string GOLD ecosystem terms; distinct from `gold` (project IDs at bioregistry.io/gold)
   HMDB: "https://bioregistry.io/hmdb:" # https://bioregistry.io/hmdb:HMDB00001
   ISA: "http://example.org/isa/"

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -34,6 +34,8 @@ prefixes:
   FMA: "http://purl.obolibrary.org/obo/FMA_"
   GENEPIO: "http://purl.obolibrary.org/obo/GENEPIO_" # for library_preparation_kit, contig identifier and count only
   GO: "http://purl.obolibrary.org/obo/GO_"
+  GOLDTERMS: "https://w3id.org/gold.path/"   # path-anchored GOLD ecosystem terms (semantic-sql bbop-sqlite/goldterms.db.gz)
+  GOLDVOCAB: "https://w3id.org/gold.vocab/"  # name-string GOLD ecosystem terms; distinct from `gold` (project IDs at bioregistry.io/gold)
   HMDB: "https://bioregistry.io/hmdb:" # https://bioregistry.io/hmdb:HMDB00001
   ISA: "http://example.org/isa/"
   KEGG.COMPOUND: "https://bioregistry.io/kegg.compound:"


### PR DESCRIPTION
## Why

#3054 documented that `sample_isolated_from` (and JGI v19 field 45) conflate four concepts — origin matrix, collection site, growth conditions, host+tissue. PR #2977 split the slot semantically but left the ranges as free-text `string`. This PR adds closed enums so the portal drives submitters to typed values and the JGI/GOLD adapter has a stable recombination target on export.

## Approach

Three closed enums, each with an `other` PV (matches existing nmdc-schema convention used in `mixs.yaml` and `PloidyEnum`). `meaning:` values prefer GOLDVOCAB where GOLD's ecosystem vocabulary has clean coverage, with ENVO/PO/UBERON fallbacks. Structured aliases attribute case/plural variants observed in real GOLD `dw_samples.sample_isolated_from` data (376K rows).

`sample_collection_site`'s class-level range stays `string` for Biosample backward compatibility; narrowing happens only on OrganismSample via `slot_usage`.

The compound-host-tissue case ("Sorghum bicolor - root") decomposes into existing slots (`host_taxid` + `sample_isolated_from`); no new tissue slot needed. New fixture demonstrates this with Pseudomonas protegens Pf-5 isolated from cotton root.

## Test plan

- [ ] CI: `make squeaky-clean all test` passes
- [ ] Schema validates against existing Biosample fixtures (since `sample_collection_site` class-level range unchanged)
- [ ] 7 OrganismSample fixtures validate against the new enum constraints

Closes #3054.