### PR TITLE
Resolve open zizmor code-scanning alerts in workflows

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] this workflow pushes to gh-pages via
+        # `mkdocs gh-deploy --force`, which relies on the persisted checkout
+        # token. Proper hardening (push with an explicit scoped token, then set
+        # persist-credentials: false) is tracked in #3147.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -15,6 +15,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # Do not persist the checkout token in .git/config. Publishing uses OIDC
+        # trusted publishing and version derivation reads only local git tags, so
+        # no step here needs the token (zizmor artipacked, #3148).
+        persist-credentials: false
 
     - name: Install Poetry
       run: |
@@ -25,7 +30,10 @@ jobs:
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
-        cache: 'poetry'
+        # No dependency cache on the release trigger: a cache poisoned by a
+        # less-privileged PR run must not reach the publish job. Trade-off is a
+        # slower job (deps re-download); correctness is unaffected
+        # (zizmor cache-poisoning, #3148).
 
     - name: Install project dependencies
       run: poetry install --no-interaction

--- a/.github/workflows/test-pages-build.yaml
+++ b/.github/workflows/test-pages-build.yaml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # zizmor: ignore[artipacked] this workflow pushes a docs preview to the
+        # gh-pages branch via rossjrw/pr-preview-action, which relies on the
+        # persisted checkout token. Proper hardening (push with an explicit
+        # scoped token, then set persist-credentials: false) is tracked in #3147.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0


### PR DESCRIPTION
Resolves the four open zizmor code-scanning alerts on `main` (the known set deliberately left out of https://github.com/microbiomedata/nmdc-schema/pull/3146).

**`pypi-publish.yaml`** — closes https://github.com/microbiomedata/nmdc-schema/issues/3148 (Review pypi-publish.yaml zizmor findings):
- Removed the poetry dependency cache on the `release` trigger. A cache poisoned by a less-privileged PR run must not reach the publish job. Cost is a slower release (deps re-download); correctness is unchanged.
- Stopped persisting the checkout token. Publishing uses OIDC trusted publishing and version derivation reads only local git tags, so no step needs it.

**`deploy-docs.yaml` and `test-pages-build.yaml`** — addresses https://github.com/microbiomedata/nmdc-schema/issues/3147 (Harden gh-pages-pushing workflows), which stays open:
- Both push to gh-pages and rely on the persisted checkout token, so `persist-credentials: false` cannot simply be set. The `artipacked` finding is suppressed inline with a reason to clear the code-scanning noise. Proper token-scoped hardening stays open in https://github.com/microbiomedata/nmdc-schema/issues/3147.

Two things to know before merge:
- The two inline suppressions silence a real finding rather than fixing it. The token stays in `.git/config`. Practical exposure is low because neither workflow uploads the checkout workspace as an artifact, but it is a workaround, not a fix.
- `persist-credentials: false` on the release path is supported by analysis, not by a live run. Confirm it with a pre-release tag (`vX.Y.Z-rc.N`) before relying on it for a real release.

Verified locally: zizmor 1.25.2 reports no findings (the two suppressions register as ignored), and actionlint is clean.
