### PR TITLE
gitignore uv.lock (interim, while this is a Poetry repo)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,13 @@ dmypy.json
 # ruff
 .ruff_cache/
 
+# uv lock file: this is a Poetry project (poetry.lock is the tracked lock).
+# A uv.lock gets generated whenever someone runs uv in the repo, and it has
+# slipped into commits before. Ignore it to stop that. REMOVE this entry when
+# the project migrates to uv (see https://github.com/microbiomedata/nmdc-schema/issues/2761),
+# since uv.lock should be tracked once uv is the lock tool.
+uv.lock
+
 # AI coding tools
 .claude/
 .aider*


### PR DESCRIPTION
A `uv.lock` gets generated whenever `uv` is run in the repo (for example to quickly resolve dependency pins during security/dependency work, since uv is a faster resolver than Poetry). This is a Poetry project, so `poetry.lock` is the tracked lock file and `uv.lock` is just a stray artifact. It has slipped into commits twice already and had to be removed (`cd1b4af33 "Remove uv.lock — project uses poetry, not uv"`, `ab4bb072d "Remove uv.lock"`), and Patrick flagged it in Slack.

This ignores `uv.lock` so it stops recurring and can't be committed by accident.

**Important:** the `.gitignore` entry includes a comment that it must be **removed** when the project migrates to uv (https://github.com/microbiomedata/nmdc-schema/issues/2761), at which point `uv.lock` becomes the lock file that should be tracked.