### PR TITLE
Add `maximum_value` to `estimated_size` (closes #3122)

### DIFF
--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7115,6 +7115,7 @@ slots:
     maximum_value: 100000000000
     comments:
       - JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp).
+      - The maximum_value here (1e11 bp = 100,000 Mb) is the eukaryote ceiling from JGI esplims. The tighter microbe ceiling (5,000 Mb) and the category-conditional required rule are enforced in submission-schema via class rules on IsolateInterface, keyed on biosafety_mat_cat.
     examples:
       - object: 300000
   ploidy:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7112,6 +7112,7 @@ slots:
     slot_uri: MIXS:0000024
     range: integer
     minimum_value: 1
+    maximum_value: 100000000000
     comments:
       - JGI reports values in megabases (Mb); NMDC stores them in base pairs (bp).
     examples:


### PR DESCRIPTION
Adds `maximum_value: 100000000000` (1e11 bp = 100,000 Mb) to the `estimated_size` slot in `mixs.yaml`.

This is a loose sanity ceiling matching the JGI esplims upper bound for eukaryotes. Tighter per-category limits (e.g., 5,000 Mb for microbes) are enforced in submission-schema via class rules, not here.