### PR TITLE
CLAUDE.md: cross-reference contributor docs; add dependency, migrator, and build gotchas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,16 @@
 # NMDC-Schema Development Guide
 
+## Authoritative conventions (see also)
+
+The repository's committed contributor docs are the canonical source for schema-modeling and process conventions. This file does not duplicate them; consult them and keep them authoritative:
+
+- `CONTRIBUTING.md`: Modeling Best Practice (naming, documentation, examples and counter-examples, enums for categorical values, PV `is_a`, reuse, placing classes under upper-level classes, ID patterning), the Current Policy vs Legacy Guidance table, and the ADR log pointer for recording decisions.
+- `DEVELOPMENT.md`: prerequisites and local development environment.
+- `MAINTAINERS.md` and `infra-admin/releases/nmdc-schema.md`: release procedure.
+- `nmdc_schema/migrators/README.md`: migrator authoring and testing.
+
+This guide adds the operational details and gotchas that are not (yet) captured in those files.
+
 ## Build/Lint/Test Commands
 - Install: `poetry install --with dev,deps`
 - Build: `make all` or `make site`
@@ -13,10 +24,29 @@
 - Check schema patterns: `poetry run python src/scripts/schema_pattern_linting.py --schema-file src/schema/nmdc.yaml`
 - View docs locally: `make serve` (in Docker: `poetry run mkdocs serve --dev-addr 0.0.0.0:8000`)
 
+Build prerequisites and gotchas:
+- `make all` needs `yq` (mikefarah/yq) on PATH (`brew install yq`); it is used to strip readonly metaslots and apply MIxS customizations. Java/ROBOT is NOT needed: the OWL artifact is produced by `linkml generate owl`.
+- `squeaky-clean` runs `clean examples-clean shuttle-clean site-clean`; it deliberately does NOT rebuild `src/schema/mixs.yaml` (that has its own slow, network-dependent `mixs-yaml-clean` target). For a full-from-scratch rebuild including a fresh MIxS pull: `make squeaky-clean mixs-yaml-clean && make src/schema/mixs.yaml && make squeaky-clean all test`.
+- CI tests only Python 3.10 and 3.13 (other workflows pin 3.12). `requires-python` is `>=3.10,<4.0`, so a too-new system Python (e.g. 3.14) is out of range and will break installs. Build and test against a supported interpreter.
+- `local/.env` is optional. Its credential blocks (BioPortal key, NCBI BioSample Postgres, source MongoDB) are only consumed by specific scripts; `make all` and `make test` run without any of them.
+
 ## Script Entry Point Policy
 - Keep `[project.scripts]` limited to package-backed, stable CLIs intended for default installs.
 - Do not add ad-hoc aliases for `src/scripts/*` into `[project.scripts]`.
 - For repo-local automation scripts, call them explicitly from Makefiles, e.g. `poetry run python src/scripts/<name>.py`.
+- Do not add new modules under `nmdc_schema/` (the published package) without a client-facing purpose; experimental and developer-only scripts go under `src/scripts/`.
+
+## Dependency Management
+
+This is a Poetry repo. Sibling `submission-schema` migrated to `uv`; do not confuse the two.
+
+- Never create a `uv.lock` here, and never run `uv add`, `uv sync`, or `uv lock`. If a stray `uv.lock` appears, delete it before committing.
+- Before tightening any pin in `pyproject.toml` (especially `linkml`), check that `submission-schema` still resolves. nmdc-schema is a library, so a tighter pin propagates to consumers even when nmdc-schema itself does not exercise the feature. `linkml` and `linkml-runtime` versions must be paired (a runtime release can drop something the matching `linkml` references).
+- `pyproject.toml` conventions: upper-bound policy (packages at 1.0 or above cap at the next major, pre-1.0 cap at the next minor); PEP 508 form (`"pkg>=min,<max"`, not the Poetry caret); alphabetical ordering within each dependency group; runtime deps in `[project.dependencies]`, dev tools in `[dependency-groups] dev`, `deptry` in its own `deps` group; transitive packages pinned for security are also added to `[tool.deptry] per_rule_ignores.DEP002`; comments cite the issue number that motivated a pin.
+
+## Released migrators
+
+Migrator partials under `nmdc_schema/migrators/partials/migrator_from_X_to_Y/` are versioned snapshots of migrations that have already run against the production database. Do not make functional changes to them; they are the authoritative record of what ran. Explanatory comments are fine. New breaking schema changes get a new migrator, not an edit to an old one (and a breaking change with no production data may legitimately ship no migrator, with the reason noted in the PR).
 
 ## Workflow security and linting (actionlint + zizmor)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ The repository's committed contributor docs are the canonical source for schema-
 
 - `CONTRIBUTING.md`: Modeling Best Practice (naming, documentation, examples and counter-examples, enums for categorical values, PV `is_a`, reuse, placing classes under upper-level classes, ID patterning), the Current Policy vs Legacy Guidance table, and the ADR log pointer for recording decisions.
 - `DEVELOPMENT.md`: prerequisites and local development environment.
-- `MAINTAINERS.md` and `infra-admin/releases/nmdc-schema.md`: release procedure.
+- `MAINTAINERS.md` and the [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md) (in the separate `microbiomedata/infra-admin` repo): release procedure.
 - `nmdc_schema/migrators/README.md`: migrator authoring and testing.
 
 This guide adds the operational details and gotchas that are not (yet) captured in those files.
@@ -26,7 +26,7 @@ This guide adds the operational details and gotchas that are not (yet) captured 
 
 Build prerequisites and gotchas:
 - `make all` needs `yq` (mikefarah/yq) on PATH (`brew install yq`); it is used to strip readonly metaslots and apply MIxS customizations. Java/ROBOT is NOT needed: the OWL artifact is produced by `linkml generate owl`.
-- `squeaky-clean` runs `clean examples-clean shuttle-clean site-clean`; it deliberately does NOT rebuild `src/schema/mixs.yaml` (that has its own slow, network-dependent `mixs-yaml-clean` target). For a full-from-scratch rebuild including a fresh MIxS pull: `make squeaky-clean mixs-yaml-clean && make src/schema/mixs.yaml && make squeaky-clean all test`.
+- `squeaky-clean` runs `clean examples-clean shuttle-clean site-clean`; it deliberately leaves `src/schema/mixs.yaml` in place. Removing that file is a separate fast target (`mixs-yaml-clean`, just an `rm`); regenerating it (`make src/schema/mixs.yaml`) is the slow, network-dependent step. For a full-from-scratch rebuild including a fresh MIxS pull: `make squeaky-clean mixs-yaml-clean && make src/schema/mixs.yaml && make squeaky-clean all test`.
 - CI tests only Python 3.10 and 3.13 (other workflows pin 3.12). `requires-python` is `>=3.10,<4.0`, so a too-new system Python (e.g. 3.14) is out of range and will break installs. Build and test against a supported interpreter.
 - `local/.env` is optional. Its credential blocks (BioPortal key, NCBI BioSample Postgres, source MongoDB) are only consumed by specific scripts; `make all` and `make test` run without any of them.
 


### PR DESCRIPTION
Consolidates durable, repo-specific guidance that was scattered across local notes, Claude memory, and team discussion (Slack #schema-technical, the repo's own contributor docs) but missing from `CLAUDE.md`. Deliberately avoids duplicating conventions already documented in `CONTRIBUTING.md`.

**Changes:**
- **Authoritative conventions (see also):** new top section pointing to `CONTRIBUTING.md` (Modeling Best Practice, Current Policy vs Legacy table, ADR log), `DEVELOPMENT.md`, `MAINTAINERS.md`, the infra-admin release runbook, and `nmdc_schema/migrators/README.md` as the canonical sources. This keeps `CLAUDE.md` focused on operational gotchas instead of drifting from those files.
- **Build prerequisites and gotchas:** `yq` required and Java/ROBOT not needed; `squeaky-clean` does not rebuild `mixs.yaml`; CI Python matrix is 3.10 and 3.13; `local/.env` is optional.
- **New Dependency Management section:** this is a Poetry repo (not `uv`, unlike `submission-schema`); never create `uv.lock`; check `submission-schema` before tightening pins; `pyproject.toml` conventions (upper-bound policy, PEP 508 form, ordering, security pins).
- **New Released migrators section:** no functional changes to released migrator partials; they are versioned snapshots of migrations that already ran in production.
- Package-module placement rule added to Script Entry Point Policy.

Sourced from a wide sweep of Desktop notes, `~/from-intel`, Claude memory, the repo's own `CONTRIBUTING.md`/`DEVELOPMENT.md`/`MAINTAINERS.md`, and Slack. Items already covered in `CONTRIBUTING.md` were intentionally not duplicated.