### PR TITLE
Add SECURITY.md with private vulnerability reporting guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please email your report to [MAM@lbl.gov](mailto:MAM@lbl.gov) so the maintainers can review it privately.
+
+## Supported Versions
+
+Only the latest release is supported with security updates. See [Releases](https://github.com/microbiomedata/nmdc-schema/releases) for the current version.
+
+## Security Updates
+
+GitHub Actions dependencies and Python dependencies are monitored by Dependabot and updated through repository automation. CodeQL code scanning runs on the default branch and on pull requests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,4 +21,4 @@ Security fixes land in the latest release. Note that downstream consumers (for e
 
 ## Security Updates
 
-GitHub Actions dependencies and Python dependencies are monitored by Dependabot and updated through repository automation. CodeQL code scanning runs on the default branch and on pull requests.
+Python dependencies are monitored by Dependabot, which opens pull requests to patch known vulnerabilities. CodeQL code scanning runs on the default branch and on pull requests, configured by [`.github/codeql/codeql-config.yml`](https://github.com/microbiomedata/nmdc-schema/blob/main/.github/codeql/codeql-config.yml).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,16 @@ If you discover a security vulnerability in this project, please report it respo
 
 Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please email your report to [MAM@lbl.gov](mailto:MAM@lbl.gov) so the maintainers can review it privately.
 
+## Scope
+
+`nmdc-schema` is a schema-definition package: LinkML schema YAML, generated Pydantic and JSON Schema artifacts, and supporting Python utilities and data migrators. It is not a network service and does not handle authentication or untrusted request input. The realistic security surface is therefore:
+
+- **Dependency vulnerabilities** in the Python and GitHub Actions dependencies (monitored by Dependabot and CodeQL).
+- **Integrity of the published [`nmdc-schema` PyPI package](https://pypi.org/project/nmdc-schema/)**, which is built via PyPI trusted publishing from this repository.
+
 ## Supported Versions
 
-Only the latest release is supported with security updates. See [Releases](https://github.com/microbiomedata/nmdc-schema/releases) for the current version.
+Security fixes land in the latest release. Note that downstream consumers (for example `nmdc-runtime` and `nmdc-server`) pin a specific `nmdc-schema` version, so a fix in the latest release does not reach a production deployment until that consumer updates its pin. See [Releases](https://github.com/microbiomedata/nmdc-schema/releases) for the current version.
 
 ## Security Updates
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in this project, please report it respo
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please email your report to [MAM@lbl.gov](mailto:MAM@lbl.gov) so the maintainers can review it privately.
+Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please email your report to [support@microbiomedata.org](mailto:support@microbiomedata.org) so the maintainers can review it privately.
 
 ## Scope
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ authors = [
     { name = "Patrick Kalita", email = "pkalita@lbl.gov" },
     { name = "Sujay Patil", email = "spatil@lbl.gov" },
 ]
+maintainers = [
+    { name = "National Microbiome Data Collaborative", email = "support@microbiomedata.org" },
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
Adds a `SECURITY.md` documenting how to report vulnerabilities privately, which versions are supported, and how dependencies are kept current.

Part of https://github.com/microbiomedata/nmdc-schema/issues/2924. The two remaining items from that issue (enable secret scanning push protection, enable private vulnerability reporting) are repository settings changes, not file changes, and are handled separately.