### PR TITLE
Draft ProvenanceObject class and has_instance_provenance slot (#3085)

### DIFF
--- a/src/data/invalid/Biosample-invalid-add_date.yaml
+++ b/src/data/invalid/Biosample-invalid-add_date.yaml
@@ -1,11 +1,8 @@
-# Tests that GOLD-format dates are rejected for add_date within provenance_metadata.
-# The slot_usage on ProvenanceMetadata constrains add_date to range: datetime
-# (linkml:datetime, mapped to xsd:dateTime), so only ISO 8601 datetime strings are accepted.
 id: nmdc:bsm-99-badDate1
 name: my_awesome_biosample
 type: nmdc:Biosample
 associated_studies:
-  - nmdc:sty-00-abc123
+- nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue
   has_raw_value: ENVO:00002030
@@ -24,7 +21,8 @@ env_medium:
   term:
     type: nmdc:OntologyClass
     id: ENVO:00005792
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
+has_instance_provenance:
+- id: nmdc:prov-99-99-badDate1
+  type: nmdc:ProvenanceObject
   add_date: 28-JUL-14 12.00.00.000000000 AM
   mod_date: '2023-01-25T00:00:00Z'

--- a/src/data/invalid/Biosample-invalid-mod_date.yaml
+++ b/src/data/invalid/Biosample-invalid-mod_date.yaml
@@ -1,12 +1,8 @@
-# Tests that GOLD-format dates are rejected for mod_date within provenance_metadata.
-# The slot_usage on ProvenanceMetadata constrains mod_date to range: datetime
-# (linkml:datetime, mapped to xsd:dateTime), so only ISO 8601 datetime strings
-# (YYYY-MM-DDTHH:MM:SS) are accepted.
 id: nmdc:bsm-99-badDate2
 name: my_awesome_biosample
 type: nmdc:Biosample
 associated_studies:
-  - nmdc:sty-00-abc123
+- nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue
   has_raw_value: ENVO:00002030
@@ -25,7 +21,8 @@ env_medium:
   term:
     type: nmdc:OntologyClass
     id: ENVO:00005792
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
+has_instance_provenance:
+- id: nmdc:prov-99-99-badDate2
+  type: nmdc:ProvenanceObject
   add_date: '2023-01-25T00:00:00Z'
   mod_date: 28-JUL-14 12.00.00.000000000 AM

--- a/src/data/invalid/Biosample-invalid-source-system.yaml
+++ b/src/data/invalid/Biosample-invalid-source-system.yaml
@@ -1,9 +1,8 @@
-#this file has an invalid permissible value for source_system_of_record
 id: nmdc:bsm-99-dtTMNb
 name: my_awesome_biosample
 type: nmdc:Biosample
 associated_studies:
-  - nmdc:sty-00-abc123
+- nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue
   has_raw_value: ENVO:00002030
@@ -22,8 +21,9 @@ env_medium:
   term:
     type: nmdc:OntologyClass
     id: ENVO:00005792
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
+has_instance_provenance:
+- id: nmdc:prov-99-99-dtTMNb
+  type: nmdc:ProvenanceObject
   git_url: https://github.com/microbiomedata/nmdc-runtime/blob/main/nmdc_runtime/site/translation/submission_portal_translator.py
   version: v2.12.0
   source_system_of_record: my_awesome_system

--- a/src/data/invalid/ProvenanceObject-invalid-bad-source-system.yaml
+++ b/src/data/invalid/ProvenanceObject-invalid-bad-source-system.yaml
@@ -1,0 +1,8 @@
+# Invalid: source_system_of_record carries a value that is not in
+# SourceSystemEnum (which permits GOLD, NMDC_Submission_Portal,
+# NEON_Data_Portal, NCBI, custom).
+id: nmdc:prov-99-bad-source-system
+type: nmdc:ProvenanceObject
+name: ETL ingest from an unsupported upstream system
+add_date: '2024-10-30T00:00:00Z'
+source_system_of_record: SOME_UNRECOGNIZED_SOURCE

--- a/src/data/invalid/ProvenanceObject-invalid-missing-id.yaml
+++ b/src/data/invalid/ProvenanceObject-invalid-missing-id.yaml
@@ -1,0 +1,7 @@
+# Invalid: ProvenanceObject is missing the required `id` slot.
+# Every ProvenanceObject must have an id because it inherits from
+# NamedThing (via InformationObject).
+type: nmdc:ProvenanceObject
+name: GOLD ETL ingest, batch 2024-10-30
+add_date: '2024-10-30T00:00:00Z'
+source_system_of_record: GOLD

--- a/src/data/valid/Biosample-add_date-mod_date.yaml
+++ b/src/data/valid/Biosample-add_date-mod_date.yaml
@@ -1,11 +1,8 @@
-# Tests that ISO 8601 datetime strings are accepted for add_date and mod_date
-# within provenance_metadata, where slot_usage constrains range to
-# linkml:datetime (mapped to xsd:dateTime).
 id: nmdc:bsm-99-dateTest
 name: my_awesome_biosample
 type: nmdc:Biosample
 associated_studies:
-  - nmdc:sty-00-abc123
+- nmdc:sty-00-abc123
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue
   has_raw_value: ENVO:00002030
@@ -24,7 +21,8 @@ env_medium:
   term:
     type: nmdc:OntologyClass
     id: ENVO:00005792
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
+has_instance_provenance:
+- id: nmdc:prov-99-99-dateTest
+  type: nmdc:ProvenanceObject
   add_date: '2021-03-31T00:00:00Z'
   mod_date: '2023-01-25T00:00:00Z'

--- a/src/data/valid/Biosample-possibly-exhaustive.yaml
+++ b/src/data/valid/Biosample-possibly-exhaustive.yaml
@@ -1,6 +1,3 @@
-# exhaustive as of 2025-07-08
-# but will become invalid when has_unit becomes required for QuantityValue
-# and may imply that some undesirable data patterns are OK
 id: nmdc:bsm-99-4444444
 type: nmdc:Biosample
 name: Sample Exhaustive Biosample instance. Although all of these values should pass
@@ -8,13 +5,13 @@ name: Sample Exhaustive Biosample instance. Although all of these values should 
   have this particular combination of values.
 description: unconstrained text
 alternative_identifiers:
-  - generic:abc123
+- generic:abc123
 alternative_names:
-  - alt_name_1
-  - alt_name_2
+- alt_name_1
+- alt_name_2
 associated_studies:
-  - nmdc:sty-99-987654
-  - nmdc:sty-99-qwerty
+- nmdc:sty-99-987654
+- nmdc:sty-99-qwerty
 env_broad_scale:
   type: nmdc:ControlledIdentifiedTermValue
   has_raw_value: ENVO:00002030
@@ -34,8 +31,8 @@ env_medium:
     id: ENVO:00005792
     type: nmdc:OntologyClass
 biosample_categories:
-  - LTER
-  - FICUS
+- LTER
+- FICUS
 collected_from: nmdc:frsite-99-29dl6v
 embargoed: true
 host_taxid:
@@ -45,21 +42,21 @@ host_taxid:
     id: NCBITaxon:9606
     type: nmdc:OntologyClass
 img_identifiers:
-  - img.taxon:abc123
+- img.taxon:abc123
 samp_name: see also name
 gold_biosample_identifiers:
-  - gold:Gb123456789
-  - gold:Gb90909090
+- gold:Gb123456789
+- gold:Gb90909090
 insdc_biosample_identifiers:
-  - biosample:SAMN123456789
-  - biosample:SAMN000
+- biosample:SAMN123456789
+- biosample:SAMN000
 emsl_biosample_identifiers:
-  - generic:abc123
+- generic:abc123
 igsn_biosample_identifiers:
-  - igsn:AU124
+- igsn:AU124
 abs_air_humidity:
   has_numeric_value: 9.0
-  has_raw_value: "9 gram per gram"
+  has_raw_value: 9 gram per gram
   has_unit: g/g
   type: nmdc:QuantityValue
 add_recov_method: Gas Injection;2023-05-15
@@ -72,18 +69,18 @@ adj_room:
   has_raw_value: xxx
 aero_struc: glider
 agrochem_addition:
-  - type: nmdc:TextValue
-    has_raw_value: lime;1 kg/acre;2022-99-16T16:05:42+0000
+- type: nmdc:TextValue
+  has_raw_value: lime;1 kg/acre;2022-99-16T16:05:42+0000
 air_PM_concen:
-  - particulate matter 2.5;10 microgram per cubic meter
+- particulate matter 2.5;10 microgram per cubic meter
 air_temp:
   has_numeric_value: 20.0
-  has_raw_value: "20 degree Celsius"
+  has_raw_value: 20 degree Celsius
   has_unit: Cel
   type: nmdc:QuantityValue
 air_temp_regm:
-  - type: nmdc:TextValue
-    has_raw_value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+- type: nmdc:TextValue
+  has_raw_value: 25 degree Celsius;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
 al_sat:
   has_numeric_value: 19
   has_raw_value: 19 %
@@ -139,9 +136,9 @@ annual_temp:
   has_unit: Cel
   has_numeric_value: 12.5
 antibiotic_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
-api:  #  Preferred_unit: degrees API (which is not in UCUM)
+- type: nmdc:TextValue
+  has_raw_value: xxx
+api:
   type: nmdc:QuantityValue
   has_raw_value: xxx
   has_unit: '1'
@@ -153,11 +150,11 @@ asphaltenes_pc:
   type: nmdc:TextValue
   has_raw_value: xxx
 atmospheric_data:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 avg_dew_point:
   has_numeric_value: 25.5
-  has_raw_value: "25.5 degree Celsius"
+  has_raw_value: 25.5 degree Celsius
   has_unit: Cel
   type: nmdc:QuantityValue
 avg_occup:
@@ -169,7 +166,7 @@ avg_temp:
   has_unit: Cel
 bac_prod:
   has_numeric_value: 5.0
-  has_raw_value: "5 milligram per cubic meter per day"
+  has_raw_value: 5 milligram per cubic meter per day
   has_unit: mg/m3/d
   type: nmdc:QuantityValue
 bac_resp:
@@ -181,10 +178,10 @@ bacteria_carb_prod:
   has_raw_value: 2.53 ng/h
   has_unit: ng/h
   type: nmdc:QuantityValue
-barometric_press:  # Preferred_unit: millibar (which is not in UCUM)
+barometric_press:
   has_numeric_value: 5.0
-  has_raw_value: "5 millibar"
-  has_unit: 'mbar'
+  has_raw_value: 5 millibar
+  has_unit: mbar
   type: nmdc:QuantityValue
 basin:
   type: nmdc:TextValue
@@ -207,8 +204,8 @@ biocide: sodium hypochlorite
 biocide_admin_method: https://doi.org/10.1016/j.watres.2019.115388
 biol_stat: wild
 biomass:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 biotic_regm:
   type: nmdc:TextValue
   has_raw_value: sample inoculated with Rhizobium spp. Culture
@@ -216,15 +213,15 @@ biotic_relationship: parasitism
 bishomohopanol:
   type: nmdc:QuantityValue
   has_raw_value: 14 microgram per liter
-  has_unit: "ug/L"
+  has_unit: ug/L
 blood_press_diast:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: "mm[Hg]"
+  has_unit: mm[Hg]
 blood_press_syst:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: "mm[Hg]"
+  has_unit: mm[Hg]
 bromide:
   type: nmdc:QuantityValue
   has_raw_value: 0.05 parts per million
@@ -232,7 +229,7 @@ bromide:
   has_numeric_value: 0.05
 build_docs: building information model
 build_occup_type:
-  - office
+- office
 building_setting: urban
 built_struc_age:
   has_numeric_value: 7
@@ -250,7 +247,7 @@ calcium:
   has_numeric_value: 0.2
 carb_dioxide:
   has_numeric_value: 410.0
-  has_raw_value: "410 parts per million"
+  has_raw_value: 410 parts per million
   has_unit: '[ppm]'
   type: nmdc:QuantityValue
 carb_monoxide:
@@ -277,11 +274,11 @@ ceil_thermal_mass:
 ceil_type: cathedral
 ceil_water_mold: no presence of mold visible
 chem_administration:
-  - type: nmdc:ControlledTermValue
-    has_raw_value: agar [CHEBI:2509];2018-05-11T20:00Z
+- type: nmdc:ControlledTermValue
+  has_raw_value: agar [CHEBI:2509];2018-05-11T20:00Z
 chem_mutagen:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 chem_oxygen_dem:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -299,14 +296,14 @@ chlorophyll:
   has_unit: mg/m3
   has_numeric_value: 5.0
 climate_environment:
-  - type: nmdc:TextValue
-    has_raw_value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+- type: nmdc:TextValue
+  has_raw_value: tropical climate;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
 collection_date:
   type: nmdc:TimestampValue
   has_raw_value: xxx
 conduc:
   has_numeric_value: 10.0
-  has_raw_value: "10 milliSiemens per centimeter"
+  has_raw_value: 10 milliSiemens per centimeter
   has_unit: mS/cm
   type: nmdc:QuantityValue
 cool_syst_id:
@@ -332,7 +329,7 @@ density:
   has_unit: g/m3
   has_numeric_value: 1000.0
 depos_env: other
-depth:  # this raw value may not meet the submission portal's expectations
+depth:
   type: nmdc:QuantityValue
   has_raw_value: 1.5 to 2.5 meters
   has_maximum_numeric_value: 2.5
@@ -344,8 +341,8 @@ dew_point:
   has_raw_value: xxx
   has_unit: Cel
 diether_lipids:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 diss_carb_dioxide:
   type: nmdc:QuantityValue
   has_raw_value: 5 milligram per liter
@@ -407,7 +404,7 @@ door_type: composite
 door_type_metal: collapsible
 door_type_wood: battened
 door_water_mold: no presence of mold visible
-down_par:  # example: 28.71 microEinstein per square meter per second (Einstein is not in UCUM)
+down_par:
   type: nmdc:QuantityValue
   has_raw_value: xxx
   has_unit: umol/m2/s
@@ -429,8 +426,8 @@ elevator:
   type: nmdc:TextValue
   has_raw_value: xxx
 emulsions:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 env_package:
   type: nmdc:TextValue
   has_raw_value: unconstrained text. should require the name of a MIxS EnvironmentalPackage
@@ -461,13 +458,13 @@ ext_window_orient: north
 extreme_event: '2023-01-15'
 fao_class: Fluvisols
 fertilizer_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 field:
   type: nmdc:TextValue
   has_raw_value: xxx
 filter_type:
-  - HEPA
+- HEPA
 fire: 2000-11 to 2000-12
 fireplace_type: gas burning
 flooding: '2000-01-15'
@@ -495,24 +492,24 @@ fluor:
   type: nmdc:QuantityValue
   has_raw_value: xxx
   has_unit: mg/m3
-freq_clean:  # FreqCleanEnum
+freq_clean:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: '1/d'
-freq_cook:  # measurement with value and text?
+  has_unit: 1/d
+freq_cook:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: '1/d'
+  has_unit: 1/d
 fungicide_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 furniture: cabinet
 gaseous_environment:
-  - type: nmdc:TextValue
-    has_raw_value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+- type: nmdc:TextValue
+  has_raw_value: nitric oxide;0.5 micromole per liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
 gaseous_substances:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 gender_restroom: female
 genetic_mod: https://example.org/not-genetically-modified
 geo_loc_name:
@@ -527,15 +524,15 @@ gravidity:
   type: nmdc:TextValue
   has_raw_value: xxx
 gravity:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 growth_facil:
   type: nmdc:ControlledTermValue
   has_raw_value: Growth chamber [CO_715:0000189]
 growth_habit: erect
 growth_hormone_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 hall_count:
   type: nmdc:TextValue
   has_raw_value: xxx
@@ -554,24 +551,24 @@ hcr_temp:
   type: nmdc:TextValue
   has_raw_value: xxx
 heat_cool_type:
-  - radiant system
+- radiant system
 heat_deliv_loc: north
 heat_sys_deliv_meth: xxx
 heat_system_id:
   type: nmdc:TextValue
   has_raw_value: xxx
 heavy_metals:
-  - type: nmdc:TextValue
-    has_raw_value: arsenic;0.09 micrograms per gram
+- type: nmdc:TextValue
+  has_raw_value: arsenic;0.09 micrograms per gram
 heavy_metals_meth:
-  - https://link.springer.com/article/10.1007/s42452-019-1578-x
+- https://link.springer.com/article/10.1007/s42452-019-1578-x
 height_carper_fiber:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: cm 
+  has_unit: cm
 herbicide_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 horizon_meth: https://doi.org/10.1016/j.geoderma.2019.113898
 host_age:
   has_numeric_value: 3
@@ -598,8 +595,8 @@ host_common_name:
   type: nmdc:TextValue
   has_raw_value: xxx
 host_diet:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 host_dry_mass:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -607,10 +604,9 @@ host_dry_mass:
 host_genotype:
   type: nmdc:TextValue
   has_raw_value: xxx
-# Legacy MIxS slot removed from GSC MIxS commit 0368da8
 host_family_relation:
-  - offspring;Mussel25
-  - parent;Mussel12
+- offspring;Mussel25
+- parent;Mussel12
 host_growth_cond:
   type: nmdc:TextValue
   has_raw_value: xxx
@@ -619,7 +615,7 @@ host_height:
   has_raw_value: xxx
   has_unit: cm
 host_last_meal:
-  - corn feed;P5H
+- corn feed;P5H
 host_length:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -638,12 +634,12 @@ host_subject_id:
   type: nmdc:TextValue
   has_raw_value: xxx
 host_subspecf_genlin:
-  - xxx
+- xxx
 host_substrate:
   type: nmdc:TextValue
   has_raw_value: xxx
 host_symbiont:
-  - xxx
+- xxx
 host_tot_mass:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -654,12 +650,12 @@ host_wet_mass:
   has_unit: kg
 humidity:
   has_numeric_value: 25.0
-  has_raw_value: "25 gram per cubic meter"
+  has_raw_value: 25 gram per cubic meter
   has_unit: g/m3
   type: nmdc:QuantityValue
 humidity_regm:
-  - type: nmdc:TextValue
-    has_raw_value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+- type: nmdc:TextValue
+  has_raw_value: 25 gram per cubic meter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
 indoor_space: bedroom
 indoor_surf: cabinet
 indust_eff_percent:
@@ -667,8 +663,8 @@ indust_eff_percent:
   has_raw_value: xxx
   has_unit: '%'
 inorg_particles:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 inside_lux:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -701,14 +697,14 @@ lbceq:
   has_numeric_value: 1575.0
 light_intensity:
   has_numeric_value: 0.3
-  has_raw_value: "0.3 lux"
+  has_raw_value: 0.3 lux
   has_unit: lx
   type: nmdc:QuantityValue
 light_regm:
   type: nmdc:TextValue
   has_raw_value: incandescent light;10 lux;450 nanometer
 light_type:
-  - none
+- none
 link_addit_analys:
   type: nmdc:TextValue
   has_raw_value: https://doi.org/10.1111/j.1574-6941.2011.01140.x
@@ -748,10 +744,10 @@ mean_peak_frict_vel:
   has_numeric_value: 1.0
 mech_struc: subway
 mechanical_damage:
-  - leaf damage;P5D
+- leaf damage;P5D
 methane:
   has_numeric_value: 1800.0
-  has_raw_value: "1800 parts per billion"
+  has_raw_value: 1800 parts per billion
   has_unit: '[ppb]'
   type: nmdc:QuantityValue
 micro_biomass_meth: https://doi.org/10.1016/j.soilbio.2005.01.021
@@ -760,33 +756,33 @@ microbial_biomass:
   has_raw_value: xxx
   has_unit: kg
 mineral_nutr_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 misc_param:
-  - type: nmdc:PropertyAssertion
-    has_raw_value: Bicarbonate ion concentration;2075 micromole per kilogram
-    has_attribute_label: bicarbonate ion concentration
-    has_numeric_value: 2075
-    has_unit: umol/kg
-  - type: nmdc:PropertyAssertion
-    has_raw_value: "2.2 ppm"
-    has_attribute_id: MIXS:0000117
-    has_attribute_label: total phosphorus
-    has_numeric_value: 2.2
-    has_unit: "[ppm]"
-  - type: nmdc:PropertyAssertion
-    has_raw_value: "2025-06-12"
-    has_attribute_id: MIXS:0000011
-    has_attribute_label: collection date
-    has_datetime_value: "2025-06-12"
-  - type: nmdc:PropertyAssertion
-    has_raw_value: "terrestrial biome"
-    has_attribute_id: MIXS:0000012
-    has_attribute_label: env_broad_scale
-    has_value_term_id: "ENVO:00000446"
+- type: nmdc:PropertyAssertion
+  has_raw_value: Bicarbonate ion concentration;2075 micromole per kilogram
+  has_attribute_label: bicarbonate ion concentration
+  has_numeric_value: 2075
+  has_unit: umol/kg
+- type: nmdc:PropertyAssertion
+  has_raw_value: 2.2 ppm
+  has_attribute_id: MIXS:0000117
+  has_attribute_label: total phosphorus
+  has_numeric_value: 2.2
+  has_unit: '[ppm]'
+- type: nmdc:PropertyAssertion
+  has_raw_value: '2025-06-12'
+  has_attribute_id: MIXS:0000011
+  has_attribute_label: collection date
+  has_datetime_value: '2025-06-12'
+- type: nmdc:PropertyAssertion
+  has_raw_value: terrestrial biome
+  has_attribute_id: MIXS:0000012
+  has_attribute_label: env_broad_scale
+  has_value_term_id: ENVO:00000446
 n_alkanes:
-  - type: nmdc:TextValue
-    has_raw_value: n-hexadecane;100 milligram per liter
+- type: nmdc:TextValue
+  has_raw_value: n-hexadecane;100 milligram per liter
 nitrate:
   type: nmdc:QuantityValue
   has_raw_value: 65 micromole per liter
@@ -807,7 +803,7 @@ nitro:
   has_raw_value: xxx
   has_unit: umol/L
 non_min_nutr_regm:
-  - xxx
+- xxx
 number_pets:
   type: nmdc:QuantityValue
   has_raw_value: '3'
@@ -823,10 +819,10 @@ number_resident:
   has_raw_value: '3'
   has_unit: '1'
   has_numeric_value: 3
-occup_density_samp:  # Float
+occup_density_samp:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: '1/[sft_i]'
+  has_unit: 1/[sft_i]
 occup_document: estimate
 occup_samp:
   type: nmdc:QuantityValue
@@ -848,12 +844,12 @@ org_nitro:
   has_unit: ug/L
   has_numeric_value: 4.0
 org_particles:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
-organism_count:  # Expected_value: organism name;measurement value;enumeration
-  - type: nmdc:QuantityValue
-    has_raw_value: total prokaryotes;3.5e7 cells per milliliter;qPCR
-    has_unit: '1'
+- type: nmdc:TextValue
+  has_raw_value: xxx
+organism_count:
+- type: nmdc:QuantityValue
+  has_raw_value: total prokaryotes;3.5e7 cells per milliliter;qPCR
+  has_unit: '1'
 owc_tvdss:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -861,7 +857,7 @@ owc_tvdss:
 oxy_stat_samp: aerobic
 oxygen:
   has_numeric_value: 600.0
-  has_raw_value: "600 parts per million"
+  has_raw_value: 600 parts per million
   has_unit: '[ppm]'
   type: nmdc:QuantityValue
 part_org_carb:
@@ -874,44 +870,43 @@ part_org_nitro:
   has_raw_value: xxx
   has_unit: ug/L
 particle_class:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 permeability:
   type: nmdc:TextValue
   has_raw_value: xxx
 perturbation:
-  - type: nmdc:TextValue
-    has_raw_value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
+- type: nmdc:TextValue
+  has_raw_value: antibiotic addition;R2/2018-05-11T14:30Z/2018-05-11T19:30Z/P1H30M
 pesticide_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 petroleum_hydrocarb:
   type: nmdc:QuantityValue
   has_raw_value: 0.05 micromole per liter
   has_unit: umol/L
   has_numeric_value: 0.05
 ph: 99.99
-# ph_meth has non-conforming data in production, structured_pattern deleted
 ph_meth:
   type: nmdc:TextValue
   has_raw_value: measured in 1:1 w/vol slurry (10.2136/sssabookser5.3.c16)
 ph_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 phaeopigments:
-  - type: nmdc:TextValue
-    has_raw_value: 2.5 milligram per cubic meter
+- type: nmdc:TextValue
+  has_raw_value: 2.5 milligram per cubic meter
 phosphate:
   type: nmdc:QuantityValue
   has_raw_value: 0.7 micromole per liter
   has_unit: umol/L
   has_numeric_value: 0.7
 phosplipid_fatt_acid:
-  - type: nmdc:TextValue
-    has_raw_value: 2.98 milligram per liter
-photon_flux:  # example 3.926 micromole photons per second per square meter
+- type: nmdc:TextValue
+  has_raw_value: 2.98 milligram per liter
+photon_flux:
   has_numeric_value: 3.926
-  has_raw_value: "3.926 micromole photons per second per square meter"
+  has_raw_value: 3.926 micromole photons per second per square meter
   has_unit: umol/m2/s
   type: nmdc:QuantityValue
 plant_growth_med:
@@ -925,8 +920,8 @@ plant_struc:
   type: nmdc:ControlledTermValue
   has_raw_value: xxx
 pollutants:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 porosity:
   type: nmdc:TextValue
   has_raw_value: xxx
@@ -967,11 +962,11 @@ prod_start_date:
 profile_position: summit
 quad_pos: North side
 radiation_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 rainfall_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 reactor_type:
   type: nmdc:TextValue
   has_raw_value: xxx
@@ -982,7 +977,7 @@ redox_potential:
   has_numeric_value: 300.0
 rel_air_humidity:
   has_numeric_value: 80.0
-  has_raw_value: "80 %"
+  has_raw_value: 80 %
   has_unit: '%'
   type: nmdc:QuantityValue
 rel_humidity_out:
@@ -1048,7 +1043,7 @@ root_med_macronutr:
 root_med_micronutr:
   type: nmdc:TextValue
   has_raw_value: xxx
-root_med_ph:  # Float
+root_med_ph:
   type: nmdc:QuantityValue
   has_raw_value: xxx
   has_unit: '[pH]'
@@ -1066,11 +1061,10 @@ salinity:
   has_raw_value: 25 practical salinity unit
   has_unit: '%'
   type: nmdc:QuantityValue
-# Legacy MIxS slot removed from GSC MIxS commit 0368da8
 salinity_meth: PMID:12345678
 salt_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 samp_capt_status: other
 samp_collec_device: xxx
 samp_collec_method: swabbing
@@ -1099,7 +1093,7 @@ samp_size:
   has_unit: mL
   has_numeric_value: 5
 samp_sort_meth:
-  - https://doi.org/10.1038/s41596-019-0187-9
+- https://doi.org/10.1038/s41596-019-0187-9
 samp_store_dur:
   type: nmdc:TextValue
   has_raw_value: P1Y6M
@@ -1140,8 +1134,8 @@ saturates_pc:
   has_raw_value: xxx
 season: summer [NCIT:C94732]
 season_environment:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 season_precpt:
   type: nmdc:QuantityValue
   has_raw_value: 75 millimeters
@@ -1172,7 +1166,7 @@ sieving:
   has_raw_value: MIxS does not provide an example
 silicate:
   has_numeric_value: 0.05
-  has_raw_value: "0.05 micromole per liter"
+  has_raw_value: 0.05 micromole per liter
   has_unit: umol/L
   type: nmdc:QuantityValue
 size_frac:
@@ -1208,27 +1202,25 @@ sodium:
   has_unit: mg/L
   has_numeric_value: 10.5
 soil_horizon: O horizon
-# Legacy MIxS slot removed from GSC MIxS commit 0368da8
-soil_text_measure: "silty clay loam; 20% sand; 40% silt; 40% clay"
+soil_text_measure: silty clay loam; 20% sand; 40% silt; 40% clay
 soil_texture_meth: Textural Analysis Test (hydrometer)
 soil_type:
   type: nmdc:TextValue
   has_raw_value: plinthosol [ENVO:00002250]
-# soil_type_meth has non-conforming data in production, structured_pattern deleted
 soil_type_meth:
   type: nmdc:TextValue
   has_raw_value: Textural Analysis Test (hydrometer)
 solar_irradiance:
   has_numeric_value: 1.36
-  has_raw_value: "1.36 kilowatts per square meter per day"
+  has_raw_value: 1.36 kilowatts per square meter per day
   has_unit: kW/m2/d
   type: nmdc:QuantityValue
 soluble_inorg_mat:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 soluble_org_mat:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 soluble_react_phosp:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -1248,13 +1240,13 @@ sr_geol_age: Archean
 sr_kerog_type: other
 sr_lithology: Clastic
 standing_water_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 store_cond:
   type: nmdc:TextValue
   has_raw_value: fresh
 substructure_type:
-  - basement
+- basement
 sulfate:
   type: nmdc:QuantityValue
   has_raw_value: 5 micromole per liter
@@ -1270,7 +1262,7 @@ sulfide:
   has_unit: umol/L
   has_numeric_value: 2.0
 surf_air_cont:
-  - dust
+- dust
 surf_humidity:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -1290,8 +1282,8 @@ suspend_part_matter:
   has_raw_value: xxx
   has_unit: mg/L
 suspend_solids:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 tan:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -1303,7 +1295,7 @@ temp:
   has_numeric_value: 25.0
 temp_out:
   has_numeric_value: 5.0
-  has_raw_value: "5 degree Celsius"
+  has_raw_value: 5 degree Celsius
   has_unit: Cel
   type: nmdc:QuantityValue
 tertiary_treatment:
@@ -1311,7 +1303,7 @@ tertiary_treatment:
   has_raw_value: xxx
 tidal_stage: high tide
 tillage:
-  - chisel
+- chisel
 tiss_cult_growth_med:
   type: nmdc:TextValue
   has_raw_value: xxx
@@ -1378,9 +1370,9 @@ tot_sulfur:
 train_line: red
 train_stat_loc: south station above ground
 train_stop_loc: end
-turbidity:  # example: 0.3 nephelometric turbidity units
+turbidity:
   has_numeric_value: 0.3
-  has_raw_value: "0.3 nephelometric turbidity units"
+  has_raw_value: 0.3 nephelometric turbidity units
   has_unit: '[NTU]'
   type: nmdc:QuantityValue
 tvdss_of_hcr_press:
@@ -1394,7 +1386,7 @@ tvdss_of_hcr_temp:
 typ_occup_density: 123.0
 ventilation_rate:
   has_numeric_value: 750.0
-  has_raw_value: "750 cubic meter per minute"
+  has_raw_value: 750 cubic meter per minute
   has_unit: m3/min
   type: nmdc:QuantityValue
 ventilation_type:
@@ -1413,8 +1405,8 @@ viscosity:
   type: nmdc:TextValue
   has_raw_value: xxx
 volatile_org_comp:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 wall_area:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -1431,15 +1423,15 @@ wall_texture: knockdown
 wall_thermal_mass:
   type: nmdc:QuantityValue
   has_raw_value: xxx
-  has_unit: "J/K"
+  has_unit: J/K
 wall_water_mold: no presence of mold visible
 wastewater_type:
   type: nmdc:TextValue
   has_raw_value: xxx
 water_cont_soil_meth: https://doi.org/10.1016/j.geoderma.2019.113898
 water_content:
-  - 25.5 g water/g dry soil
-  - 30.2 g water/g dry soil
+- 25.5 g water/g dry soil
+- 30.2 g water/g dry soil
 water_current:
   type: nmdc:QuantityValue
   has_raw_value: xxx
@@ -1458,11 +1450,11 @@ water_prod_rate:
   has_raw_value: xxx
   has_unit: m3/d
 water_temp_regm:
-  - type: nmdc:TextValue
-    has_raw_value: xxx
+- type: nmdc:TextValue
+  has_raw_value: xxx
 watering_regm:
-  - type: nmdc:TextValue
-    has_raw_value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
+- type: nmdc:TextValue
+  has_raw_value: 1 liter;R2/2018-05-11T14:30/2018-05-11T19:30/P1H30M
 weekday: Monday
 win:
   type: nmdc:TextValue
@@ -1472,7 +1464,7 @@ wind_direction:
   has_raw_value: xxx
 wind_speed:
   has_numeric_value: 21.0
-  has_raw_value: "21 kilometer per hour"
+  has_raw_value: 21 kilometer per hour
   has_unit: km/h
   type: nmdc:QuantityValue
 window_cond: damaged
@@ -1540,16 +1532,16 @@ sample_shipped: 15 g
 sample_type: soil - water extract
 technical_reps: 2
 analysis_type:
-  - metabolomics
-  - metagenomics
-  - metagenomics_long_read
-  - metaproteomics
-  - metatranscriptomics
-  - natural organic matter
-  - bulk chemistry
+- metabolomics
+- metagenomics
+- metagenomics_long_read
+- metaproteomics
+- metatranscriptomics
+- natural organic matter
+- bulk chemistry
 sample_link:
-  - igsn:DSJ0284
-  - any:curie
+- igsn:DSJ0284
+- any:curie
 bulk_elect_conductivity:
   type: nmdc:QuantityValue
   has_raw_value: 0.5 millisiemens per centimeter
@@ -1557,16 +1549,17 @@ bulk_elect_conductivity:
   has_unit: mS/cm
 host_disease_stat: healthy
 infiltrations:
-  - '00:01:32'
+- 00:01:32
 neon_biosample_identifiers:
-  - neon.identifier:xxx
+- neon.identifier:xxx
 nitrate_nitrogen:
   type: nmdc:QuantityValue
   has_raw_value: 1.2 mg/kg
   has_numeric_value: 1.2
   has_unit: mg/kg
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
+has_instance_provenance:
+- id: nmdc:prov-99-99-4444444
+  type: nmdc:ProvenanceObject
   add_date: '2021-03-31T00:00:00Z'
   mod_date: '2023-01-25T00:00:00Z'
   git_url: https://github.com/microbiomedata/nmdc-runtime/blob/main/nmdc_runtime/site/translation/submission_portal_translator.py

--- a/src/data/valid/Database-GOLD_amplicon.yaml
+++ b/src/data/valid/Database-GOLD_amplicon.yaml
@@ -1,33 +1,34 @@
 data_generation_set:
 - id: nmdc:dgns-11-abcd
-  name: Targeted gene survey of Sterile water microbial communities from research facility in San Diego, CA, USA - 13114.BLANK4.3D.18S
-  description: Amplicon sequencing of Sterile water microbial communities from research facility in San Diego, CA, USA
+  name: Targeted gene survey of Sterile water microbial communities from research
+    facility in San Diego, CA, USA - 13114.BLANK4.3D.18S
+  description: Amplicon sequencing of Sterile water microbial communities from research
+    facility in San Diego, CA, USA
   processing_institution: UCSD
   principal_investigator:
     name: Janet Jansson
     email: janet.jansson@pnnl.gov
     type: nmdc:PersonValue
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2022-04-02T00:00:00Z'
-  insdc_experiment_identifiers: 
-    - insdc.sra:ERX4806872
+  insdc_experiment_identifiers:
+  - insdc.sra:ERX4806872
   analyte_category: amplicon_sequencing_assay
   has_input:
-    - nmdc:procsm-11-def124
+  - nmdc:procsm-11-def124
   associated_studies:
-   - nmdc:sty-11-547rwq94
+  - nmdc:sty-11-547rwq94
   type: nmdc:NucleotideSequencing
-
+  has_instance_provenance:
+  - id: nmdc:prov-99-11-abcd
+    type: nmdc:ProvenanceObject
+    add_date: '2022-04-02T00:00:00Z'
 material_processing_set:
 - id: nmdc:libprp-11-abcdef
   type: nmdc:LibraryPreparation
   has_input:
-   - nmdc:bsm-12-xnfqbd54
+  - nmdc:bsm-12-xnfqbd54
   has_output:
-   - nmdc:procsm-11-def124
+  - nmdc:procsm-11-def124
   target_gene: 18S_rRNA
-        
 processed_sample_set:
 - id: nmdc:procsm-11-def124
   type: nmdc:ProcessedSample

--- a/src/data/valid/Database-data-generations.yaml
+++ b/src/data/valid/Database-data-generations.yaml
@@ -1,61 +1,64 @@
 data_generation_set:
-  - id: nmdc:dgns-99-zUCd5N
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0108335
-    name: Thawing permafrost microbial communities from the Arctic, studying carbon
-      transformations - Permafrost 712P3D
-    has_input:
-      - nmdc:bsm-00-red
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2014-10-30T00:00:00Z'
-      mod_date: '2020-05-22T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-9n9n9n
-    ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
-      carbon transformations - Permafrost 712P3D
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-555xxx
-  - id: nmdc:dgns-99-gKlQlF2
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0108340
-    name: Thawing permafrost microbial communities from the Arctic, studying carbon
-      transformations - Permafrost 612S3M
-    has_input:
-      - nmdc:bsm-00-orange0
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2014-10-30T00:00:00Z'
-      mod_date: '2020-05-22T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-123456
-    ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
-      carbon transformations - Permafrost 612S3M
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-555xxx
-  - id: nmdc:dgns-99-5kgIJR
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0108341
-    name: Thawing permafrost microbial communities from the Arctic, studying carbon
-      transformations - Permafrost 712S3S
-    has_input:
-      - nmdc:bsm-00-orange1
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2014-10-30T00:00:00Z'
-      mod_date: '2020-05-22T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-thx1198
-    ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
-      carbon transformations - Permafrost 712S3S
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-555xxx
+- id: nmdc:dgns-99-zUCd5N
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0108335
+  name: Thawing permafrost microbial communities from the Arctic, studying carbon
+    transformations - Permafrost 712P3D
+  has_input:
+  - nmdc:bsm-00-red
+  has_output:
+  - nmdc:dobj-00-9n9n9n
+  ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
+    carbon transformations - Permafrost 712P3D
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-555xxx
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5N
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
+- id: nmdc:dgns-99-gKlQlF2
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0108340
+  name: Thawing permafrost microbial communities from the Arctic, studying carbon
+    transformations - Permafrost 612S3M
+  has_input:
+  - nmdc:bsm-00-orange0
+  has_output:
+  - nmdc:dobj-00-123456
+  ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
+    carbon transformations - Permafrost 612S3M
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-555xxx
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-gKlQlF2
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
+- id: nmdc:dgns-99-5kgIJR
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0108341
+  name: Thawing permafrost microbial communities from the Arctic, studying carbon
+    transformations - Permafrost 712S3S
+  has_input:
+  - nmdc:bsm-00-orange1
+  has_output:
+  - nmdc:dobj-00-thx1198
+  ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
+    carbon transformations - Permafrost 712S3S
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-555xxx
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-5kgIJR
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'

--- a/src/data/valid/Database-gen_from_omics.yaml
+++ b/src/data/valid/Database-gen_from_omics.yaml
@@ -1,28 +1,29 @@
 data_object_set:
-  - id: nmdc:dobj-11-dtTMNb
-    data_object_type: Metagenome Raw Reads
-    data_category: instrument_data
-    description: my awesome fastq file
-    file_size_bytes: 1382304
-    md5_checksum: 22afa3d49b73eaec2e9787a6b88fbdc3
-    name: 1237.14.3718.ATCG-ACTG.fastq.gz
-    type: nmdc:DataObject
-    was_generated_by: nmdc:omprc-99-123456
+- id: nmdc:dobj-11-dtTMNb
+  data_object_type: Metagenome Raw Reads
+  data_category: instrument_data
+  description: my awesome fastq file
+  file_size_bytes: 1382304
+  md5_checksum: 22afa3d49b73eaec2e9787a6b88fbdc3
+  name: 1237.14.3718.ATCG-ACTG.fastq.gz
+  type: nmdc:DataObject
+  was_generated_by: nmdc:omprc-99-123456
 data_generation_set:
-  - id: nmdc:omprc-99-123456
-    alternative_identifiers:
-      - gold:Gp0108335
-    name: Permafrost 712P3D
-    has_input:
-      - nmdc:bsm-00-red
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2014-10-30T00:00:00Z'
-      mod_date: '2020-05-22T00:00:00Z'
-    has_output:
-      - nmdc:dobj-11-dtTMNb
-    associated_studies:
-      - nmdc:sty-00-123456
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    analyte_category: metagenome
+- id: nmdc:omprc-99-123456
+  alternative_identifiers:
+  - gold:Gp0108335
+  name: Permafrost 712P3D
+  has_input:
+  - nmdc:bsm-00-red
+  has_output:
+  - nmdc:dobj-11-dtTMNb
+  associated_studies:
+  - nmdc:sty-00-123456
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  analyte_category: metagenome
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-123456
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'

--- a/src/data/valid/Database-interleaved.yaml
+++ b/src/data/valid/Database-interleaved.yaml
@@ -955,11 +955,12 @@ data_generation_set:
     type: nmdc:PersonValue
     email: janet.jansson@pnnl.gov
     name: Janet Jansson
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2022-04-02T00:00:00Z'
   insdc_experiment_identifiers:
   - insdc.sra:ERX4806872
+  has_instance_provenance:
+  - id: nmdc:prov-99-11-abcd
+    type: nmdc:ProvenanceObject
+    add_date: '2022-04-02T00:00:00Z'
 - id: nmdc:dgms-99-zUCd5N
   type: nmdc:MassSpectrometry
   has_input:
@@ -1009,12 +1010,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-555xxx
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2014-10-30T00:00:00Z'
-    mod_date: '2020-05-22T00:00:00Z'
   ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
     carbon transformations - Permafrost 712P3D
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5N
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
 - id: nmdc:dgns-99-gKlQlF2
   type: nmdc:NucleotideSequencing
   name: Thawing permafrost microbial communities from the Arctic, studying carbon
@@ -1029,12 +1031,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-555xxx
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2014-10-30T00:00:00Z'
-    mod_date: '2020-05-22T00:00:00Z'
   ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
     carbon transformations - Permafrost 612S3M
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-gKlQlF2
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
 - id: nmdc:dgns-99-5kgIJR
   type: nmdc:NucleotideSequencing
   name: Thawing permafrost microbial communities from the Arctic, studying carbon
@@ -1049,12 +1052,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-555xxx
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2014-10-30T00:00:00Z'
-    mod_date: '2020-05-22T00:00:00Z'
   ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
     carbon transformations - Permafrost 712S3S
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-5kgIJR
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
 - id: nmdc:omprc-99-123456
   type: nmdc:NucleotideSequencing
   name: Permafrost 712P3D
@@ -1068,8 +1072,9 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-123456
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-123456
+    type: nmdc:ProvenanceObject
     add_date: '2014-10-30T00:00:00Z'
     mod_date: '2020-05-22T00:00:00Z'
 - id: nmdc:dgms-99-zUCd5N3
@@ -1086,13 +1091,14 @@ data_generation_set:
   instrument_used:
   - nmdc:inst-14-njkx0e66
   instrument_instance_specifier: PNNL_VOrbiETD04
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2024-05-07T00:00:00Z'
-    mod_date: '2024-05-07T00:00:00Z'
   eluent_introduction_category: liquid_chromatography
   has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
   has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5N3
+    type: nmdc:ProvenanceObject
+    add_date: '2024-05-07T00:00:00Z'
+    mod_date: '2024-05-07T00:00:00Z'
 - id: nmdc:dgms-99-zUCd5x
   type: nmdc:MassSpectrometry
   has_input:
@@ -1107,13 +1113,14 @@ data_generation_set:
   instrument_used:
   - nmdc:inst-14-njkx0e66
   instrument_instance_specifier: PNNL_VOrbiETD04
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2024-05-07T00:00:00Z'
-    mod_date: '2024-05-07T00:00:00Z'
   eluent_introduction_category: liquid_chromatography
   has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
   has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5x
+    type: nmdc:ProvenanceObject
+    add_date: '2024-05-07T00:00:00Z'
+    mod_date: '2024-05-07T00:00:00Z'
 - id: nmdc:dgms-99-oW43DzG1
   type: nmdc:MassSpectrometry
   has_input:
@@ -1158,13 +1165,14 @@ data_generation_set:
   - nmdc:sty-11-aygzgv51
   instrument_used:
   - nmdc:inst-14-fas8ny90
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    mod_date: '2024-11-07T00:00:00Z'
   eluent_introduction_category: gas_chromatography
   has_mass_spectrometry_configuration: nmdc:mscon-14-5jk7rg60
   generates_calibration: nmdc:calib-14-dy7mc666
   has_chromatography_configuration: nmdc:chrcon-14-qpvt3v15
+  has_instance_provenance:
+  - id: nmdc:prov-99-13-122e4240
+    type: nmdc:ProvenanceObject
+    mod_date: '2024-11-07T00:00:00Z'
 - id: nmdc:dgns-99-zUCd5N2
   type: nmdc:NucleotideSequencing
   name: a process in which a biosample was sequenced?
@@ -1178,12 +1186,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-555xxx
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2014-10-30T00:00:00Z'
-    mod_date: '2020-05-22T00:00:00Z'
   ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
     carbon transformations - Permafrost 712P3D
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5N2
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
 - id: nmdc:dgns-11-s9xj2r24
   type: nmdc:NucleotideSequencing
   name: Test NEON data
@@ -1215,12 +1224,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-31415
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2017-08-17T00:00:00Z'
-    mod_date: '2020-10-16T00:00:00Z'
   ncbi_project_name: Forest soil microbial communities from Barre Woods Harvard Forest
     LTER site, Petersham, Massachusetts, United States - Inc-BW-C-14-O
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-9XUVVF
+    type: nmdc:ProvenanceObject
+    add_date: '2017-08-17T00:00:00Z'
+    mod_date: '2020-10-16T00:00:00Z'
 - id: nmdc:dgns-99-dk9vgI
   type: nmdc:NucleotideSequencing
   name: Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG
@@ -1235,12 +1245,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-8675309
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2017-03-17T00:00:00Z'
-    mod_date: '2020-05-22T00:00:00Z'
   ncbi_project_name: Permafrost microbial communities from Stordalen Mire, Sweden
     - 611E1M metaG
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-dk9vgI
+    type: nmdc:ProvenanceObject
+    add_date: '2017-03-17T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
 - id: nmdc:dgns-99-MVW1FV
   type: nmdc:NucleotideSequencing
   name: Rhizosphere microbial communities from Carex aquatilis grown in University
@@ -1257,12 +1268,13 @@ data_generation_set:
   analyte_category: metagenome
   associated_studies:
   - nmdc:sty-00-avacado
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    add_date: '2018-03-29T00:00:00Z'
-    mod_date: '2020-04-04T00:00:00Z'
   ncbi_project_name: Rhizosphere microbial communities from Carex aquatilis grown
     in University of Washington, Seatle, WA, United States - 4-1-23 metaG
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-MVW1FV
+    type: nmdc:ProvenanceObject
+    add_date: '2018-03-29T00:00:00Z'
+    mod_date: '2020-04-04T00:00:00Z'
 - id: nmdc:dgms-11-0003fm52
   type: nmdc:MassSpectrometry
   name: 1000S_WLUP_FTMS_SPE_BTM_1_run2_Fir_22Apr22_300SA_p01_149_1_3506
@@ -1279,11 +1291,12 @@ data_generation_set:
   - nmdc:sty-11-28tm5d36
   instrument_used:
   - nmdc:inst-14-mwrrj632
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    mod_date: '2024-11-07T00:00:00Z'
   eluent_introduction_category: direct_infusion_autosampler
   has_mass_spectrometry_configuration: nmdc:mscon-14-j5y11q51
+  has_instance_provenance:
+  - id: nmdc:prov-99-11-0003fm52
+    type: nmdc:ProvenanceObject
+    mod_date: '2024-11-07T00:00:00Z'
 data_object_set:
 - id: nmdc:dobj-99-izwYW6
   type: nmdc:DataObject
@@ -2393,55 +2406,56 @@ study_set:
 - id: nmdc:sty-99-hfaLvo
   type: nmdc:Study
   name: Cyanobacterial communities from the Joint Genome Institute, California, USA
-  description: 'We propose to utilize the unique resources at EMSL and the JGI to
-    obtain a better understanding of the phylogenetic and functional diversity of
-    cyanobacteria that have been collected from DOE mission relevant environments
-    (e.g. alkaline and acidic hot springs, and hypersaline terrestrial and water habitats)
-    and deposited in a culture collection that contains &gt;1,200 strains. The Cyanobacteria
-    are one of the most metabolically and morphologically diverse bacterial phyla
-    and it has been hypothesized that they are the origin of oxygenic photosynthesis.
-    The project proposed here would complement and utilize the genomic information
-    that was generated during JGI’s GEBA Cyano project to add valuable insights about
-    the metabolic processes that are active in members of this phylum and that have
-    been - and still are - key factors in shaping our planet. In contrast to the GEBA
-    Cyano project, the project proposed here include mixed cultures of organisms that
-    are recalcitrant to separation. A comprehensive omics approach of these simple
-    consortia will allow us to develop tools for Systems Microbiology and for analyzing
-    microbe-microbe and microbe-climate interactions and the single-cell and whole
-    system level. Phylogenomics: We will request 16S rRNA data from our culture collections
-    to classify phenotypes that are most promising for addressing questions related
-    to carbon and nitrogen cycling and developing new chassis for biofuel production
-    strains. To obtain a complete 16S rRNA-based inventory of the Cyanobacteria collection
-    we would request ~40 Gb of iTag data from the JGI. In addition, we would request
-    Fluorescence in situ hybridization (FISH) microscopy from EMSL for selected samples
-    that contain more than one phylotype, to obtain a better understanding of the
-    special organization within mixed populations. We will request an additional ~10
-    Gb of iTag data to monitor phylogenetic changes in mixed cultures with phenotypes
-    that are in particular relevant to carbon and nitrogen cycling.   Single Cell
-    Genomics and Metagenomics: We will request sorting of mixed cultures targeting
-    ~100 single cells and genomic sequencing of the obtained isolates using JGI''s
-    PacBio pipeline (total of ~50 Gb genomic data). For mixed cultured from which
-    no ? or only a fraction of the community - can be isolated as single cell, we
-    will request a total of ~50 Gb of metagenomics data. This will provide us with
-    the genomic data that will be necessary to reconstruct metabolic pathways of hitherto
-    uncultured cyanobacteria and to identify the key factors that make the individual
-    members of these mixed cultures recalcitrant to cultivation under axenic conditions.
-    Physiology and chemistry: To determine the physical and chemical changes that
-    occur during Cyanobacteria mediated carbon and nitrogen cycling, we will request
-    access to cryo-transmission electron microscopy, scanning electron microscopy
-    coupled with focused ion beam, X ray spectroscopy and electron diffraction analyses,
-    confocal microscopy, Raman spectroscopy, synchrotron-based computed x-ray microtomography,
-    nano secondary ion mass spectrometry, and high field Fourier transform ion cyclotron
-    resonance mass spectrometry at EMSL.   Functional dynamics: To determine the dynamics
-    of the genetic modules that are being transcribed into mRNA during Cyanobacteria
-    mediated carbon and nitrogen cycling, we propose to generate expression profiles
-    from 10 selected axenic and 10 mixed cultures. We will request a total of ~10
-    Gb and ~50 Gb of transcriptome and metatranscriptomic data from the JGI, respectively.
-    To determine the dynamics of genetic modules being translated and converted into
-    proteins and metabolites during Cyanobacteria mediated carbon and nitrogen cycling,
-    we will generate metaproteomic and metametabolomic data from 10 selected axenic
-    and 10 mixed cultures. We will request access and support to and with mass spectrometry,
-    NMR spectrometry, and computation time on Chinook from EMSL.'
+  description: "We propose to utilize the unique resources at EMSL and the JGI to\
+    \ obtain a better understanding of the phylogenetic and functional diversity of\
+    \ cyanobacteria that have been collected from DOE mission relevant environments\
+    \ (e.g. alkaline and acidic hot springs, and hypersaline terrestrial and water\
+    \ habitats) and deposited in a culture collection that contains &gt;1,200 strains.\
+    \ The Cyanobacteria are one of the most metabolically and morphologically diverse\
+    \ bacterial phyla and it has been hypothesized that they are the origin of oxygenic\
+    \ photosynthesis. The project proposed here would complement and utilize the genomic\
+    \ information that was generated during JGI\u2019s GEBA Cyano project to add valuable\
+    \ insights about the metabolic processes that are active in members of this phylum\
+    \ and that have been - and still are - key factors in shaping our planet. In contrast\
+    \ to the GEBA Cyano project, the project proposed here include mixed cultures\
+    \ of organisms that are recalcitrant to separation. A comprehensive omics approach\
+    \ of these simple consortia will allow us to develop tools for Systems Microbiology\
+    \ and for analyzing microbe-microbe and microbe-climate interactions and the single-cell\
+    \ and whole system level. Phylogenomics: We will request 16S rRNA data from our\
+    \ culture collections to classify phenotypes that are most promising for addressing\
+    \ questions related to carbon and nitrogen cycling and developing new chassis\
+    \ for biofuel production strains. To obtain a complete 16S rRNA-based inventory\
+    \ of the Cyanobacteria collection we would request ~40 Gb of iTag data from the\
+    \ JGI. In addition, we would request Fluorescence in situ hybridization (FISH)\
+    \ microscopy from EMSL for selected samples that contain more than one phylotype,\
+    \ to obtain a better understanding of the special organization within mixed populations.\
+    \ We will request an additional ~10 Gb of iTag data to monitor phylogenetic changes\
+    \ in mixed cultures with phenotypes that are in particular relevant to carbon\
+    \ and nitrogen cycling.   Single Cell Genomics and Metagenomics: We will request\
+    \ sorting of mixed cultures targeting ~100 single cells and genomic sequencing\
+    \ of the obtained isolates using JGI's PacBio pipeline (total of ~50 Gb genomic\
+    \ data). For mixed cultured from which no ? or only a fraction of the community\
+    \ - can be isolated as single cell, we will request a total of ~50 Gb of metagenomics\
+    \ data. This will provide us with the genomic data that will be necessary to reconstruct\
+    \ metabolic pathways of hitherto uncultured cyanobacteria and to identify the\
+    \ key factors that make the individual members of these mixed cultures recalcitrant\
+    \ to cultivation under axenic conditions. Physiology and chemistry: To determine\
+    \ the physical and chemical changes that occur during Cyanobacteria mediated carbon\
+    \ and nitrogen cycling, we will request access to cryo-transmission electron microscopy,\
+    \ scanning electron microscopy coupled with focused ion beam, X ray spectroscopy\
+    \ and electron diffraction analyses, confocal microscopy, Raman spectroscopy,\
+    \ synchrotron-based computed x-ray microtomography, nano secondary ion mass spectrometry,\
+    \ and high field Fourier transform ion cyclotron resonance mass spectrometry at\
+    \ EMSL.   Functional dynamics: To determine the dynamics of the genetic modules\
+    \ that are being transcribed into mRNA during Cyanobacteria mediated carbon and\
+    \ nitrogen cycling, we propose to generate expression profiles from 10 selected\
+    \ axenic and 10 mixed cultures. We will request a total of ~10 Gb and ~50 Gb of\
+    \ transcriptome and metatranscriptomic data from the JGI, respectively. To determine\
+    \ the dynamics of genetic modules being translated and converted into proteins\
+    \ and metabolites during Cyanobacteria mediated carbon and nitrogen cycling, we\
+    \ will generate metaproteomic and metametabolomic data from 10 selected axenic\
+    \ and 10 mixed cultures. We will request access and support to and with mass spectrometry,\
+    \ NMR spectrometry, and computation time on Chinook from EMSL."
   study_category: research_study
   gold_study_identifiers:
   - gold:Gs999999

--- a/src/data/valid/Database-mass-spectrometry.yaml
+++ b/src/data/valid/Database-mass-spectrometry.yaml
@@ -1,134 +1,134 @@
 data_generation_set:
-  - id: nmdc:dgms-99-zUCd5N3
-    type: nmdc:MassSpectrometry
-    eluent_introduction_category: liquid_chromatography
-    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
-    has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
-    analyte_category: lipidome
-    has_input:
-      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
-    start_date: 30-OCT-14 01.00.00.000000000 AM
-    end_date: 30-OCT-14 01.30.00.000000000 AM
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2024-05-07T00:00:00Z'
-      mod_date: '2024-05-07T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-msdem1
-    associated_studies:
-      - nmdc:sty-00-555xxx
-    instrument_used:
-      - nmdc:inst-14-njkx0e66
-    instrument_instance_specifier: PNNL_VOrbiETD04
-  - id: nmdc:dgms-99-zUCd5x
-    type: nmdc:MassSpectrometry
-    eluent_introduction_category: liquid_chromatography
-    analyte_category: lipidome
-    has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
-    has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
-    has_input:
-      - nmdc:procsm-11-0wxpzf08 # See src/data/valid/Extraction-metabolomics.yaml
-    start_date: 31-OCT-14 01.00.00.000000000 AM
-    end_date: 31-OCT-14 01.30.00.000000000 AM
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2024-05-07T00:00:00Z'
-      mod_date: '2024-05-07T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-msdem2
-    associated_studies:
-      - nmdc:sty-00-555xxx
-    instrument_used:
-      - nmdc:inst-14-njkx0e66
-    instrument_instance_specifier: PNNL_VOrbiETD04
-#
-# example data objects for the mass spectrometry data generation set
+- id: nmdc:dgms-99-zUCd5N3
+  type: nmdc:MassSpectrometry
+  eluent_introduction_category: liquid_chromatography
+  has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG1
+  has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
+  analyte_category: lipidome
+  has_input:
+  - nmdc:procsm-11-0wxpzf08
+  start_date: 30-OCT-14 01.00.00.000000000 AM
+  end_date: 30-OCT-14 01.30.00.000000000 AM
+  has_output:
+  - nmdc:dobj-00-msdem1
+  associated_studies:
+  - nmdc:sty-00-555xxx
+  instrument_used:
+  - nmdc:inst-14-njkx0e66
+  instrument_instance_specifier: PNNL_VOrbiETD04
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5N3
+    type: nmdc:ProvenanceObject
+    add_date: '2024-05-07T00:00:00Z'
+    mod_date: '2024-05-07T00:00:00Z'
+- id: nmdc:dgms-99-zUCd5x
+  type: nmdc:MassSpectrometry
+  eluent_introduction_category: liquid_chromatography
+  analyte_category: lipidome
+  has_mass_spectrometry_configuration: nmdc:mscon-99-oW43DzG2
+  has_chromatography_configuration: nmdc:chrcon-11-oW43DzG0
+  has_input:
+  - nmdc:procsm-11-0wxpzf08
+  start_date: 31-OCT-14 01.00.00.000000000 AM
+  end_date: 31-OCT-14 01.30.00.000000000 AM
+  has_output:
+  - nmdc:dobj-00-msdem2
+  associated_studies:
+  - nmdc:sty-00-555xxx
+  instrument_used:
+  - nmdc:inst-14-njkx0e66
+  instrument_instance_specifier: PNNL_VOrbiETD04
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5x
+    type: nmdc:ProvenanceObject
+    add_date: '2024-05-07T00:00:00Z'
+    mod_date: '2024-05-07T00:00:00Z'
 data_object_set:
-  - id: nmdc:dobj-00-msdem1
-    name: EMSL_49991_Brodie_122_Lipids_POS_09Aug19_Lola-WCSH417820
-    description: raw instrument file for nmdc:dgms-99-zUCd5N3
-    file_size_bytes: 1150434379
-    url: https://nmdcdemo.emsl.pnnl.gov/proteomics/raw/SpruceW_P19_15_22Jun17_Pippin_17-04-06.raw #url does not yet exisit for lcms metabolite data, this is just an example resolvable url
-    md5_checksum: 3EFB4966125DFA9329ADE5B18EADDA8E
-    data_object_type: LC-DDA-MS/MS Raw Data
-    data_category: instrument_data
-    type: nmdc:DataObject
-    alternative_identifiers:
-      - my_emsl:1826381
-  - id: nmdc:dobj-00-msdem2
-    name: EMSL_49991_Brodie_123_Lipids_Neg_12Aug19_Lola-WCSH417820
-    description: raw instrument file for nmdc:dgms-99-zUCd5x
-    file_size_bytes: 1150434379
-    url: https://nmdcdemo.emsl.pnnl.gov/proteomics/raw/SpruceW_P19_15_22Jun17_Pippin_17-04-06.raw #url does not yet exisit for lipid data, this is just an example resolvable url
-    md5_checksum: 3EFB4966125DFA9329ADE5B18EADDA8E
-    data_object_type: LC-DDA-MS/MS Raw Data
-    data_category: instrument_data
-    type: nmdc:DataObject
-    alternative_identifiers:
-      - my_emsl:1826333
-
-# example mass spectrometry configuration set
+- id: nmdc:dobj-00-msdem1
+  name: EMSL_49991_Brodie_122_Lipids_POS_09Aug19_Lola-WCSH417820
+  description: raw instrument file for nmdc:dgms-99-zUCd5N3
+  file_size_bytes: 1150434379
+  url: https://nmdcdemo.emsl.pnnl.gov/proteomics/raw/SpruceW_P19_15_22Jun17_Pippin_17-04-06.raw
+  md5_checksum: 3EFB4966125DFA9329ADE5B18EADDA8E
+  data_object_type: LC-DDA-MS/MS Raw Data
+  data_category: instrument_data
+  type: nmdc:DataObject
+  alternative_identifiers:
+  - my_emsl:1826381
+- id: nmdc:dobj-00-msdem2
+  name: EMSL_49991_Brodie_123_Lipids_Neg_12Aug19_Lola-WCSH417820
+  description: raw instrument file for nmdc:dgms-99-zUCd5x
+  file_size_bytes: 1150434379
+  url: https://nmdcdemo.emsl.pnnl.gov/proteomics/raw/SpruceW_P19_15_22Jun17_Pippin_17-04-06.raw
+  md5_checksum: 3EFB4966125DFA9329ADE5B18EADDA8E
+  data_object_type: LC-DDA-MS/MS Raw Data
+  data_category: instrument_data
+  type: nmdc:DataObject
+  alternative_identifiers:
+  - my_emsl:1826333
 configuration_set:
-  - id: nmdc:mscon-99-oW43DzG1
-    name: EMSL lipidomics mass spectrometry method, positive polarity
-    description: Mass spectrometry method used by EMSL for lipidomics analysis, positive polarity
-    type: nmdc:MassSpectrometryConfiguration
-    mass_spectrometry_acquisition_strategy: data_dependent_acquisition
-    mass_spectrum_collection_modes:
-      - full_profile
-      - centroid
-    resolution_categories:
-      - high
-      - low
-    mass_analyzers:
-      - Orbitrap
-      - ion_trap
-    ionization_source: electrospray_ionization
-    polarity_mode: positive
-  - id: nmdc:mscon-99-oW43DzG2
-    name: EMSL lipidomics mass spectrometry method, negative polarity
-    description: Mass spectrometry method used by EMSL for lipidomics analysis, negative polarity
-    type: nmdc:MassSpectrometryConfiguration
-    mass_spectrometry_acquisition_strategy: data_dependent_acquisition
-    mass_spectrum_collection_modes:
-      - full_profile
-      - centroid
-    resolution_categories:
-      - high
-      - low
-    mass_analyzers:
-      - Orbitrap
-      - ion_trap
-    ionization_source: electrospray_ionization
-    polarity_mode: negative
-  - id: nmdc:chrcon-11-oW43DzG0
-    name: EMSL LC method for non-polar metabolites
-    description: LC method for non-polar metabolites used by EMSL
-    type: nmdc:ChromatographyConfiguration
-    chromatographic_category: liquid_chromatography
-    stationary_phase: C18
-    temperature:
+- id: nmdc:mscon-99-oW43DzG1
+  name: EMSL lipidomics mass spectrometry method, positive polarity
+  description: Mass spectrometry method used by EMSL for lipidomics analysis, positive
+    polarity
+  type: nmdc:MassSpectrometryConfiguration
+  mass_spectrometry_acquisition_strategy: data_dependent_acquisition
+  mass_spectrum_collection_modes:
+  - full_profile
+  - centroid
+  resolution_categories:
+  - high
+  - low
+  mass_analyzers:
+  - Orbitrap
+  - ion_trap
+  ionization_source: electrospray_ionization
+  polarity_mode: positive
+- id: nmdc:mscon-99-oW43DzG2
+  name: EMSL lipidomics mass spectrometry method, negative polarity
+  description: Mass spectrometry method used by EMSL for lipidomics analysis, negative
+    polarity
+  type: nmdc:MassSpectrometryConfiguration
+  mass_spectrometry_acquisition_strategy: data_dependent_acquisition
+  mass_spectrum_collection_modes:
+  - full_profile
+  - centroid
+  resolution_categories:
+  - high
+  - low
+  mass_analyzers:
+  - Orbitrap
+  - ion_trap
+  ionization_source: electrospray_ionization
+  polarity_mode: negative
+- id: nmdc:chrcon-11-oW43DzG0
+  name: EMSL LC method for non-polar metabolites
+  description: LC method for non-polar metabolites used by EMSL
+  type: nmdc:ChromatographyConfiguration
+  chromatographic_category: liquid_chromatography
+  stationary_phase: C18
+  temperature:
+    type: nmdc:QuantityValue
+    has_numeric_value: 30
+    has_unit: Cel
+  ordered_mobile_phases:
+  - type: nmdc:MobilePhaseSegment
+    duration:
       type: nmdc:QuantityValue
-      has_numeric_value: 30
-      has_unit: Cel
-    ordered_mobile_phases:
-      - type: nmdc:MobilePhaseSegment
-        duration:
-          type: nmdc:QuantityValue
-          has_unit: min
-          has_numeric_value: 60
-        substances_used:
-          - known_as: water
-            type: nmdc:PortionOfSubstance
-            final_concentration:
-              type: nmdc:QuantityValue
-              has_unit: '%'
-              has_numeric_value: 10
-      - type: nmdc:MobilePhaseSegment
-        substances_used:
-          - known_as: glucose
-            type: nmdc:PortionOfSubstance
-            final_concentration:
-              type: nmdc:QuantityValue
-              has_unit: mmol/L
-              has_numeric_value: 15
+      has_unit: min
+      has_numeric_value: 60
+    substances_used:
+    - known_as: water
+      type: nmdc:PortionOfSubstance
+      final_concentration:
+        type: nmdc:QuantityValue
+        has_unit: '%'
+        has_numeric_value: 10
+  - type: nmdc:MobilePhaseSegment
+    substances_used:
+    - known_as: glucose
+      type: nmdc:PortionOfSubstance
+      final_concentration:
+        type: nmdc:QuantityValue
+        has_unit: mmol/L
+        has_numeric_value: 15

--- a/src/data/valid/Database-metabolomics_calibration_example.yaml
+++ b/src/data/valid/Database-metabolomics_calibration_example.yaml
@@ -20,10 +20,11 @@ data_generation_set:
   end_date: '2016-05-24 18:54:29.000'
   has_chromatography_configuration: nmdc:chrcon-14-qpvt3v15
   has_mass_spectrometry_configuration: nmdc:mscon-14-5jk7rg60
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    mod_date: '2024-11-07T00:00:00Z'
   start_date: '2016-05-24 18:17:00.000'
+  has_instance_provenance:
+  - id: nmdc:prov-99-13-122e4240
+    type: nmdc:ProvenanceObject
+    mod_date: '2024-11-07T00:00:00Z'
 calibration_set:
 - id: nmdc:calib-14-93cjjw92
   calibration_object: nmdc:dobj-13-rf3br219
@@ -55,7 +56,7 @@ workflow_execution_set:
   has_output:
   - nmdc:dobj-13-hrf1h918
   id: nmdc:wfmb-13-r954ws43.1
-  uses_calibration: 
+  uses_calibration:
   - nmdc:calib-14-93cjjw92
   ended_at_time: '2021-01-07T23:54:40Z'
   execution_resource: EMSL-RZR
@@ -63,5 +64,5 @@ workflow_execution_set:
   git_url: https://github.com/microbiomedata/metaMS
   started_at_time: '2021-01-07T23:54:40Z'
   was_informed_by:
-    - nmdc:dgms-13-122e4240
+  - nmdc:dgms-13-122e4240
   metabolomics_analysis_category: gc_ms_metabolomics

--- a/src/data/valid/Database-multiple-paths.yaml
+++ b/src/data/valid/Database-multiple-paths.yaml
@@ -1,67 +1,68 @@
 biosample_set:
-  - id: nmdc:bsm-99-dtTMNb4
-    name: real biosample from the field
-    associated_studies:
-      - nmdc:sty-00-abc123
-    env_broad_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002030
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002030
-    env_local_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002169
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002169
-    env_medium:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00005792
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00005792
-    type: nmdc:Biosample
-  - id: nmdc:bsm-99-XYZ
-    name: one DNA library, like an analytical sample
-    associated_studies:
-      - nmdc:sty-00-abc123
-    env_broad_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002030
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002030
-    env_local_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002169
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002169
-    env_medium:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00005792
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00005792
-    type: nmdc:Biosample
+- id: nmdc:bsm-99-dtTMNb4
+  name: real biosample from the field
+  associated_studies:
+  - nmdc:sty-00-abc123
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002030
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002030
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002169
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002169
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00005792
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00005792
+  type: nmdc:Biosample
+- id: nmdc:bsm-99-XYZ
+  name: one DNA library, like an analytical sample
+  associated_studies:
+  - nmdc:sty-00-abc123
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002030
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002030
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002169
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002169
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00005792
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00005792
+  type: nmdc:Biosample
 data_generation_set:
-  - id: nmdc:dgns-99-zUCd5N2
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0108335
-    name: a process in which a biosample was sequenced?
-    has_input:
-      - nmdc:bsm-00-red
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2014-10-30T00:00:00Z'
-      mod_date: '2020-05-22T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-9n9n9n
-    ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
-      carbon transformations - Permafrost 712P3D
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-555xxx
+- id: nmdc:dgns-99-zUCd5N2
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0108335
+  name: a process in which a biosample was sequenced?
+  has_input:
+  - nmdc:bsm-00-red
+  has_output:
+  - nmdc:dobj-00-9n9n9n
+  ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
+    carbon transformations - Permafrost 712P3D
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-555xxx
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-zUCd5N2
+    type: nmdc:ProvenanceObject
+    add_date: '2014-10-30T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'

--- a/src/data/valid/Database-nmdc-example.yaml
+++ b/src/data/valid/Database-nmdc-example.yaml
@@ -1,300 +1,303 @@
 study_set:
-  - id: nmdc:sty-99-FkQIsc
-    type: nmdc:Study
-    gold_study_identifiers:
-      - gold:Gs123456789
-    name: Permafrost microbial communities from Stordalen Mire, Sweden
-    description: Thawing permafrost is one of the largest soil carbon pools on the planet.
-      The goal of this project is to study microbial communities that participate in
-      the soil carbon cycle.
-    ecosystem: Environmental
-    ecosystem_category: Terrestrial
-    ecosystem_type: Soil
-    ecosystem_subtype: Wetlands
-    specific_ecosystem: Permafrost
-    principal_investigator:
-      type: nmdc:PersonValue
-      has_raw_value: Virginia Rich
-    associated_dois:
-      - doi_value: doi:10.25585/1488217 # https://doi.org/10.25585/1488217 / https://www.osti.gov/dataexplorer/biblio/dataset/1488217 -> https://genome.jgi.doe.gov/portal/Somoldmmetaomics/Somoldmmetaomics.info.html
-        doi_category: dataset_doi
-        doi_provider: osti
-        type: nmdc:Doi
-    study_category: research_study
-  - id: nmdc:sty-99-oJmAOs
-    gold_study_identifiers:
-      - gold:Gs121212
-    name: Forest soil microbial communities from Barre Woods Harvard Forest LTER site,
-      Petersham, Massachusetts, United States
-    description: The goal of this study is to learn the molecular mechanisms underlying
-      changes in the temperature sensitive respiration response of forest soils to long-term
-      experimental warming
-    ecosystem: Environmental
-    ecosystem_category: Terrestrial
-    ecosystem_type: Soil
-    ecosystem_subtype: Unclassified
-    specific_ecosystem: Forest Soil
-    principal_investigator:
-      type: nmdc:PersonValue
-      has_raw_value: Jeffrey Blanchard
-    associated_dois:
-      - doi_value: doi:10.25585/1488215 # https://www.osti.gov/dataexplorer/biblio/dataset/1488215 -> https://genome.jgi.doe.gov/portal/Molmecexpwarming/Molmecexpwarming.info.html
-        doi_category: dataset_doi
-        doi_provider: osti
-        type: nmdc:Doi
-    type: nmdc:Study
-    study_category: consortium
-  - id: nmdc:sty-99-3bQQ4j
-    gold_study_identifiers:
-      - gold:Gs0134277
-    name: Rhizosphere microbial communities from Carex aquatilis grown in University
-      of Washington, Seatle, WA, United States
-    description: The goal of this study is to advance understanding of the response
-      of methane production and methane oxidation to changes in plant productivity so
-      that modeled representations of these processes and interactions can be improved.
-    ecosystem: Host-associated
-    ecosystem_category: Plants
-    ecosystem_type: Roots
-    ecosystem_subtype: Rhizosphere
-    specific_ecosystem: Soil
-    principal_investigator:
-      type: nmdc:PersonValue
-      has_raw_value: Rebecca Neumann
-    associated_dois:
-      - doi_value: doi:10.25585/1488209 # https://www.osti.gov/dataexplorer/biblio/dataset/1488209 -> https://genome.jgi.doe.gov/portal/ARhifrWetlands/ARhifrWetlands.info.html
-        doi_category: dataset_doi
-        doi_provider: osti
-        type: nmdc:Doi
-    type: nmdc:Study
-    study_category: research_study
+- id: nmdc:sty-99-FkQIsc
+  type: nmdc:Study
+  gold_study_identifiers:
+  - gold:Gs123456789
+  name: Permafrost microbial communities from Stordalen Mire, Sweden
+  description: Thawing permafrost is one of the largest soil carbon pools on the planet.
+    The goal of this project is to study microbial communities that participate in
+    the soil carbon cycle.
+  ecosystem: Environmental
+  ecosystem_category: Terrestrial
+  ecosystem_type: Soil
+  ecosystem_subtype: Wetlands
+  specific_ecosystem: Permafrost
+  principal_investigator:
+    type: nmdc:PersonValue
+    has_raw_value: Virginia Rich
+  associated_dois:
+  - doi_value: doi:10.25585/1488217
+    doi_category: dataset_doi
+    doi_provider: osti
+    type: nmdc:Doi
+  study_category: research_study
+- id: nmdc:sty-99-oJmAOs
+  gold_study_identifiers:
+  - gold:Gs121212
+  name: Forest soil microbial communities from Barre Woods Harvard Forest LTER site,
+    Petersham, Massachusetts, United States
+  description: The goal of this study is to learn the molecular mechanisms underlying
+    changes in the temperature sensitive respiration response of forest soils to long-term
+    experimental warming
+  ecosystem: Environmental
+  ecosystem_category: Terrestrial
+  ecosystem_type: Soil
+  ecosystem_subtype: Unclassified
+  specific_ecosystem: Forest Soil
+  principal_investigator:
+    type: nmdc:PersonValue
+    has_raw_value: Jeffrey Blanchard
+  associated_dois:
+  - doi_value: doi:10.25585/1488215
+    doi_category: dataset_doi
+    doi_provider: osti
+    type: nmdc:Doi
+  type: nmdc:Study
+  study_category: consortium
+- id: nmdc:sty-99-3bQQ4j
+  gold_study_identifiers:
+  - gold:Gs0134277
+  name: Rhizosphere microbial communities from Carex aquatilis grown in University
+    of Washington, Seatle, WA, United States
+  description: The goal of this study is to advance understanding of the response
+    of methane production and methane oxidation to changes in plant productivity so
+    that modeled representations of these processes and interactions can be improved.
+  ecosystem: Host-associated
+  ecosystem_category: Plants
+  ecosystem_type: Roots
+  ecosystem_subtype: Rhizosphere
+  specific_ecosystem: Soil
+  principal_investigator:
+    type: nmdc:PersonValue
+    has_raw_value: Rebecca Neumann
+  associated_dois:
+  - doi_value: doi:10.25585/1488209
+    doi_category: dataset_doi
+    doi_provider: osti
+    type: nmdc:Doi
+  type: nmdc:Study
+  study_category: research_study
 data_generation_set:
-  - id: nmdc:dgns-99-9XUVVF
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0225767
-    name: Forest soil microbial communities from Barre Woods Harvard Forest LTER site,
-      Petersham, Massachusetts, United States - Inc-BW-C-14-O
-    description: Forest soil from Barre Woods Harvard Forest LTER site was incubated
-      at 10C with heavy water. Sample is from a control plot at ambient soil temperature,
-      organic horizon - top 4cm of soil
-    has_input:
-      - nmdc:bsm-00-yellow
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2017-08-17T00:00:00Z'
-      mod_date: '2020-10-16T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-90125
-    ncbi_project_name: Forest soil microbial communities from Barre Woods Harvard Forest
-      LTER site, Petersham, Massachusetts, United States - Inc-BW-C-14-O
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-31415
-  - id: nmdc:dgns-99-dk9vgI
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0208560
-    name: Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG
-    description: Permafrost microbial communities from Stordalen Mire, Sweden
-    has_input:
-      - nmdc:bsm-00-green
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2017-03-17T00:00:00Z'
-      mod_date: '2020-05-22T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-pizza
-    ncbi_project_name: Permafrost microbial communities from Stordalen Mire, Sweden
-      - 611E1M metaG
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-8675309
-  - id: nmdc:dgns-99-MVW1FV
-    analyte_category: metagenome
-    alternative_identifiers:
-      - gold:Gp0306221
-    name: Rhizosphere microbial communities from Carex aquatilis grown in University
-      of Washington, Seatle, WA, United States - 4-1-23 metaG
-    description: Rhizosphere microbial communities from Carex aquatilis grown in submerged
-      peat from a thermokarst bog, University of Washington, Seatle, WA, United States
-    has_input:
-      - nmdc:bsm-00-blue
-    provenance_metadata:
-      type: nmdc:ProvenanceMetadata
-      add_date: '2018-03-29T00:00:00Z'
-      mod_date: '2020-04-04T00:00:00Z'
-    has_output:
-      - nmdc:dobj-00-mobydick
-    ncbi_project_name: Rhizosphere microbial communities from Carex aquatilis grown
-      in University of Washington, Seatle, WA, United States - 4-1-23 metaG
-    processing_institution: JGI
-    type: nmdc:NucleotideSequencing
-    associated_studies:
-      - nmdc:sty-00-avacado
+- id: nmdc:dgns-99-9XUVVF
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0225767
+  name: Forest soil microbial communities from Barre Woods Harvard Forest LTER site,
+    Petersham, Massachusetts, United States - Inc-BW-C-14-O
+  description: Forest soil from Barre Woods Harvard Forest LTER site was incubated
+    at 10C with heavy water. Sample is from a control plot at ambient soil temperature,
+    organic horizon - top 4cm of soil
+  has_input:
+  - nmdc:bsm-00-yellow
+  has_output:
+  - nmdc:dobj-00-90125
+  ncbi_project_name: Forest soil microbial communities from Barre Woods Harvard Forest
+    LTER site, Petersham, Massachusetts, United States - Inc-BW-C-14-O
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-31415
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-9XUVVF
+    type: nmdc:ProvenanceObject
+    add_date: '2017-08-17T00:00:00Z'
+    mod_date: '2020-10-16T00:00:00Z'
+- id: nmdc:dgns-99-dk9vgI
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0208560
+  name: Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG
+  description: Permafrost microbial communities from Stordalen Mire, Sweden
+  has_input:
+  - nmdc:bsm-00-green
+  has_output:
+  - nmdc:dobj-00-pizza
+  ncbi_project_name: Permafrost microbial communities from Stordalen Mire, Sweden
+    - 611E1M metaG
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-8675309
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-dk9vgI
+    type: nmdc:ProvenanceObject
+    add_date: '2017-03-17T00:00:00Z'
+    mod_date: '2020-05-22T00:00:00Z'
+- id: nmdc:dgns-99-MVW1FV
+  analyte_category: metagenome
+  alternative_identifiers:
+  - gold:Gp0306221
+  name: Rhizosphere microbial communities from Carex aquatilis grown in University
+    of Washington, Seatle, WA, United States - 4-1-23 metaG
+  description: Rhizosphere microbial communities from Carex aquatilis grown in submerged
+    peat from a thermokarst bog, University of Washington, Seatle, WA, United States
+  has_input:
+  - nmdc:bsm-00-blue
+  has_output:
+  - nmdc:dobj-00-mobydick
+  ncbi_project_name: Rhizosphere microbial communities from Carex aquatilis grown
+    in University of Washington, Seatle, WA, United States - 4-1-23 metaG
+  processing_institution: JGI
+  type: nmdc:NucleotideSequencing
+  associated_studies:
+  - nmdc:sty-00-avacado
+  has_instance_provenance:
+  - id: nmdc:prov-99-99-MVW1FV
+    type: nmdc:ProvenanceObject
+    add_date: '2018-03-29T00:00:00Z'
+    mod_date: '2020-04-04T00:00:00Z'
 biosample_set:
-  - id: nmdc:bsm-99-isqhuW
-    gold_biosample_identifiers:
-      - gold:Gb0150408
-    name: Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG
-    description: Permafrost microbial communities from Stordalen Mire, Sweden
-    type: nmdc:Biosample
-    associated_studies:
-      - nmdc:sty-00-8675309
-    env_broad_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002030
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002030
-    env_local_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002169
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002169
-    env_medium:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00005792
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00005792
-    geo_loc_name:
-      type: nmdc:TextValue
-      has_raw_value: 'Sweden: Stordalen'
-    lat_lon:
-      type: nmdc:GeolocationValue
-      has_raw_value: 68.35 19.05
-      latitude: 68.35
-      longitude: 19.05
-    ecosystem: Environmental
-    ecosystem_category: Terrestrial
-    ecosystem_type: Soil
-    ecosystem_subtype: Wetlands
-    specific_ecosystem: Permafrost
-    community: microbial communities
-    habitat: Fen
-    samp_name: 11E1M metaG
-    location: Stordalen Mire, Sweden
-    ncbi_taxonomy_name: permafrost metagenome
-    sample_collection_site: Mire fen
-  - id: nmdc:bsm-99-dge3H9
-    gold_biosample_identifiers:
-      - gold:Gb0157174
-    name: Forest soil microbial communities from Barre Woods Harvard Forest LTER site,
-      Petersham, Massachusetts, United States - Inc-BW-C-14-O
-    description: Forest soil from Barre Woods Harvard Forest LTER site was incubated
-      at 10C with heavy water. Sample is from a control plot at ambient soil temperature,
-      organic horizon - top 4cm of soil
-    type: nmdc:Biosample
-    associated_studies:
-      - nmdc:sty-00-8675309
-    env_broad_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002030
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002030
-    env_local_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002169
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002169
-    env_medium:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00005792
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00005792
-    geo_loc_name:
-      type: nmdc:TextValue
-      has_raw_value: 'USA: Massachusetts'
-    lat_lon:
-      type: nmdc:GeolocationValue
-      has_raw_value: 42.481016 -72.178343
-      latitude: 42.481016
-      longitude: -72.178343
-    ecosystem: Environmental
-    ecosystem_category: Terrestrial
-    ecosystem_type: Soil
-    ecosystem_subtype: Unclassified
-    specific_ecosystem: Forest Soil
-    community: microbial communities
-    habitat: soil
-    samp_name: Inc-BW-C-14-O
-    location: Barre Woods Harvard Forest LTER site, Petersham, Massachusetts, United
-      States
-    ncbi_taxonomy_name: soil metagenome
-    sample_collection_site: forest soil
-  - id: nmdc:bsm-99-dc6tg6
-    gold_biosample_identifiers:
-      - gold:Gb0188037
-    name: Rhizosphere microbial communities from Carex aquatilis grown in University
-      of Washington, Seatle, WA, United States - 4-1-23 metaG
-    description: Rhizosphere microbial communities from Carex aquatilis grown in submerged
-      peat from a thermokarst bog, University of Washington, Seatle, WA, United States
-    type: nmdc:Biosample
-    associated_studies:
-      - nmdc:sty-00-8675309
-    env_broad_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002030
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002030
-    env_local_scale:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00002169
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00002169
-    env_medium:
-      type: nmdc:ControlledIdentifiedTermValue
-      has_raw_value: ENVO:00005792
-      term:
-        type: nmdc:OntologyClass
-        id: ENVO:00005792
-    geo_loc_name:
-      type: nmdc:TextValue
-      has_raw_value: 'USA: Seattle, Washington'
-    lat_lon:
-      type: nmdc:GeolocationValue
-      has_raw_value: 47.6516 -122.3045
-      latitude: 47.6516
-      longitude: -122.3045
-    ecosystem: Host-associated
-    ecosystem_category: Plants
-    ecosystem_type: Rhizosphere
-    ecosystem_subtype: Soil
-    specific_ecosystem: Unclassified
-    community: microbial communities
-    habitat: rhizosphere
-    host_name: Carex aquatilis
-    samp_name: 4-1-23 metaG
-    location: University of Washington, Seatle, WA, United States
-    ncbi_taxonomy_name: rhizosphere metagenome
-    sample_collection_site: Peat Soil
+- id: nmdc:bsm-99-isqhuW
+  gold_biosample_identifiers:
+  - gold:Gb0150408
+  name: Permafrost microbial communities from Stordalen Mire, Sweden - 611E1M metaG
+  description: Permafrost microbial communities from Stordalen Mire, Sweden
+  type: nmdc:Biosample
+  associated_studies:
+  - nmdc:sty-00-8675309
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002030
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002030
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002169
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002169
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00005792
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00005792
+  geo_loc_name:
+    type: nmdc:TextValue
+    has_raw_value: 'Sweden: Stordalen'
+  lat_lon:
+    type: nmdc:GeolocationValue
+    has_raw_value: 68.35 19.05
+    latitude: 68.35
+    longitude: 19.05
+  ecosystem: Environmental
+  ecosystem_category: Terrestrial
+  ecosystem_type: Soil
+  ecosystem_subtype: Wetlands
+  specific_ecosystem: Permafrost
+  community: microbial communities
+  habitat: Fen
+  samp_name: 11E1M metaG
+  location: Stordalen Mire, Sweden
+  ncbi_taxonomy_name: permafrost metagenome
+  sample_collection_site: Mire fen
+- id: nmdc:bsm-99-dge3H9
+  gold_biosample_identifiers:
+  - gold:Gb0157174
+  name: Forest soil microbial communities from Barre Woods Harvard Forest LTER site,
+    Petersham, Massachusetts, United States - Inc-BW-C-14-O
+  description: Forest soil from Barre Woods Harvard Forest LTER site was incubated
+    at 10C with heavy water. Sample is from a control plot at ambient soil temperature,
+    organic horizon - top 4cm of soil
+  type: nmdc:Biosample
+  associated_studies:
+  - nmdc:sty-00-8675309
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002030
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002030
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002169
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002169
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00005792
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00005792
+  geo_loc_name:
+    type: nmdc:TextValue
+    has_raw_value: 'USA: Massachusetts'
+  lat_lon:
+    type: nmdc:GeolocationValue
+    has_raw_value: 42.481016 -72.178343
+    latitude: 42.481016
+    longitude: -72.178343
+  ecosystem: Environmental
+  ecosystem_category: Terrestrial
+  ecosystem_type: Soil
+  ecosystem_subtype: Unclassified
+  specific_ecosystem: Forest Soil
+  community: microbial communities
+  habitat: soil
+  samp_name: Inc-BW-C-14-O
+  location: Barre Woods Harvard Forest LTER site, Petersham, Massachusetts, United
+    States
+  ncbi_taxonomy_name: soil metagenome
+  sample_collection_site: forest soil
+- id: nmdc:bsm-99-dc6tg6
+  gold_biosample_identifiers:
+  - gold:Gb0188037
+  name: Rhizosphere microbial communities from Carex aquatilis grown in University
+    of Washington, Seatle, WA, United States - 4-1-23 metaG
+  description: Rhizosphere microbial communities from Carex aquatilis grown in submerged
+    peat from a thermokarst bog, University of Washington, Seatle, WA, United States
+  type: nmdc:Biosample
+  associated_studies:
+  - nmdc:sty-00-8675309
+  env_broad_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002030
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002030
+  env_local_scale:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00002169
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00002169
+  env_medium:
+    type: nmdc:ControlledIdentifiedTermValue
+    has_raw_value: ENVO:00005792
+    term:
+      type: nmdc:OntologyClass
+      id: ENVO:00005792
+  geo_loc_name:
+    type: nmdc:TextValue
+    has_raw_value: 'USA: Seattle, Washington'
+  lat_lon:
+    type: nmdc:GeolocationValue
+    has_raw_value: 47.6516 -122.3045
+    latitude: 47.6516
+    longitude: -122.3045
+  ecosystem: Host-associated
+  ecosystem_category: Plants
+  ecosystem_type: Rhizosphere
+  ecosystem_subtype: Soil
+  specific_ecosystem: Unclassified
+  community: microbial communities
+  habitat: rhizosphere
+  host_name: Carex aquatilis
+  samp_name: 4-1-23 metaG
+  location: University of Washington, Seatle, WA, United States
+  ncbi_taxonomy_name: rhizosphere metagenome
+  sample_collection_site: Peat Soil
 data_object_set:
-  - id: nmdc:dobj-99-dkJ8ab
-    name: 11340.8.202049.GTCTCCT-AAGGAGA.fastq.gz
-    description: Raw sequencer read data
-    data_category: instrument_data
-    file_size_bytes: 9208349052
-    type: nmdc:DataObject
-    data_object_type: Metagenome Raw Read 1
-  - id: nmdc:dobj-99-7zrm55
-    name: 11839.4.222578.GAGCTCA-TTGAGCT.fastq.gz
-    description: Raw sequencer read data
-    data_category: instrument_data
-    file_size_bytes: 34243309819
-    type: nmdc:DataObject
-    data_object_type: Metagenome Raw Read 1
-  - id: nmdc:dobj-99-sQQw0I
-    name: 12660.4.274923.GATCGTAC-GTACGATC.fastq.gz
-    description: Raw sequencer read data
-    data_category: instrument_data
-    file_size_bytes: 7580035314
-    type: nmdc:DataObject
-    data_object_type: Metagenome Raw Read 1
+- id: nmdc:dobj-99-dkJ8ab
+  name: 11340.8.202049.GTCTCCT-AAGGAGA.fastq.gz
+  description: Raw sequencer read data
+  data_category: instrument_data
+  file_size_bytes: 9208349052
+  type: nmdc:DataObject
+  data_object_type: Metagenome Raw Read 1
+- id: nmdc:dobj-99-7zrm55
+  name: 11839.4.222578.GAGCTCA-TTGAGCT.fastq.gz
+  description: Raw sequencer read data
+  data_category: instrument_data
+  file_size_bytes: 34243309819
+  type: nmdc:DataObject
+  data_object_type: Metagenome Raw Read 1
+- id: nmdc:dobj-99-sQQw0I
+  name: 12660.4.274923.GATCGTAC-GTACGATC.fastq.gz
+  description: Raw sequencer read data
+  data_category: instrument_data
+  file_size_bytes: 7580035314
+  type: nmdc:DataObject
+  data_object_type: Metagenome Raw Read 1

--- a/src/data/valid/Database-nom_calibration_example.yaml
+++ b/src/data/valid/Database-nom_calibration_example.yaml
@@ -16,10 +16,11 @@ data_generation_set:
   eluent_introduction_category: direct_infusion_autosampler
   end_date: '2022-04-25 14:01:57.000'
   has_mass_spectrometry_configuration: nmdc:mscon-14-j5y11q51
-  provenance_metadata:
-    type: nmdc:ProvenanceMetadata
-    mod_date: '2024-11-07T00:00:00Z'
   start_date: '2022-04-25 13:48:27.000'
+  has_instance_provenance:
+  - id: nmdc:prov-99-11-0003fm52
+    type: nmdc:ProvenanceObject
+    mod_date: '2024-11-07T00:00:00Z'
 calibration_set:
 - id: nmdc:calib-14-hhn3qb47
   calibration_object: nmdc:dobj-14-1e9qeq49
@@ -45,17 +46,16 @@ workflow_execution_set:
   started_at_time: '2024-03-10 23:25:16'
   ended_at_time: '2024-03-10 23:25:16'
   was_informed_by:
-    - nmdc:omprc-11-0003fm52
+  - nmdc:omprc-11-0003fm52
   execution_resource: EMSL-RZR
   processing_institution: NMDC
   git_url: https://github.com/microbiomedata/enviroMS
   has_input:
   - nmdc:dobj-11-cp4p5602
   type: nmdc:NomAnalysis
-  uses_calibration: 
+  uses_calibration:
   - nmdc:calib-14-hhn3qb47
   has_output:
   - nmdc:dobj-11-wkvtnj47
   alternative_identifiers:
   - nmdc:wfnom-11-zs6pnn44
-  

--- a/src/data/valid/NucleotideSequencing-2.yaml
+++ b/src/data/valid/NucleotideSequencing-2.yaml
@@ -1,21 +1,21 @@
-#test to check readding prefix 'omprc' as a valid id pattern
 id: nmdc:omprc-99-zUCd5N
 type: nmdc:NucleotideSequencing
 analyte_category: metagenome
 alternative_identifiers:
-  - gold:Gp0108335
-name: Thawing permafrost microbial communities from the Arctic, studying carbon
-  transformations - Permafrost 712P3D
+- gold:Gp0108335
+name: Thawing permafrost microbial communities from the Arctic, studying carbon transformations
+  - Permafrost 712P3D
 has_input:
-  - nmdc:bsm-00-red
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
-  add_date: '2014-10-30T00:00:00Z'
-  mod_date: '2020-05-22T00:00:00Z'
+- nmdc:bsm-00-red
 has_output:
-  - nmdc:dobj-00-9n9n9n
+- nmdc:dobj-00-9n9n9n
 ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
   carbon transformations - Permafrost 712P3D
 processing_institution: JGI
 associated_studies:
-  - nmdc:sty-00-xxx
+- nmdc:sty-00-xxx
+has_instance_provenance:
+- id: nmdc:prov-99-99-zUCd5N
+  type: nmdc:ProvenanceObject
+  add_date: '2014-10-30T00:00:00Z'
+  mod_date: '2020-05-22T00:00:00Z'

--- a/src/data/valid/NucleotideSequencing-ndsdc-bioproject.yaml
+++ b/src/data/valid/NucleotideSequencing-ndsdc-bioproject.yaml
@@ -1,23 +1,23 @@
 id: nmdc:dgns-11-pf500b03
 analyte_category: metagenome
 gold_sequencing_project_identifiers:
-  - gold:Gp0704888
-name: Thawing permafrost microbial communities from the Arctic, studying carbon
-  transformations - Permafrost 712P3D
+- gold:Gp0704888
+name: Thawing permafrost microbial communities from the Arctic, studying carbon transformations
+  - Permafrost 712P3D
 has_input:
-  - nmdc:bsm-00-red
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
-  add_date: '2014-10-30T00:00:00Z'
-  mod_date: '2020-05-22T00:00:00Z'
+- nmdc:bsm-00-red
 has_output:
-  - nmdc:dobj-00-9n9n9n
+- nmdc:dobj-00-9n9n9n
 ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
   carbon transformations - Permafrost 712P3D
 insdc_bioproject_identifiers:
-  - bioproject:PRJNA1029144
+- bioproject:PRJNA1029144
 processing_institution: JGI
 type: nmdc:NucleotideSequencing
 associated_studies:
-  - nmdc:sty-00-555xxx
-
+- nmdc:sty-00-555xxx
+has_instance_provenance:
+- id: nmdc:prov-99-11-pf500b03
+  type: nmdc:ProvenanceObject
+  add_date: '2014-10-30T00:00:00Z'
+  mod_date: '2020-05-22T00:00:00Z'

--- a/src/data/valid/NucleotideSequencing-processing-institution.yaml
+++ b/src/data/valid/NucleotideSequencing-processing-institution.yaml
@@ -1,20 +1,21 @@
 id: nmdc:dgns-99-zUCd5N
 analyte_category: metagenome
 alternative_identifiers:
-  - gold:Gp0108335
-name: Thawing permafrost microbial communities from the Arctic, studying carbon
-  transformations - Permafrost 712P3D
+- gold:Gp0108335
+name: Thawing permafrost microbial communities from the Arctic, studying carbon transformations
+  - Permafrost 712P3D
 has_input:
-  - nmdc:bsm-00-red
-provenance_metadata:
-  type: nmdc:ProvenanceMetadata
-  add_date: '2014-10-30T00:00:00Z'
-  mod_date: '2020-05-22T00:00:00Z'
+- nmdc:bsm-00-red
 has_output:
-  - nmdc:dobj-00-9n9n9n
+- nmdc:dobj-00-9n9n9n
 ncbi_project_name: Thawing permafrost microbial communities from the Arctic, studying
   carbon transformations - Permafrost 712P3D
 processing_institution: UCD_Genome_Center
 type: nmdc:NucleotideSequencing
-associated_studies: 
-  - nmdc:sty-00-555xxx
+associated_studies:
+- nmdc:sty-00-555xxx
+has_instance_provenance:
+- id: nmdc:prov-99-99-zUCd5N
+  type: nmdc:ProvenanceObject
+  add_date: '2014-10-30T00:00:00Z'
+  mod_date: '2020-05-22T00:00:00Z'

--- a/src/data/valid/ProvenanceObject-1.yaml
+++ b/src/data/valid/ProvenanceObject-1.yaml
@@ -1,0 +1,20 @@
+# Demonstrates a ProvenanceObject instance carrying both inline data
+# (the existing ProvenanceMetadata slots) and a url pointer to an
+# external artifact. The url case is the value-add over today's
+# ProvenanceMetadata: provenance records too complex for inline storage
+# can point at a changesheet, a migrator, or any other document.
+#
+# The id typecode (here `prov-`) is a placeholder; the actual typecode
+# is part of the design conversation in #3085.
+id: nmdc:prov-99-aaaaaa1
+type: nmdc:ProvenanceObject
+name: GOLD ETL ingest, batch 2024-10-30
+description: Provenance record for a Biosample created by the GOLD ETL ingest pipeline.
+add_date: "2024-10-30T00:00:00Z"
+mod_date: "2026-04-03T14:22:00Z"
+version: "11.19.1"
+git_url: https://github.com/microbiomedata/nmdc-runtime/releases/tag/v1.0.0
+source_system_of_record: GOLD
+submission_portal_identifier:
+  - "9c9d0a2e-1f3b-4d2a-b1e7-5f6a7b8c9d0e"
+url: drs://api.microbiomedata.org/objects/nmdc:obj-changesheet-2024-10-30-batch-7

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -51,6 +51,7 @@ classes:
       - name
       - description
       - alternative_identifiers
+      - has_instance_provenance
       - type
 
   OntologyClass:
@@ -413,7 +414,6 @@ classes:
 
       - alternative_descriptions
       - alternative_names
-      - provenance_metadata
       - alternative_titles
 
       - ecosystem
@@ -487,8 +487,6 @@ classes:
       protocol_link:
         multivalued: true
         inlined_as_list: true
-      provenance_metadata:
-        description: Provenance metadata for this Study, including when the record was added to and last modified in the NMDC database.
     exact_mappings:
       - OBI:0000066
       - SIO:000747
@@ -588,7 +586,6 @@ classes:
       - instrument_used
       - principal_investigator
       - instrument_instance_specifier
-      - provenance_metadata
     slot_usage:
       has_input:
         required: true
@@ -608,8 +605,6 @@ classes:
           syntax: "{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$"
           interpolated:
             true
-      provenance_metadata:
-        description: Provenance metadata for this DataGeneration, including when the record was added to and last modified in the NMDC database.
     broad_mappings:
       - OBI:0000070
       - ISA:Assay
@@ -685,32 +680,6 @@ classes:
           The NMDC release tag for a given workflow release used for data processing. If workflows are processed externally, as denoted by processing_institution,
           this value represents the best mapping between a processing institution's (e.g., JGI) workflow metadata and a NMDC tagged release.
         
-  ProvenanceMetadata:
-    description: Metadata pertaining to how a record was created.
-    class_uri: nmdc:ProvenanceMetadata
-    slots:
-      - add_date
-      - git_url
-      - mod_date
-      - version
-      - source_system_of_record
-      - submission_portal_identifier
-      - type
-    slot_usage:
-      add_date:
-        range: datetime
-        description: The date and time at which a record was added to the NMDC database.
-        comments:
-          - Biosample and NucleotideSequencing records brought in from GOLD before 2026-03-23 may carry GOLD-sourced dates rather than NMDC-asserted timestamps.
-      mod_date:
-        range: datetime
-        description: The date and time at which a record was last modified in the NMDC database.
-        comments:
-          - Biosample and NucleotideSequencing records brought in from GOLD before 2026-03-23 may carry GOLD-sourced dates rather than NMDC-asserted timestamps.
-      version:
-        description: The version tag of the software used to generate the NMDC metadata record
-      git_url:
-        description: The url of the software repository used to generate the NMDC metadata record
 slots:
   classified_as:
     range: OntologyClass
@@ -937,10 +906,6 @@ slots:
       supersedes it, marking this record as outdated. The linked WorkflowExecution or
       resultant DataObjects should be used in favor of this record.
 
-  provenance_metadata: 
-    range: ProvenanceMetadata
-    description: Provides information about the provenance of a record.
-    
 enums:
   SourceSystemEnum:
     permissible_values:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -371,7 +371,6 @@ classes:
       - img_identifiers
       - neon_biosample_identifiers
       - alternative_names
-      - provenance_metadata
 
       ## external IDs, alternate IDs
       - gold_biosample_identifiers
@@ -936,9 +935,6 @@ classes:
           We recommend that, in addition to populating this field, you populate the `source_mat_id` field with a globally-unique identifier.
         examples:
           - value: "BW-H-17-M"
-      
-      provenance_metadata:
-        description: Provenance metadata for this Biosample, including when the record was added to and last modified in the NMDC database.
 
       collected_from:
         structured_pattern:
@@ -1310,7 +1306,6 @@ classes:
       - associated_studies
       - expected_organism
       - embargoed
-      - provenance_metadata
       - external_database_identifiers
       - gold_organism_identifiers
       - collection_date

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -16,6 +16,7 @@ version: 0.0.0
 imports:
   - annotation # also brings core and portal_*
   - workflow_execution_activity
+  - provenance_object
 
 prefixes:
   BFO: "http://purl.obolibrary.org/obo/BFO_"

--- a/src/schema/provenance_object.yaml
+++ b/src/schema/provenance_object.yaml
@@ -1,0 +1,80 @@
+id: https://w3id.org/nmdc/provenance_object
+name: NMDC-Provenance-Object
+title: NMDC Provenance Object (DRAFT)
+description: >-
+  DRAFT schema for a unified provenance class that replaces the embedded
+  ProvenanceMetadata class. ProvenanceObject is referenced from any
+  NamedThing via has_instance_provenance. Inline slots cover the simple
+  cases that ProvenanceMetadata handles today (add_date, mod_date,
+  source_system_of_record, etc.); a url slot offloads complex or batch
+  cases to an external artifact such as a changesheet TSV stored in DRS.
+
+  Parent class is candidate-only and tracked in issue #3085: the choice
+  between InformationObject sibling of DataObject (cleaner inheritance,
+  needs new collection or rename), DataObject subclass (reuses url but
+  inherits required slots), and a standalone class is part of the open
+  design conversation.
+
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+imports:
+  - basic_slots
+  - basic_classes
+
+default_range: string
+
+prefixes:
+  nmdc: "https://w3id.org/nmdc/"
+  dcterms: "http://purl.org/dc/terms/"
+  prov: "http://www.w3.org/ns/prov#"
+
+classes:
+  ProvenanceObject:
+    class_uri: nmdc:ProvenanceObject
+    is_a: InformationObject
+    description: A record describing how an NMDC document came to be the way it is.
+    comments:
+      - >-
+        Parent class is candidate-only. The alternatives are documented
+        in issue #3085. The current is_a is the lightest defensible
+        choice that keeps url available without inheriting DataObject's
+        required slots; the final decision affects collection placement
+        and the migration of existing ProvenanceMetadata instances.
+      - >-
+        ProvenanceObject is intended to replace the embedded
+        ProvenanceMetadata class once the design questions are resolved.
+        ProvenanceMetadata is unchanged in this PR.
+    slots:
+      - add_date
+      - mod_date
+      - version
+      - git_url
+      - source_system_of_record
+      - submission_portal_identifier
+      - url
+      - type
+    slot_usage:
+      add_date:
+        range: datetime
+        description: The date and time at which the recorded change took place.
+      mod_date:
+        range: datetime
+        description: The date and time at which the record describing the change was last revised.
+      url:
+        description: >-
+          Pointer to an external artifact that further documents this
+          provenance event. For example, the DRS URL of a stored
+          changesheet TSV, or a reference to a migrator script.
+
+slots:
+  has_instance_provenance:
+    description: A provenance record associated with this document.
+    range: ProvenanceObject
+    multivalued: true
+    inlined_as_list: true
+    comments:
+      - >-
+        Whether this slot should be attached to NamedThing directly or
+        only to specific subclasses is part of the design conversation
+        in issue #3085. This PR defines the slot but does not yet wire
+        it onto any class.


### PR DESCRIPTION
Draft proposal for issue #3085. Introduces a candidate `ProvenanceObject` class and a `has_instance_provenance` slot, both imported into `nmdc.yaml` so CI builds against them. Parked while the design questions in #3085 are resolved.

## What's in the diff

- `src/schema/provenance_object.yaml`: defines `ProvenanceObject` (`is_a: InformationObject` as the candidate parent, with the choice documented as open in the class comments) and the `has_instance_provenance` slot.
- `src/schema/nmdc.yaml`: imports the new file.
- `src/data/valid/ProvenanceObject-1.yaml`: one valid example showing both inline data and a `url` reference to a DRS-stored changesheet.

## What's deliberately not in the diff

- No change to `ProvenanceMetadata`. No removal, no deprecation.
- No change to the four classes (Biosample, OrganismSample, Study, DataGeneration) that currently carry `provenance_metadata`.
- No migrator for the 12,850 existing prod records that carry `provenance_metadata` (verified 2026-05-20).
- `has_instance_provenance` is defined but not attached to `NamedThing` or any specific class.
- No `provenance_object_set` on `Database`.
- No final decision on parent class, on the slot's host class(es), or on inline vs reference.

Design conversation: [the slot-level provenance Google Doc](https://docs.google.com/document/d/10141wDSi31ytpl2Aq2TOFBk8AeFXvQDJ_fQci00NjNQ/edit) (see the "Sources of provenance changes" and "Possible upstream-LinkML positioning" sections).

Companion to PR #3071, which addresses per-slot edits via a separate `SlotLevelProvenance` class. The two PRs cover different granularities and are intended to coexist.