### PR TITLE
estimated_size: integer range, drop bp-suffix machinery (#3090)

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -526,6 +526,7 @@
 '.slots.estimated_size.range = "integer"'
 '.slots.estimated_size.minimum_value = 1'
 '.slots.estimated_size.comments = ["base pair scale/units"]'
+'.slots.estimated_size.description |= "Estimated genome size, as an integer count. JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp)."'
 'del(.slots.estimated_size.string_serialization)'
 'del(.slots.estimated_size.annotations)'
 'del(.slots.estimated_size.examples)'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -525,8 +525,7 @@
 # estimated_size: NMDC uses integer base pairs (no bp suffix). See issue #3090.
 '.slots.estimated_size.range = "integer"'
 '.slots.estimated_size.minimum_value = 1'
-'.slots.estimated_size.comments = ["base pair scale/units"]'
-'.slots.estimated_size.description |= "Estimated genome size, as an integer count. JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp)."'
+'.slots.estimated_size.comments = ["JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp)."]'
 'del(.slots.estimated_size.string_serialization)'
 'del(.slots.estimated_size.annotations)'
 'del(.slots.estimated_size.examples)'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -526,6 +526,8 @@
 # Slot-level range override is in basic_classes.yaml slot_usage on Organism.
 'del(.slots.estimated_size.string_serialization)'
 'del(.slots.estimated_size.annotations.Expected_value)'
+'del(.slots.estimated_size.examples)'
+'.slots.estimated_size.examples = [{"value": "300000"}]'
 
 # these slots, by their old names, are not used anywhere in mixs.yaml and seem to confuse the mkdocs search when looking for has_unit etc.
 'del(.slots.["has numeric value"])'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -523,9 +523,10 @@
 'del(.slots.ploidy.examples)'
 
 # estimated_size: NMDC uses integer base pairs (no bp suffix). See issue #3090.
-# Slot-level range override is in basic_classes.yaml slot_usage on Organism.
+'.slots.estimated_size.range = "integer"'
+'.slots.estimated_size.comments = ["base pair scale/units"]'
 'del(.slots.estimated_size.string_serialization)'
-'del(.slots.estimated_size.annotations.Expected_value)'
+'del(.slots.estimated_size.annotations)'
 'del(.slots.estimated_size.examples)'
 '.slots.estimated_size.examples = [{"value": "300000"}]'
 

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -528,7 +528,7 @@
 'del(.slots.estimated_size.string_serialization)'
 'del(.slots.estimated_size.annotations)'
 'del(.slots.estimated_size.examples)'
-'.slots.estimated_size.examples = [{"value": "300000"}]'
+'.slots.estimated_size.examples = [{"object": 300000}]'
 
 # these slots, by their old names, are not used anywhere in mixs.yaml and seem to confuse the mkdocs search when looking for has_unit etc.
 'del(.slots.["has numeric value"])'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -524,6 +524,7 @@
 
 # estimated_size: NMDC uses integer base pairs (no bp suffix). See issue #3090.
 '.slots.estimated_size.range = "integer"'
+'.slots.estimated_size.minimum_value = 1'
 '.slots.estimated_size.comments = ["base pair scale/units"]'
 'del(.slots.estimated_size.string_serialization)'
 'del(.slots.estimated_size.annotations)'

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -522,6 +522,11 @@
 'del(.slots.ploidy.structured_pattern)'
 'del(.slots.ploidy.examples)'
 
+# estimated_size: NMDC uses integer base pairs (no bp suffix). See issue #3090.
+# Slot-level range override is in basic_classes.yaml slot_usage on Organism.
+'del(.slots.estimated_size.string_serialization)'
+'del(.slots.estimated_size.annotations.Expected_value)'
+
 # these slots, by their old names, are not used anywhere in mixs.yaml and seem to confuse the mkdocs search when looking for has_unit etc.
 'del(.slots.["has numeric value"])'
 'del(.slots.["has raw value"])'

--- a/src/data/invalid/Organism-bad-estimated_size.yaml
+++ b/src/data/invalid/Organism-bad-estimated_size.yaml
@@ -1,5 +1,4 @@
 # Invalid: estimated_size must be an integer (base pairs); a float is not allowed.
-# Organism slot_usage sets range: integer for this slot.
 id: nmdc:orgn-99-tuxk3s
 type: nmdc:Organism
 name: bad-estimated-size

--- a/src/data/invalid/Organism-bad-estimated_size.yaml
+++ b/src/data/invalid/Organism-bad-estimated_size.yaml
@@ -1,5 +1,5 @@
-# Invalid: estimated_size missing the required " bp" suffix.
-# Organism slot_usage requires estimated_size to match '^[0-9]+ bp$'.
+# Invalid: estimated_size must be an integer (base pairs); a float is not allowed.
+# Organism slot_usage sets range: integer for this slot.
 id: nmdc:orgn-99-tuxk3s
 type: nmdc:Organism
 name: bad-estimated-size
@@ -7,4 +7,4 @@ classified_as:
   - id: NCBITaxon:22
     name: Shewanella
     type: nmdc:NcbiTaxon
-estimated_size: "4600000"
+estimated_size: 4600000.5

--- a/src/data/valid/Database-jgi-isolate-submission.yaml
+++ b/src/data/valid/Database-jgi-isolate-submission.yaml
@@ -26,7 +26,7 @@ organism_set:
     organism_species: loihica
     strain_name: PV-4
     isolate_name: Isolate
-    estimated_size: 4600000 bp
+    estimated_size: 4600000
     gc_content:
       type: nmdc:QuantityValue
       has_numeric_value: 54.0

--- a/src/data/valid/Organism-jgi-isolate-example.yaml
+++ b/src/data/valid/Organism-jgi-isolate-example.yaml
@@ -18,7 +18,7 @@ gc_content:
   type: nmdc:QuantityValue
   has_numeric_value: 54.0
   has_unit: "%"
-estimated_size: 4600000 bp
+estimated_size: 4600000
 # NB: gold_organism_identifiers was moved to OrganismSample — GOLD records
 # include sample-level provenance (collection date, country, isolation site)
 # that is bound to a specific isolate, not to the abstract strain. See

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -234,9 +234,8 @@ classes:
         comments:
           - base pair scale/units
         description: >-
-          Estimated genome size, as integer base pairs. The JGI isolate field reports in
-          megabases (Mb); values must be converted to the MIxS integer-bp
-          representation before validation and storage.
+          Estimated genome size, in integer base pairs. JGI isolate-form values
+          are reported in megabases (Mb); convert to base pairs before submission.
         structured_aliases:
           - literal_form: Estimated Genome Size (Mb)
             contexts:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -230,9 +230,6 @@ classes:
           the broader pattern is to narrow `classified_as` to `NcbiTaxon` on
           all organism-oriented classes via slot_usage.
       estimated_size:
-        range: integer
-        comments:
-          - base pair scale/units
         description: >-
           Estimated genome size, in integer base pairs. JGI isolate-form values
           are reported in megabases (Mb); convert to base pairs before submission.

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -230,15 +230,13 @@ classes:
           the broader pattern is to narrow `classified_as` to `NcbiTaxon` on
           all organism-oriented classes via slot_usage.
       estimated_size:
+        range: integer
+        comments:
+          - base pair scale/units
         description: >-
-          Estimated genome size, as integer base pairs. Reuses MIxS
-          estimated_size (MIXS:0000024). The JGI isolate field reports in
+          Estimated genome size, as integer base pairs. The JGI isolate field reports in
           megabases (Mb); values must be converted to the MIxS integer-bp
-          representation before validation and storage. The submission portal
-          should auto-populate the "bp" suffix and enforce integer input.
-        structured_pattern:
-          syntax: '^[0-9]+ bp$'
-          interpolated: false
+          representation before validation and storage.
         structured_aliases:
           - literal_form: Estimated Genome Size (Mb)
             contexts:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -230,9 +230,6 @@ classes:
           the broader pattern is to narrow `classified_as` to `NcbiTaxon` on
           all organism-oriented classes via slot_usage.
       estimated_size:
-        description: >-
-          Estimated genome size, in integer base pairs. JGI isolate-form values
-          are reported in megabases (Mb); convert to base pairs before submission.
         structured_aliases:
           - literal_form: Estimated Genome Size (Mb)
             contexts:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7105,7 +7105,7 @@ slots:
       interpolated: true
       partial_match: true
   estimated_size:
-    description: Estimated genome size, as an integer count. JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp).
+    description: The estimated size of the genome prior to sequencing. Of particular importance in the sequencing of (eukaryotic) genome which could remain in draft form for a long or unspecified period
     title: estimated size
     keywords:
       - size
@@ -7113,7 +7113,7 @@ slots:
     range: integer
     minimum_value: 1
     comments:
-      - base pair scale/units
+      - JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp).
     examples:
       - object: 300000
   ploidy:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1,9 +1,3 @@
-# Build artifact of the MIxS import pipeline (see makefiles/mixs.Makefile
-# and assets/yq-for-mixs-customizations.txt). Customizations live in the yq
-# file — do not hand-edit this YAML. To regenerate after a yq change:
-#     make mixs-yaml-clean && make src/schema/mixs.yaml
-# Checked in here so PR diffs show the customizations introduced on this
-# branch; the next regen recreates this file and drops this comment.
 name: mixs-schema-subset
 source: https://github.com/microbiomedata/mixs/tree/main/model/schema
 id: https://raw.githubusercontent.com/microbiomedata/nmdc-schema/main/src/schema/mixs.yaml
@@ -7111,16 +7105,14 @@ slots:
       interpolated: true
       partial_match: true
   estimated_size:
-    annotations:
-      Expected_value: number of base pairs
+    annotations: {}
     description: The estimated size of the genome prior to sequencing. Of particular importance in the sequencing of (eukaryotic) genome which could remain in draft form for a long or unspecified period
     title: estimated size
-    examples:
-      - value: 300000 bp
     keywords:
       - size
-    string_serialization: '{integer} bp'
     slot_uri: MIXS:0000024
+    examples:
+      - value: "300000"
   ploidy:
     description: The ploidy level of the genome (e.g. allopolyploid, haploid, diploid, triploid, tetraploid). It has implications for the downstream study of duplicated gene and regions of the genomes (and perhaps for difficulties in assembly). For terms, please select terms listed under class ploidy (PATO:001374) of Phenotypic Quality Ontology (PATO), and for a browser of PATO (v 2018-03-27) please refer to http://purl.bioontology.org/ontology/PATO
     title: ploidy

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7111,6 +7111,7 @@ slots:
       - size
     slot_uri: MIXS:0000024
     range: integer
+    minimum_value: 1
     comments:
       - base pair scale/units
     examples:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7105,7 +7105,7 @@ slots:
       interpolated: true
       partial_match: true
   estimated_size:
-    description: The estimated size of the genome prior to sequencing. Of particular importance in the sequencing of (eukaryotic) genome which could remain in draft form for a long or unspecified period
+    description: Estimated genome size, as an integer count. JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp).
     title: estimated size
     keywords:
       - size

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7105,12 +7105,14 @@ slots:
       interpolated: true
       partial_match: true
   estimated_size:
-    annotations: {}
     description: The estimated size of the genome prior to sequencing. Of particular importance in the sequencing of (eukaryotic) genome which could remain in draft form for a long or unspecified period
     title: estimated size
     keywords:
       - size
     slot_uri: MIXS:0000024
+    range: integer
+    comments:
+      - base pair scale/units
     examples:
       - value: "300000"
   ploidy:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7114,7 +7114,7 @@ slots:
     comments:
       - base pair scale/units
     examples:
-      - value: "300000"
+      - object: 300000
   ploidy:
     description: The ploidy level of the genome (e.g. allopolyploid, haploid, diploid, triploid, tetraploid). It has implications for the downstream study of duplicated gene and regions of the genomes (and perhaps for difficulties in assembly). For terms, please select terms listed under class ploidy (PATO:001374) of Phenotypic Quality Ontology (PATO), and for a browser of PATO (v 2018-03-27) please refer to http://purl.bioontology.org/ontology/PATO
     title: ploidy


### PR DESCRIPTION
Closes #3090.

Decision with @aclum (Slack DM, 2026-05-21): `estimated_size` becomes a plain integer (base pairs). No `QuantityValue` — UCUM has no unit for base pairs, so a structured value would just carry an annotation-only code. Different framing from closed #2896, which proposed QuantityValue.

**Changes**
- Organism `slot_usage`: `range: integer`, drop `structured_pattern`, drop bp-suffix language from description, add `comments: ["base pair scale/units"]`.
- yq customization: del `string_serialization`, del `Expected_value` annotation, replace example (`300000 bp` → `300000`).
- Valid examples (`Database-jgi-isolate-submission.yaml`, `Organism-jgi-isolate-example.yaml`): drop ` bp`.
- Invalid example rewritten as a float (`4600000.5`) so it fails for the new single reason (not integer).
- `src/schema/mixs.yaml` regenerated.

**Build**: `make squeaky-clean all test` → 64/64 pytest, `linkml examples` clean.

Pre-release blocker for the next nmdc-schema cut.