### PR TITLE
Remove unused imports from migrator infrastructure modules

### DIFF
--- a/nmdc_schema/migrators/helpers.py
+++ b/nmdc_schema/migrators/helpers.py
@@ -1,8 +1,7 @@
 import logging
-from typing import Any, List, Dict
+from typing import Any, List
 from importlib import resources
 from pathlib import Path
-from functools import lru_cache
 import yaml
 from nmdc_schema.nmdc_data import get_nmdc_schema_definition
 from linkml_runtime import SchemaView

--- a/nmdc_schema/migrators/migrator_base.py
+++ b/nmdc_schema/migrators/migrator_base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List
 from logging import getLogger
 from nmdc_schema.migrators.adapters.adapter_base import AdapterBase
 


### PR DESCRIPTION
Removes unused imports from two migrator infrastructure files (not migrator partials):

- `nmdc_schema/migrators/helpers.py`: `Dict`, `lru_cache`
- `nmdc_schema/migrators/migrator_base.py`: `Dict`, `List`

Partial fix for #3113. Split from #3115 to allow separate review of migrator infrastructure changes.