### PR TITLE
Set persist-credentials: false on non-pushing workflow checkouts

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -29,6 +29,8 @@ jobs:
       - name: Check out commit
         # Reference: https://github.com/actions/checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install Poetry
         run: pipx install poetry
       - name: Set up Python

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,8 @@ jobs:
       #----------------------------------------------
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Poetry
         run: pipx install poetry


### PR DESCRIPTION
Addresses 2 of the `artipacked` findings from a zizmor audit of `.github/workflows/`. zizmor flags `actions/checkout` for persisting credentials in `.git/config`, which could leak if the workspace is uploaded as an artifact.

This PR sets `persist-credentials: false` only on the two workflows that do no git push and no post-checkout git operations:
- `main.yaml` (build and test)
- `check-links.yaml` (link checker)

Verified with zizmor: these two findings clear, and actionlint stays clean on both files.

Deliberately **not** touched here, because their checkouts need different handling and a casual change could break them:
- `deploy-docs.yaml` and `test-pages-build.yaml` push to gh-pages and need the persisted credentials.
- `pypi-publish.yaml` is the release pipeline (a high-severity cache-poisoning finding and an artipacked finding), which deserves careful, separately-reviewed handling.

Those are tracked in follow-up issues.