### PR TITLE
Fix 4 misclassified mapping predicates

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -758,7 +758,7 @@ slots:
         and MassSpectrometry, the MassSpectrometry record is considered the primary class to reference.
     multivalued: true  
     range: DataGeneration
-    narrow_mappings:
+    exact_mappings:
       - prov:wasInformedBy
     structured_aliases:
       - literal_form: was_informed_by

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -758,7 +758,7 @@ slots:
         and MassSpectrometry, the MassSpectrometry record is considered the primary class to reference.
     multivalued: true  
     range: DataGeneration
-    exact_mappings:
+    mappings:
       - prov:wasInformedBy
     structured_aliases:
       - literal_form: was_informed_by

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1260,7 +1260,7 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
-    broad_mappings:
+    exact_mappings:
       - OBI:0000094
 
   PortionOfSubstance:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -969,7 +969,7 @@ enums:
         aliases:
           - 16S rRNA
           - 16S ribosomal RNA
-        narrow_mappings:
+        related_mappings:
           - OBI:0002763
       23S_rRNA:
         aliases:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1367,7 +1367,7 @@ slots:
       - sample weight
     exact_mappings:
       - MS:1000004
-    narrow_mappings:
+    broad_mappings:
       - MIXS:0000111
     range: QuantityValue
     annotations:


### PR DESCRIPTION
## Summary
- `input_mass` -> MIXS:0000111: `narrow_mappings` to `broad_mappings` (samp_size is broader than input_mass)
- `was_informed_by` -> prov:wasInformedBy: `narrow_mappings` to `mappings` (same concept, but PROV property-to-property alignments use generic `mappings` per CLAUDE.md convention; see #3118 for whether this convention should be revisited)
- `MaterialProcessing` -> OBI:0000094: `broad_mappings` to `exact_mappings` (same concept)
- `16S_rRNA` -> OBI:0002763: `narrow_mappings` to `related_mappings` (maps a gene target to an assay type)

Closes #3109

## Test plan
- [ ] `make all` builds cleanly
- [ ] `make test` passes