### PR TITLE
Pin upload-sarif to its commit SHA (fixes zizmor ref-version-mismatch)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -40,7 +40,7 @@ jobs:
         # Also non-blocking: if zizmor crashed before writing a valid SARIF,
         # the upload may fail, but that must not fail the build either.
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@b0c4fd77f6c559021d78430ec4d0d169ae74a4eb # v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: zizmor.sarif
           category: zizmor


### PR DESCRIPTION
Fixes the self-inflicted finding the new zizmor workflow reported on itself: `zizmor/ref-version-mismatch` at `zizmor.yml:43` (code scanning alert #16).

codeql-action `v3` is an annotated tag. The previous pin `b0c4fd77…` was the SHA of the **tag object**, not the commit it dereferences to, so it is not a real commit (the `commits/<sha>` API 404s on it). Repointed to the actual commit SHA `dd903d2e4f5405488e5ef1422510ee31c8b32357` (which is what `v3` dereferences to, and what zizmor reported), keeping the `# v3` comment accurate.

Verified locally: actionlint clean, and zizmor now reports no findings on `zizmor.yml`.