### PR TITLE
Fix two high-importance security findings in src/scripts

### DIFF
--- a/nmdc_schema/migration_recursion.py
+++ b/nmdc_schema/migration_recursion.py
@@ -118,7 +118,9 @@ def main(schema_path, input_path, output_path, migrator_name):
     # all migrations complete. save data.
     logger.info(f"Saving migrated data to {output_path}")
     with open(output_path, "w") as f:
-        yaml.dump(total_dict, f)
+        # safe_dump: total_dict is loaded YAML (primitives); this keeps output
+        # free of Python-specific tags and fails loud on any non-primitive.
+        yaml.safe_dump(total_dict, f)
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -6377,4 +6377,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "68cfea59414808170462da0cfeb29a64f067a727cb4576d1a97e87c656492d0e"
+content-hash = "5db3a83381bc9ae62f9e34d81dd5327ea6becd0eb96f78ae2cb2eaa0c1292151"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dev = [
     "bandit>=1.7.8,<2.0.0",
     "black>=26.3.1,<27.0.0",
     "curies>=0.9.0,<1.0.0",
+    "defusedxml>=0.7.1,<1.0.0",  # hardened XML parsing in src/scripts/ncbi_nmdc_exact_term_matching.py
     "exhaustion-check>=0.1.1,<0.2.0",  # for exhaustion-check, pretty-sort-yaml (also get-first-of-first)
     "fastjsonschema>=2.20.0,<3.0.0",
     "flake8>=7.0.0,<8.0.0",

--- a/src/scripts/extract_numeric_values.py
+++ b/src/scripts/extract_numeric_values.py
@@ -123,7 +123,7 @@ def main():
     # Write back the updated YAML
     if updates_made > 0:
         with open(yaml_file, 'w') as f:
-            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
         print(f"\nUpdated {updates_made} fields with has_numeric_value")
     else:
         print("No updates needed")

--- a/src/scripts/ncbi_nmdc_exact_term_matching.py
+++ b/src/scripts/ncbi_nmdc_exact_term_matching.py
@@ -2,7 +2,9 @@ import csv
 from bs4 import BeautifulSoup
 from linkml_runtime.utils.schemaview import SchemaView
 
-import xml.etree.ElementTree as ET
+# defusedxml hardens parsing of the network-fetched NCBI BioSample XML against
+# XML entity-expansion attacks (XXE / billion laughs). Drop-in for ET.parse.
+import defusedxml.ElementTree as ET
 import click
 import requests
 import pandas as pd

--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -368,7 +368,9 @@ def extract_study(ctx, study_id: str, output_file: Union[str, bytes, os.PathLike
     # no custom tags) and avoids the arbitrary-object risk zizmor/bandit flag.
     yaml_data = yaml.safe_load(yaml_dumper.dumps(db))
     with open(output_file_path, "w") as f:
-        f.write(yaml.dump(yaml_data, indent=4))
+        # safe_dump to keep the load+dump pipeline consistently safe (no
+        # Python-specific tags if a non-primitive ever reaches yaml_data).
+        f.write(yaml.safe_dump(yaml_data, indent=4))
 
 
 if __name__ == "__main__":

--- a/src/scripts/nmdc_database_tools.py
+++ b/src/scripts/nmdc_database_tools.py
@@ -364,7 +364,9 @@ def extract_study(ctx, study_id: str, output_file: Union[str, bytes, os.PathLike
         logger.info("No missing data objects found.")
     # Write the results to a YAML file
     logger.info(f"Writing results to {output_file_path}.")
-    yaml_data = yaml.load(yaml_dumper.dumps(db), Loader=yaml.FullLoader)
+    # safe_load is sufficient here (the input is our own dumped schema data,
+    # no custom tags) and avoids the arbitrary-object risk zizmor/bandit flag.
+    yaml_data = yaml.safe_load(yaml_dumper.dumps(db))
     with open(output_file_path, "w") as f:
         f.write(yaml.dump(yaml_data, indent=4))
 


### PR DESCRIPTION
Fixes the two high-importance security findings from a bandit / ruff `S` scan of the hand-written Python (both in `src/scripts`, which is developer tooling, not shipped in the package and not console entry points).

- **`nmdc_database_tools.py`**: `yaml.safe_load` instead of `yaml.load`. The input is our own dumped schema data, so `safe_load` is sufficient and removes the arbitrary-object-instantiation risk (B506 / S506).
- **`ncbi_nmdc_exact_term_matching.py`**: parse the network-fetched NCBI BioSample XML with `defusedxml` to harden against XML entity-expansion attacks (B314 / S314). Adds `defusedxml` as a dev-group dependency.

No consumer impact: neither script is in the published package or `[project.scripts]`, and `defusedxml` is dev-only, so what users `pip install` and import is unchanged.

The remaining lower-importance findings (requests without timeout, hardcoded /tmp, notebook eval) and the mypy typing backlog are tracked separately.
