### PR TITLE
Fix JGI isolate structured_aliases: real source URL, exhaustive subset, sever ref_biomaterial↔Reference Genome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,9 +98,17 @@ GitHub issue links, specification documents. Ontology CURIEs belong in a
 `*_mappings` slot. See #3031 for an open cleanup of MIXS CURIEs currently
 in `see_also` in `portal_mixs_inspired.yaml`.
 
-**`structured_aliases`** requires `literal_form`, `contexts` (a URL), and
-a SKOS predicate (`EXACT_SYNONYM`, `NARROW_SYNONYM`, `BROAD_SYNONYM`,
-`RELATED_SYNONYM`). Plain `aliases` is for unattributed synonym strings.
+**`structured_aliases`** requires `literal_form`, a SKOS predicate
+(`EXACT_SYNONYM`, `NARROW_SYNONYM`, `BROAD_SYNONYM`, `RELATED_SYNONYM`),
+and `source` (a real, publicly resolvable URL identifying where the alias
+comes from). Use `source`, not `contexts`: `source` means "where the alias
+comes from" (StructuredAlias metamodel), which is what we record; `contexts`
+means "the context in which the alias applies," which is different. When the
+authoritative source is access-restricted (e.g. the JGI Isolate form
+template), put the best public URL in `source` and a one-line caveat in
+`notes`. Per-alias rationale (e.g. why a predicate is NARROW rather than
+EXACT) also goes in `notes`, not in a YAML `#` comment. Plain `aliases` is
+for unattributed synonym strings.
 
 ## LinkML Readonly Metaslots — Do Not Assert
 The LinkML metamodel defines 12 slots that are **readonly** — populated

--- a/src/docs/jgi-isolate-field-routing.md
+++ b/src/docs/jgi-isolate-field-routing.md
@@ -3,6 +3,13 @@
 Complete routing of all 55 fields from the JGI Isolate (NA) v19 submission form
 to nmdc-schema classes, submission-schema, or deferred.
 
+The authoritative field-to-slot-and-interface mapping is the "Montana-SlotEval"
+tab of the JGI isolate metadata spreadsheet (Pupo). Per the isolate modeling
+squad, submission-schema targets three interfaces: `IsolateInterface`,
+`JgiIsolateGenomeInterface`, and `JgiIsolateTranscriptomeInterface` (the split is
+tracked in submission-schema #444). Where the nmdc-schema slot below differs from
+the Montana-SlotEval submission slot, the Montana slot is noted in parentheses.
+
 ## OrganismSample (osm)
 
 | # | JGI Field | nmdc-schema slot | Provenance |
@@ -18,7 +25,7 @@ to nmdc-schema classes, submission-schema, or deferred.
 | 38 | Second ribosomal sequence comments | ~~`second_ribosomal_sequence_comments`~~ → submission-schema `JgiIsolateInterface.isolate_second_ribosomal_seq_comments` | Moved: same reason. |
 | 29 | Fungal 16S screening?* | ~~`fungal_16s_screening`~~ → submission-schema `JgiIsolateInterface.isolate_fungal_16s_screening` | Moved: same reason. |
 | 30 | ITS match UNITE?* | ~~`its_match_unite`~~ → submission-schema `JgiIsolateInterface.isolate_its_match_unite` | Moved: same reason. |
-| 40 | Sample Isolation Method* | `sample_isolation_method` | JGI-native (new) |
+| 40 | Sample Isolation Method* | `sample_isolation_method` (Montana-SlotEval submission slot: `isolate_meth`) | JGI-native (new) |
 | 44 | Sample Isolated From* | `sample_isolated_from` | JGI-native (new) — origin matrix only ("the *what* the organism came out of") |
 | 45a | Collection Site or Growth Conditions* (collection-site half) | `sample_collection_site` | NMDC-native (pre-existing slot, reused for OrganismSample) — geographic / environmental site context |
 | 45b | Collection Site or Growth Conditions* (growth-conditions half) | `sample_growth_conditions` | JGI-native (new) — in-vitro lab maintenance context. MIxS `isol_growth_condt` (MIXS:0000003) was considered but its DOI/PMID/URL pattern doesn't fit free text |
@@ -62,7 +69,7 @@ loaded with NcbiTaxon from semantic-sql / OWL.
 | 6 | Genus* | `organism_genus` | JGI-native (new) |
 | 7 | Species* | `organism_species` | JGI-native (new) |
 | 8 | Strain or cultivar* | `strain_name` | JGI-native (new) |
-| 9 | Isolate | `isolate_name` | JGI-native (new) |
+| 9 | Isolate | `isolate_name` (Montana-SlotEval routes this field to `samp_name`) | JGI-native (new) |
 | 10 | Culture Collection and ID | `source_mat_id` | MIxS (existing, slot_usage override) |
 | 12 | Estimated Genome Size* | `estimated_size` | MIxS (newly imported) |
 | 13 | GC Content % | `gc_content` | JGI-native (new) |

--- a/src/docs/jgi-isolate-field-routing.md
+++ b/src/docs/jgi-isolate-field-routing.md
@@ -67,7 +67,7 @@ loaded with NcbiTaxon from semantic-sql / OWL.
 | 12 | Estimated Genome Size* | `estimated_size` | MIxS (newly imported) |
 | 13 | GC Content % | `gc_content` | JGI-native (new) |
 | 14 | Ploidy Comments | `ploidy` | MIxS (newly imported) |
-| 15 | Reference Genome* | `ref_biomaterial` | MIxS (newly imported) |
+| 15 | Reference Genome* | `reference_genome` (submission-schema-local slot) | submission-schema-native, NOT ref_biomaterial. Promotion to nmdc-schema tracked in submission-schema issue 447 |
 | 16 | Host Genus* (viral) | `host_genus` (on Biosample) | JGI-native (new) |
 | 17 | Host Species* (viral) | `host_species` (on Biosample) | JGI-native (new) |
 | 18 | Host Strain* (viral) | `host_strain` (on Biosample) | JGI-native (new) |
@@ -99,7 +99,6 @@ loaded with NcbiTaxon from semantic-sql / OWL.
 |---|---|---|---|
 | `estimated_size` | MIXS:0000024 | Organism | Estimated Genome Size |
 | `ploidy` | MIXS:0000021 | Organism | Ploidy Comments |
-| `ref_biomaterial` | MIXS:0000025 | Organism | Reference Genome |
 
 `isol_growth_condt` (MIXS:0000003) was imported but not assigned. Its MIxS semantics are
 "publication reference for isolation/growth conditions" (DOI/PMID/URL pattern), which does

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -258,27 +258,12 @@ classes:
               type: nmdc:TextValue
               has_raw_value: https://www.ncbi.nlm.nih.gov/datasets/genome/GCA_000016065.1/
             description: URL form (e.g. NCBI Genome record)
-        in_subset:
-          - jgi_isolate
-        structured_aliases:
-          - literal_form: Reference Genome
-            predicate: RELATED_SYNONYM
-            source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
-            notes:
-              - Exact JGI form template is access-restricted; source is the public submission overview.
-              - MIxS expects a publication citation; JGI's "Reference Genome" sometimes refers to the genome record itself (IMG / Phytozome IDs). Concepts overlap but differ.
         comments:
           - >-
             The MIxS pattern accepts DOI, PMID, or URL. DOI is preferred
-            when available — it gives a stable reference to the publication
+            when available; it gives a stable reference to the publication
             or genome report. See the `associated_dois` pattern elsewhere in
             the NMDC schema for DOI-structured alternatives.
-          - >-
-            JGI "Reference Genome" submissions sometimes carry non-publication
-            identifiers such as IMG or Phytozome IDs, which do not match the
-            MIxS pattern. Those are out of scope for this slot and should be
-            captured separately (see `gold_organism_identifiers` and
-            `insdc_nucleotide_identifiers` for genome / assembly references).
           - >-
             The MIxS name ref_biomaterial may be renamed in a future MIxS
             release. See ongoing MIxS renaming work.

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -230,6 +230,8 @@ classes:
           the broader pattern is to narrow `classified_as` to `NcbiTaxon` on
           all organism-oriented classes via slot_usage.
       estimated_size:
+        in_subset:
+          - jgi_isolate
         structured_aliases:
           - literal_form: Estimated Genome Size (Mb)
             predicate: BROAD_SYNONYM
@@ -256,6 +258,8 @@ classes:
               type: nmdc:TextValue
               has_raw_value: https://www.ncbi.nlm.nih.gov/datasets/genome/GCA_000016065.1/
             description: URL form (e.g. NCBI Genome record)
+        in_subset:
+          - jgi_isolate
         structured_aliases:
           - literal_form: Reference Genome
             predicate: RELATED_SYNONYM

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -232,9 +232,11 @@ classes:
       estimated_size:
         structured_aliases:
           - literal_form: Estimated Genome Size (Mb)
-            contexts:
-              - https://jgi.doe.gov/isolate-submission-form/v19
-            predicate: BROAD_SYNONYM    # Per @aclum: Mb is a coarser unit than bp — a single Mb value covers many possible bp values, so the alias is broader in granularity
+            predicate: BROAD_SYNONYM
+            source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+            notes:
+              - Exact JGI form template is access-restricted; source is the public submission overview.
+              - "Per @aclum: Mb is a coarser unit than bp, so a single Mb value covers many possible bp values; the alias is broader in granularity."
       ref_biomaterial:
         description: >-
           Reference for the organism, preferentially a DOI when a primary
@@ -256,9 +258,11 @@ classes:
             description: URL form (e.g. NCBI Genome record)
         structured_aliases:
           - literal_form: Reference Genome
-            contexts:
-              - https://jgi.doe.gov/isolate-submission-form/v19
-            predicate: RELATED_SYNONYM    # MIxS expects a publication citation; JGI's "Reference Genome" sometimes refers to the genome record itself (IMG / Phytozome IDs). Concepts overlap but differ.
+            predicate: RELATED_SYNONYM
+            source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+            notes:
+              - Exact JGI form template is access-restricted; source is the public submission overview.
+              - MIxS expects a publication citation; JGI's "Reference Genome" sometimes refers to the genome record itself (IMG / Phytozome IDs). Concepts overlap but differ.
         comments:
           - >-
             The MIxS pattern accepts DOI, PMID, or URL. DOI is preferred

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -35,18 +35,22 @@ default_range: string
 subsets:
   jgi_isolate:
     description: >-
-      Slots originating from the JGI Isolate (NA) v19 submission form that are not
-      already captured by MIxS or other existing standards. These slots support
-      organism identity, strain verification, purity assessment, and biosafety
-      classification for cultured isolate submissions to JGI.
+      Slots that map to a field on the JGI Isolate (NA) v19 submission form,
+      identified by a structured_alias whose literal_form is the exact form
+      field name. Membership is the alias: a slot is in this subset if and only
+      if it carries a JGI Isolate v19 structured_alias. Most members are new
+      NMDC slots for organism identity, strain verification, purity assessment,
+      and biosafety classification; a few are reused MIxS slots (for example
+      host_taxid, source_mat_id, estimated_size) whose JGI mapping is recorded
+      via the alias rather than by a new slot.
     see_also:
       - https://github.com/microbiomedata/nmdc-schema/issues/2803
     comments:
       - >-
-        Slots in this subset carry structured_aliases whose literal_form is the
-        exact field name on the JGI Isolate (NA) v19 spreadsheet. The form
-        template itself is access-restricted; the alias source points to the
-        public JGI submission overview.
+        The form template itself is access-restricted; each alias source points
+        to the public JGI submission overview. To keep this subset exhaustive,
+        add in_subset jgi_isolate wherever a JGI Isolate v19 structured_alias is
+        added, at the same scope the alias lives (global slot or class slot_usage).
 
 slots:
 
@@ -165,15 +169,10 @@ slots:
 
   sample_collection_site:
     description: >-
-      Free-text description of the place where the sample was collected — the
-      geographic / environmental site or named location.
-    comments:
-      - >-
-        On `OrganismSample`, this slot routes the collection-site half of JGI
-        Isolate (NA) v19 form field 45 ("Collection Site or Growth Conditions").
-        The growth-conditions half routes to `sample_growth_conditions`. The
-        submitter populates one or the other depending on whether the sample
-        came from a field collection or from in-vitro maintenance.
+      Free-text description of the place where the sample was collected: the
+      geographic or environmental site or named location.
+    in_subset:
+      - jgi_isolate
     structured_aliases:
       - literal_form: Collection Site or Growth Conditions
         predicate: NARROW_SYNONYM

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -43,9 +43,10 @@ subsets:
       - https://github.com/microbiomedata/nmdc-schema/issues/2803
     comments:
       - >-
-        Slots in this subset carry structured_aliases with context
-        https://jgi.doe.gov/isolate-submission-form/v19 mapping to the
-        exact field name on the JGI Isolate (NA) v19 spreadsheet.
+        Slots in this subset carry structured_aliases whose literal_form is the
+        exact field name on the JGI Isolate (NA) v19 spreadsheet. The form
+        template itself is access-restricted; the alias source points to the
+        public JGI submission overview.
 
 slots:
 
@@ -175,9 +176,11 @@ slots:
         came from a field collection or from in-vitro maintenance.
     structured_aliases:
       - literal_form: Collection Site or Growth Conditions
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
-        predicate: NARROW_SYNONYM    # JGI label bundles two concepts; this slot covers only the collection-site half
+        predicate: NARROW_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
+          - JGI label bundles two concepts; this slot covers only the collection-site half.
     range: string
 
   salinity_category:
@@ -536,9 +539,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Genus
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: Shewanella
         description: GOLD organism_v2 Go0000189 (Shewanella loihica PV-4, queried 2026-04-21)
@@ -557,9 +561,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Species
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: loihica
         description: GOLD organism_v2 Go0000189 (Shewanella loihica PV-4, queried 2026-04-21)
@@ -594,9 +599,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Strain or cultivar
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: PV-4
         description: GOLD organism_v2 Go0000189 (Shewanella loihica PV-4, queried 2026-04-21)
@@ -619,9 +625,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Isolate
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: Bd21-3
         description: GOLD dw_sample_taxonomy_info.isolate (n=260 records, queried 2026-04-30) — Brachypodium distachyon Bd21-3 reference accession
@@ -641,9 +648,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: GC Content %
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
 
   expected_organism:
     range: Organism
@@ -660,9 +668,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Sample Isolation Method
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: Wizard Genomic DNA Purification Kit
         description: Promega Wizard kit — a widely-used DNA isolation method in JGI bacterial isolate submissions
@@ -746,9 +755,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Host Genus
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: Zea
         description: GOLD organism_v2 host_name "Zea mays" (n=432 records, queried 2026-04-30)
@@ -765,9 +775,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Host Species
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: mays
         description: GOLD organism_v2 host_name "Zea mays" (n=432 records, queried 2026-04-30)
@@ -784,9 +795,10 @@ slots:
       - jgi_isolate
     structured_aliases:
       - literal_form: Host Strain
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
     examples:
       - value: K-12
         description: GOLD organism_v2 host_name "Escherichia coli K-12" (Go0084483 Escherichia phage JSE, queried 2026-04-30)

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1323,6 +1323,8 @@ classes:
           syntax: "{id_nmdc_prefix}:orgn-{id_shoulder}-{id_blade}$"
           interpolated: true
       source_mat_id:
+        in_subset:
+          - jgi_isolate
         description: >-
           Culture collection identifier for the source of this organism sample.
         comments:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1376,9 +1376,11 @@ classes:
               https://catalog.bcrc.firdi.org.tw/BcrcContent?bid=10694
         structured_aliases:
           - literal_form: Culture Collection and ID
-            contexts:
-              - https://jgi.doe.gov/isolate-submission-form/v19
-            predicate: NARROW_SYNONYM    # JGI label is narrower (culture-collection-only) than MIxS source_mat_id (any material-sample identifier)
+            predicate: NARROW_SYNONYM
+            source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+            notes:
+              - Exact JGI form template is access-restricted; source is the public submission overview.
+              - JGI label is narrower (culture-collection-only) than MIxS source_mat_id (any material-sample identifier).
     close_mappings:
       - OBI:0100051
     comments:

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -3513,9 +3513,10 @@ slots:
     range: ControlledIdentifiedTermValue
     structured_aliases:
       - literal_form: Host NCBI Taxonomy ID
-        contexts:
-          - https://jgi.doe.gov/isolate-submission-form/v19
         predicate: EXACT_SYNONYM
+        source: https://jgi.doe.gov/user-programs/pmo-overview/project-materials-submission-overview/
+        notes:
+          - Exact JGI form template is access-restricted; source is the public submission overview.
   host_tot_mass:
     annotations:
       Preferred_unit: kilogram, gram

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -3511,6 +3511,8 @@ slots:
     comments:
       - Homo sapiens [NCBITaxon:9606] would be a reasonable has_raw_value
     range: ControlledIdentifiedTermValue
+    in_subset:
+      - jgi_isolate
     structured_aliases:
       - literal_form: Host NCBI Taxonomy ID
         predicate: EXACT_SYNONYM


### PR DESCRIPTION
Closes #3156.

The JGI isolate structured_aliases shipped a fabricated form URL that 404s, so the schema asserted a source that does not exist. This replaces it with a real public source and standardizes on the `source` slot. Two adjacent inconsistencies are fixed in the same pass: the `jgi_isolate` subset now includes every slot that actually carries a JGI alias (it was missing `sample_collection_site` and the reused MIxS slots), and the incorrect `ref_biomaterial` to "Reference Genome" alias is removed because those concepts are unrelated.

Stacked on #3155; the base retargets to main when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)