### PR TITLE
Clear zizmor pedantic-persona findings in workflows

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -16,14 +16,20 @@ on:
   # Reference: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
   workflow_dispatch: {}
 
-permissions:
-  contents: read
-  issues: write
+permissions: {}  # default deny; the job below grants only what it needs
+
+# Only one link-check at a time; a newer run supersedes an older one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 run-name: Check links in docs
 jobs:
   build-docs-and-check-links:
     name: Build docs and check links
+    permissions:
+      contents: read  # check out the repository to scan docs for links
+      issues: write   # file an issue listing broken links (peter-evans/create-issue-from-file)
     runs-on: ubuntu-latest
     steps:
       - name: Check out commit

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -18,7 +18,7 @@ on:
 
 permissions: {}  # default deny; the job below grants only what it needs
 
-# Only one link-check at a time; a newer run supersedes an older one.
+# Supersede an in-progress link-check for the same ref; a newer run wins.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -4,8 +4,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}  # default deny; the job below grants only what it needs
 
 # Cancel outdated runs when new commits are pushed to main
 concurrency:
@@ -14,6 +13,9 @@ concurrency:
 
 jobs:
   build-docs:
+    name: Build and deploy documentation
+    permissions:
+      contents: write  # push the built docs to the gh-pages branch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-
+    name: Build and test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -4,14 +4,21 @@ on:
   release:
     types: [created]
 
+permissions: {}  # default deny; the publish job below grants only id-token: write
+
+# Serialize publishes but never cancel one in progress: interrupting a release
+# mid-publish could leave a partial upload. cancel-in-progress is false.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      # this permission is mandatory for trusted publishing
-      id-token: write
+      id-token: write  # mandatory for OIDC trusted publishing (no other scope needed)
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -6,8 +6,9 @@ on:
 
 permissions: {}  # default deny; the publish job below grants only id-token: write
 
-# Serialize publishes but never cancel one in progress: interrupting a release
-# mid-publish could leave a partial upload. cancel-in-progress is false.
+# Never cancel an in-progress publish: interrupting a release mid-upload could
+# leave a partial upload. Grouped per ref so re-triggering the same release does
+# not publish it twice concurrently; unrelated releases still publish in parallel.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/test-pages-build.yaml
+++ b/.github/workflows/test-pages-build.yaml
@@ -7,14 +7,19 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}  # default deny; the job below grants only what it needs
 
-concurrency: preview-${{ github.ref }}
+# One preview build per PR; a newer push supersedes an in-progress build.
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   run:
+    name: Build and deploy docs preview
+    permissions:
+      contents: write       # push the docs preview to the gh-pages branch
+      pull-requests: write  # comment the preview link on the PR (rossjrw/pr-preview-action)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -14,6 +14,11 @@ on:
 
 permissions: {}
 
+# One audit per ref; a newer push supersedes an in-progress run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     name: zizmor

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,22 +52,26 @@ Migrator partials under `nmdc_schema/migrators/partials/migrator_from_X_to_Y/` a
 
 The GitHub Actions workflows in `.github/workflows/` are security-sensitive: they carry permissions, secrets, and the PyPI release path. Two static tools audit them:
 
-- `actionlint`: workflow syntax, deprecated action references, and shell bugs in `run:` steps.
-- `zizmor`: workflow security audit (credential persistence, cache poisoning, template injection, and more).
+- `actionlint`: workflow syntax, deprecated action references, and shell bugs in `run:` steps. It only lints shell in `run:` blocks when `shellcheck` is on PATH, and inline Python when `pyflakes` is on PATH; without those it silently skips its strictest checks. For a full-strength run install both (`brew install actionlint shellcheck`, `pipx install pyflakes`).
+- `zizmor`: workflow security audit (credential persistence, cache poisoning, template injection, and more). Its default (`regular`) persona is what CI reports to code scanning; `--persona pedantic` surfaces extra lower-signal audits (excessive-permissions, undocumented-permissions, concurrency-limits, anonymous-definition) that the default hides.
 
 When developing in this repo, if these tools are available in the active environment, run them against the workflows as a routine self-check. Do this whenever a workflow is edited, and opportunistically on any substantive session even when no workflow changed:
 
 ```bash
-actionlint
-uvx zizmor .github/workflows/        # or: pipx run zizmor .github/workflows/
+actionlint                                       # with shellcheck + pyflakes on PATH
+uvx zizmor .github/workflows/                    # default persona (what CI reports)
+uvx zizmor --persona pedantic .github/workflows/ # stricter, optional
 ```
 
 Do not install the tools just to run this, and do not treat their absence as a failure; skip the check when they are not present. `actionlint` is a Go binary (`brew install actionlint`). `zizmor` runs with no install via `uvx zizmor` or `pipx run zizmor`.
 
-Act on new findings, but do not re-report the known ones that are already triaged:
+As of June 2026 the workflows pass both `actionlint` (with shellcheck + pyflakes) and `zizmor` at default and `--persona pedantic`, with two deliberate exceptions. Act on new findings, but do not re-report these known, triaged ones:
 
-- The credential-persistence (`artipacked`) findings on `deploy-docs.yaml` and `test-pages-build.yaml` are intentional, because those workflows push to gh-pages. Tracked in #3147.
-- The `pypi-publish.yaml` findings (cache poisoning and credential persistence) are deliberately left for separate, release-pipeline-aware review. Tracked in #3148. Do not edit `pypi-publish.yaml` casually.
+- The credential-persistence (`artipacked`) findings on `deploy-docs.yaml` and `test-pages-build.yaml` are intentional, because those workflows push to gh-pages with the persisted token. They are suppressed inline with `# zizmor: ignore[artipacked]` and a reason. Proper token-scoped hardening stays open in #3147.
+- The `pypi-publish.yaml` cache-poisoning and credential-persistence findings were fixed in #3160 (removed the release-trigger dependency cache; set `persist-credentials: false`). The `persist-credentials: false` change is validated by analysis, not a live run; confirm it with a pre-release before relying on it. Closed #3148.
+- The pedantic-persona findings (excessive-permissions, concurrency-limits, undocumented-permissions, anonymous-definition) were fixed in #3162 by scoping permissions to the job with a top-level `permissions: {}` deny-all, adding concurrency groups (the publish job uses `cancel-in-progress: false`), documenting each elevated scope, and naming jobs. Closed #3161.
+
+When editing permissions, keep the established pattern: top-level `permissions: {}`, and grant the minimum at the job level with an inline comment saying why. Do not edit `pypi-publish.yaml` casually; it is the release path and only fully exercises at publish time.
 
 CI also runs zizmor in a non-blocking job that reports to code scanning (the Security tab), added in #3149. The local check is for faster, in-development feedback.
 


### PR DESCRIPTION
Clears the zizmor findings that the default (`regular`) persona does not report, so they were never in code scanning. Tracked in https://github.com/microbiomedata/nmdc-schema/issues/3161. Fixed for real rather than suppressed.

What changed:
- **excessive-permissions** (the 4 high + 1 medium): each permission is now scoped to the job that needs it, with a top-level `permissions: {}` deny-all. This is the pattern `zizmor.yml` already uses. Effective grants are unchanged; the scope is narrower.
- **concurrency-limits**: added a `concurrency` group to `check-links`, `pypi-publish`, and `zizmor.yml`. The release workflow uses `cancel-in-progress: false` so a publish is never interrupted partway.
- **undocumented-permissions**: a one-line comment on each elevated scope explaining why it is needed.
- **anonymous-definition**: named the previously unnamed jobs.

One behavior change to call out: `test-pages-build` now cancels an in-progress preview build when a newer commit is pushed to the same PR (previously builds serialized without cancel). This is the usual preview behavior and saves CI minutes.

Verified locally: zizmor 1.25.2 reports no findings at both default and `--persona pedantic` (the 2 remaining ignores are the gh-pages `artipacked` items tracked in https://github.com/microbiomedata/nmdc-schema/issues/3147). actionlint is clean with both shellcheck and pyflakes active.
