### PR TITLE
Add zizmor workflow security audit (non-blocking, reports to code scanning)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,6 +37,9 @@ jobs:
 
       - name: Upload zizmor findings to code scanning
         if: always()
+        # Also non-blocking: if zizmor crashed before writing a valid SARIF,
+        # the upload may fail, but that must not fail the build either.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
         with:
           sarif_file: zizmor.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,43 @@
+name: Workflow security audit (zizmor)
+
+# Audits the repository's GitHub Actions workflows with zizmor
+# (https://docs.zizmor.sh). Non-blocking: findings are reported to GitHub
+# code scanning (the Security tab), not by failing CI. zizmor is pinned to
+# a specific version so a tool upgrade cannot turn this red on unchanged
+# workflows; bump it deliberately.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload SARIF to code scanning
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        # Non-blocking: zizmor exits non-zero when it finds anything, but we
+        # report via code scanning rather than failing the build.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pipx run zizmor==1.25.2 --format sarif .github/workflows/ > zizmor.sarif
+
+      - name: Upload zizmor findings to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor


### PR DESCRIPTION
Adds a `zizmor` workflow that audits `.github/workflows/` and reports findings to GitHub code scanning (the Security tab), next to CodeQL.

Designed to be low-risk and non-disruptive:
- **Non-blocking.** The zizmor step uses `continue-on-error`, so findings never fail CI or block a PR. They surface in the Security tab instead.
- **Version-pinned.** zizmor is pinned to `1.25.2`, so a future tool release adding stricter audits cannot turn this red on unchanged workflows. Bump it deliberately.
- **Least privilege.** Top-level `permissions: {}`; the job gets only `security-events: write` (to upload SARIF) and `contents: read`.
- **Does not touch the release pipeline.** `pypi-publish.yaml` is untouched.

The currently-known findings are tracked in https://github.com/microbiomedata/nmdc-schema/issues/3147 (gh-pages workflows) and https://github.com/microbiomedata/nmdc-schema/issues/3148 (release pipeline). Once those are resolved or suppressed inline, this can be flipped to a blocking required check if desired.

Verified locally: actionlint is clean on the new workflow, and zizmor does not flag its own checkout (persist-credentials is false, no cache).