### PR TITLE
Add OBI meaning: to novaseq, hiseq, nextseq InstrumentModelEnum PVs

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -1112,7 +1112,8 @@ enums:
         aliases:
           - NovaSeq
           - Illumina NovaSeq
-          
+        meaning: OBI:0003685
+
       novaseq_6000:
         aliases:
           - NovaSeq 6000
@@ -1157,7 +1158,8 @@ enums:
       hiseq:
         aliases:
           - Illumina HiSeq
-      
+        meaning: OBI:0003683
+
       hiseq_1000:
         aliases:
           - Illumina HiSeq 1000
@@ -1227,6 +1229,7 @@ enums:
         aliases:
           - NextSeq
           - Illumina NextSeq
+        meaning: OBI:0003684
         structured_aliases:
           - literal_form: Illumina NextSeq-HO
             contexts:


### PR DESCRIPTION
## Summary
- Adds `meaning:` OBI CURIEs to three umbrella sequencer PVs that already had OBI terms but were missing the annotation
- `novaseq` -> `OBI:0003685` (Illumina NovaSeq series instrument)
- `hiseq` -> `OBI:0003683` (Illumina HiSeq series instrument)
- `nextseq` -> `OBI:0003684` (Illumina NextSeq series instrument)

Closes #3107

## Test plan
- [ ] `make all` builds cleanly
- [ ] `make test` passes