### PR TITLE
Add sequel_IIe to InstrumentModelEnum

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -1278,7 +1278,11 @@ enums:
         aliases:
           - PacBio Sequel II
         meaning: OBI:0002633
-      
+
+      sequel_IIe:
+        aliases:
+          - PacBio Sequel IIe
+
       revio:
         aliases:
           - PacBio Revio


### PR DESCRIPTION
## Summary
- Adds `sequel_IIe` permissible value to `InstrumentModelEnum` in `src/schema/basic_classes.yaml`, with alias `PacBio Sequel IIe`
- PacBio Sequel IIe is a distinct instrument from the original Sequel and Sequel II — it shares Sequel II's chemistry/optics but adds on-instrument compute for HiFi (CCS) read generation
- No OBI term currently exists for Sequel IIe, so the entry omits `meaning:` — consistent with the existing `revio` entry

## Test plan
- [x] `make all` builds cleanly
- [x] `make test` passes
- [ ] New value appears in generated artifacts (JSON Schema, OWL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)