### PR TITLE
Remove underscores from nitrate/nitrite slot titles

### DIFF
--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1566,7 +1566,7 @@ slots:
       occurrence: "1"
       storage_units: "[ppm]|mg/kg|mg/L"
     description: Concentration of nitrate nitrogen in the sample
-    title: nitrate_nitrogen
+    title: nitrate nitrogen
     examples:
       - value: 0.29 mg/kg
     see_also:
@@ -1582,7 +1582,7 @@ slots:
       occurrence: "1"
       storage_units: "[ppm]|mg/kg|mg/L"
     description: Concentration of nitrite nitrogen in the sample
-    title: nitrite_nitrogen
+    title: nitrite nitrogen
     examples:
       - value: 1.2 mg/kg
     see_also:


### PR DESCRIPTION
Changes the display titles `nitrate_nitrogen` and `nitrite_nitrogen` to `nitrate nitrogen` and `nitrite nitrogen` in `core.yaml`.

Titles are display labels, not slot names. The slot names are unchanged, so no data, no identifiers, and no downstream consumers are affected. Submission-schema already overrides `nitrate_nitrogen` to `nitrate` in its own slot_usage, so the portal display is independent of this change.

@pkalita-lbl confirmed on the issue that changing slot titles would not disrupt the submission portal.

Closes https://github.com/microbiomedata/nmdc-schema/issues/2532