### PR TITLE
Correct package license to CC0-1.0 to match the LICENSE file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nmdc_schema"
 dynamic = ["version"]
 description = "Schema resources for the National Microbiome Data Collaborative (NMDC)"
 readme = "README.md"
-license = "MIT"
+license = "CC0-1.0"
 requires-python = ">=3.10,<4.0"
 authors = [
     { name = "Bill Duncan", email = "wdduncan@gmail.com" },
@@ -53,6 +53,7 @@ dependencies = [
 Homepage = "https://microbiomedata.github.io/nmdc-schema/"
 Documentation = "https://microbiomedata.github.io/nmdc-schema/"
 Repository = "https://github.com/microbiomedata/nmdc-schema"
+Issues = "https://github.com/microbiomedata/nmdc-schema/issues"
 
 # scripts should have click clis
 # click parameters/options should be written out with hyphens


### PR DESCRIPTION
`pyproject.toml` declared `license = "MIT"`, but the repository's binding `LICENSE` file is **CC0 1.0 Universal** and every schema module declares CC0. This corrects the package metadata to match the actual license.

Evidence this is a correction, not a licensing decision (all from nmdc-schema's own history):
- The `LICENSE` file (CC0 1.0) was created 2021-04-09 (commit "Create LICENSE") — the first, deliberate license choice.
- `license = "MIT"` first appeared 2023-01-27 in the commit "top level config files from cc" (cookiecutter), about two years later, as a template default, while CC0 classifier lines were being commented out. It was never reconciled with the LICENSE file.
- No record anywhere (issues, PRs, commits, Slack) of a deliberate choice to license the package MIT.

`CC0-1.0` is the SPDX identifier matching the LICENSE file. Also adds an `Issues` URL to `[project.urls]`.

Note: `submission-schema` has the same MIT-in-metadata pattern and likely the same cookiecutter origin; worth checking separately.

Closes https://github.com/microbiomedata/nmdc-schema/issues/3145