### PR TITLE
Remove unused FMA prefix and dead commented code

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -122,10 +122,6 @@ enums:
       derivatizing_agent:
         description: Chemically modifies analytes to improve detection or separation.
         # meaning: MSIO:0000003
-      # labeling_reagent:
-      #   description:  Introduces a detectable label for tracing or quantification.
-      # precipitating_agent:
-      #   description: Causes precipitation of unwanted substances or aids in the concentration of analytes.
       solubilizing_agent: { }
 
   SampleStateEnum:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -110,10 +110,6 @@ enums:
       base:
         description: Accepts a proton or donates an electron pair in a chemical reaction.
         meaning: CHEBI:22695
-      # protease:
-      #   description: Enzyme that catalyzes cleavage of peptide bonds in proteins.
-      # proteolytic_enzyme:
-      #   description: Enzyme that catalyzes the hydrolysis of proteins.
       ms_proteolytic_enzyme:
         description: Enzyme that catalyzes the hydrolysis of proteins and is used in mass spectrometry based proteomics
         meaning: MS:1002986
@@ -123,9 +119,6 @@ enums:
       surfactant:
         description: Reduces surface tension and aids in the solubilization of substances.
         meaning: CHEBI:35195
-      # stabilizer:
-      #   description: Prevents degradation or loss of analytes during sample storage or preparation.
-      #   meaning: CFo000000033
       derivatizing_agent:
         description: Chemically modifies analytes to improve detection or separation.
         # meaning: MSIO:0000003
@@ -1523,9 +1516,6 @@ slots:
       name of the environmental package, a selection of fields can be made from the
       subtables and can be reported
     range: TextValue
-  #      pattern: '[air|built environment|host\-associated|human\-associated|human\-skin|human\-oral|human\-gut|human\-vaginal|hydrocarbon
-  #        resources\-cores|hydrocarbon resources\-fluids\/swabs|microbial mat\/biofilm|misc
-  #        environment|plant\-associated|sediment|soil|wastewater\/sludge|water]'
   zinc:
     annotations:
       Expected_value: measurement value

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -31,7 +31,6 @@ prefixes:
   EGGNOG: "https://bioregistry.io/eggnog:" # https://bioregistry.io/eggnog:veNOG12876
   ENVO: "http://purl.obolibrary.org/obo/ENVO_"
   FBcv: "http://purl.obolibrary.org/obo/FBcv_" # for Biosample only
-  FMA: "http://purl.obolibrary.org/obo/FMA_"
   GENEPIO: "http://purl.obolibrary.org/obo/GENEPIO_" # for library_preparation_kit, contig identifier and count only
   GO: "http://purl.obolibrary.org/obo/GO_"
   HMDB: "https://bioregistry.io/hmdb:" # https://bioregistry.io/hmdb:HMDB00001


### PR DESCRIPTION
Three low-risk deletions, no functional changes.

**Unused prefix** (closes https://github.com/microbiomedata/nmdc-schema/issues/2920): removed `FMA: "http://purl.obolibrary.org/obo/FMA_"` from `nmdc.yaml`. FMA appears only in free-text `Expected_value` annotations in `mixs.yaml`, not as any `class_uri`, `slot_uri`, `meaning`, or mapping CURIE.

**Commented-out permissible values** (closes https://github.com/microbiomedata/nmdc-schema/issues/2399): removed three dead PV blocks from `SubstanceRoleEnum` in `core.yaml`: `protease`, `proteolytic_enzyme`, and `stabilizer`. The `stabilizer` entry also had a likely-malformed `meaning` value (`CFo000000033`).

**Commented-out pattern** (closes https://github.com/microbiomedata/nmdc-schema/issues/2400): removed two comment lines from the `env_package` slot in `core.yaml`. The pattern used character-class syntax (`[air|built environment|...]`) that is incompatible with LinkML's `structured_pattern` format and was never active.