### PR TITLE
Consolidate Python linters into ruff; add lint + dependabot automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+
+# Version updates. Dependabot security updates and alerts are configured
+# separately in repo settings; this file adds proactive version bumps.
+# Updates are grouped to keep PR volume low.
+updates:
+  # Keep the SHA-pinned GitHub Actions current (security patches reach pinned
+  # actions only through deliberate bumps).
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Python dependencies (Dependabot reads pyproject.toml for the pip ecosystem).
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        patterns: ["*"]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -54,4 +54,6 @@ jobs:
       # "S" to select in [tool.ruff.lint] and remove this step.
       - name: Ruff security scan (non-blocking)
         continue-on-error: true
-        run: poetry run ruff check --select S --ignore S101 .
+        # S101 (assert) is ignored only for tests/** via [tool.ruff.lint]
+        # per-file-ignores, so asserts elsewhere still surface here.
+        run: poetry run ruff check --select S .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,57 @@
+name: Python lint (ruff)
+
+# Lints hand-written Python with ruff, the single linter + formatter that
+# replaced black, flake8, isort, bandit, and pydocstyle (see [tool.ruff] in
+# pyproject.toml). ruff runs from the Poetry environment so the version is
+# pinned by poetry.lock.
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions: {}  # default deny; the job below grants only what it needs
+
+# One lint run per ref; a newer push supersedes an in-progress run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    name: ruff
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # check out the repository to lint it
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Ruff lint
+        run: poetry run ruff check .
+
+      # Formatting is not yet gated: the existing code is not uniformly
+      # ruff-format-clean. A one-time `make format` sweep (~75 files) and the
+      # blocking format check are tracked in #3166, kept separate to avoid
+      # mixing large churn into this PR.
+
+      # Non-blocking until the known src/scripts findings (#3164) are cleared,
+      # mirroring how the zizmor job is non-blocking. Once #3164 is done, add
+      # "S" to select in [tool.ruff.lint] and remove this step.
+      - name: Ruff security scan (non-blocking)
+        continue-on-error: true
+        run: poetry run ruff check --select S --ignore S101 .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,21 @@ When editing permissions, keep the established pattern: top-level `permissions: 
 
 CI also runs zizmor in a non-blocking job that reports to code scanning (the Security tab), added in #3149. The local check is for faster, in-development feedback.
 
+## Python linting and tooling
+
+`ruff` is the single linter and formatter. It replaced black/autopep8 (formatting), flake8 (E/F/W), isort (I), bandit (the `S` security rules), and pydocstyle (D); those packages were removed from the dev group. `mypy` (types), `pylint`, `vulture`, and `pyroma` are kept because ruff does not fully cover them. `deptry` checks for unused/missing dependencies.
+
+- Config lives in `[tool.ruff]` in `pyproject.toml`. Generated artifacts (`nmdc.py`, `nmdc_pydantic.py`, `nmdc_materialized_patterns.yaml`), `notebooks/`, and the frozen `migrators/partials/` are excluded.
+- `make lint` runs `ruff check .` (the blocking CI gate, currently the `F`/pyflakes rules). `make format` runs `ruff format` + `ruff check --fix`.
+- CI: `.github/workflows/lint.yaml` runs `ruff check` (blocking) plus a non-blocking `ruff check --select S` security scan. Formatting is not yet gated (the code is not uniformly format-clean); the one-time sweep is tracked in #3166. The security backlog (timeouts, hardcoded /tmp in `src/scripts`) is #3164; once cleared, add `"S"` to `select` and drop the separate step. mypy typing cleanup is #3165.
+- ruff `S` reproduces bandit's findings, so bandit is redundant here. The in-repo `ruff` + `zizmor` (workflows) pair covers what CodeQL was doing for this repo (CodeQL had 0 open Python alerts), if a move away from CodeQL is wanted.
+
+**YAML safety:** always use `yaml.safe_load` and `yaml.safe_dump` in authored code, never `yaml.load`/`yaml.dump` (even with `FullLoader`). The repo is uniformly on the safe variants as of #3163; keep it that way. linkml's own `yaml_dumper` is separate and fine.
+
+Dependabot security updates and alerts are on; `.github/dependabot.yml` adds grouped weekly version updates for the `github-actions` and `pip` ecosystems. Secret scanning is on.
+
 ## Code Style Guidelines
-- Follow PEP8 conventions and Black formatting
+- Follow PEP8 conventions; format with `ruff format` (black-compatible)
 - Use snake_case for variables/functions, PascalCase for classes
 - Type annotations required for all parameters and returns
 - Imports: stdlib first, third-party next, local modules last

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,19 @@ linkml-validate-schema:
 check-dependencies:
 	$(RUN) deptry nmdc_schema --known-first-party nmdc_schema
 
+# Lint hand-written Python with ruff (config in pyproject.toml).
+# `lint` is the check-only gate CI runs; `format` rewrites in place.
+# Formatting is not yet gated in CI (the code is not uniformly format-clean);
+# run `make format` for a deliberate sweep.
+.PHONY: lint
+lint:
+	$(RUN) ruff check .
+
+.PHONY: format
+format:
+	$(RUN) ruff format .
+	$(RUN) ruff check --fix .
+
 # Test documentation locally
 serve: mkd-serve
 

--- a/nmdc_schema/dump_single_modality.py
+++ b/nmdc_schema/dump_single_modality.py
@@ -226,7 +226,7 @@ def dump_from_api(ctx, client_base_url, endpoint_prefix, page_size):
             ns = stats.get("ns")
             storage_stats = stats.get("storageStats")
             logger.info(f"Namespace: {ns}")
-            logger.info(f"Storage Stats:")
+            logger.info("Storage Stats:")
             logger.info(pprint.pformat(storage_stats))
             logger.info("------------------------------------")
             as_collection_name = ns.split(".")[-1]

--- a/nmdc_schema/nmdc_data.py
+++ b/nmdc_schema/nmdc_data.py
@@ -5,15 +5,12 @@
 import io
 import json
 import pkgutil
-from os.path import getatime
 from typing import Dict, List, Optional
 from enum import Enum
 
 import click
-import yaml
 from linkml.utils.rawloader import load_raw_schema
 from linkml_runtime.linkml_model.meta import SchemaDefinition
-from linkml_runtime.utils.schemaview import SchemaView
 
 
 class SchemaVariantIdentifier(str, Enum):

--- a/poetry.lock
+++ b/poetry.lock
@@ -119,22 +119,6 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
-name = "autopep8"
-version = "2.3.2"
-description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128"},
-    {file = "autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758"},
-]
-
-[package.dependencies]
-pycodestyle = ">=2.12.0"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "babel"
 version = "2.17.0"
 description = "Internationalization utilities"
@@ -168,31 +152,6 @@ files = [
 
 [package.extras]
 extras = ["regex"]
-
-[[package]]
-name = "bandit"
-version = "1.9.4"
-description = "Security oriented static analyser for python code."
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e"},
-    {file = "bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
-PyYAML = ">=5.3.1"
-rich = "*"
-stevedore = ">=1.20.0"
-
-[package.extras]
-baseline = ["GitPython (>=3.1.30)"]
-sarif = ["jschema-to-python (>=1.2.3)", "sarif-om (>=1.0.4)"]
-test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)"]
-toml = ["tomli (>=1.1.0) ; python_version < \"3.11\""]
-yaml = ["PyYAML"]
 
 [[package]]
 name = "bcp47"
@@ -261,59 +220,6 @@ health = ["click-default-group", "jinja2", "pandas (<3.0)", "pyyaml", "tabulate"
 mapping-checking = ["pandas (<3.0)", "sentence-transformers"]
 paper-ranking = ["pandas (<3.0)", "pubmed-downloader (>=0.0.12)", "scikit-learn", "tabulate"]
 web = ["a2wsgi", "api-analytics[fastapi]", "bootstrap-flask", "curies[fastapi]", "fastapi", "flask (>=3.0.0)", "markdown", "pyyaml", "rdflib", "rdflib-endpoint (>=0.5.3)", "rdflib-jsonld", "uvicorn", "werkzeug (>=3.0.0)"]
-
-[[package]]
-name = "black"
-version = "26.3.1"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2"},
-    {file = "black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b"},
-    {file = "black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac"},
-    {file = "black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a"},
-    {file = "black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a"},
-    {file = "black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff"},
-    {file = "black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c"},
-    {file = "black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5"},
-    {file = "black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e"},
-    {file = "black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5"},
-    {file = "black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1"},
-    {file = "black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f"},
-    {file = "black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7"},
-    {file = "black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983"},
-    {file = "black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb"},
-    {file = "black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54"},
-    {file = "black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f"},
-    {file = "black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56"},
-    {file = "black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839"},
-    {file = "black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2"},
-    {file = "black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78"},
-    {file = "black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568"},
-    {file = "black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f"},
-    {file = "black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c"},
-    {file = "black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1"},
-    {file = "black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b"},
-    {file = "black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=1.0.0"
-platformdirs = ">=2"
-pytokens = ">=0.4.0,<0.5.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; sys_platform == \"win32\""]
 
 [[package]]
 name = "boltons"
@@ -1217,23 +1123,6 @@ files = [
     {file = "fastobo-0.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:f51e8cd85dd50b92d760477854b12152b43cef97077f500f78202d1863f74488"},
     {file = "fastobo-0.14.1.tar.gz", hash = "sha256:a230d780581332d041db29299f6c1b960b0228285d8de9981364540c14d069bc"},
 ]
-
-[[package]]
-name = "flake8"
-version = "7.3.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e"},
-    {file = "flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.14.0,<2.15.0"
-pyflakes = ">=3.4.0,<3.5.0"
 
 [[package]]
 name = "flexcache"
@@ -4026,18 +3915,6 @@ files = [
 pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d"},
-    {file = "pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783"},
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 description = "C parser in Python"
@@ -4184,36 +4061,6 @@ files = [
 
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
-
-[[package]]
-name = "pydocstyle"
-version = "6.3.0"
-description = "Python docstring style checker"
-optional = false
-python-versions = ">=3.6"
-groups = ["dev"]
-files = [
-    {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
-    {file = "pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1"},
-]
-
-[package.dependencies]
-snowballstemmer = ">=2.2.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.3) ; python_version < \"3.11\""]
-
-[[package]]
-name = "pyflakes"
-version = "3.4.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f"},
-    {file = "pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58"},
-]
 
 [[package]]
 name = "pygments"
@@ -4601,61 +4448,6 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5"},
-    {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe"},
-    {file = "pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c"},
-    {file = "pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7"},
-    {file = "pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2"},
-    {file = "pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440"},
-    {file = "pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc"},
-    {file = "pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d"},
-    {file = "pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16"},
-    {file = "pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6"},
-    {file = "pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083"},
-    {file = "pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1"},
-    {file = "pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1"},
-    {file = "pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9"},
-    {file = "pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68"},
-    {file = "pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b"},
-    {file = "pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f"},
-    {file = "pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1"},
-    {file = "pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4"},
-    {file = "pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78"},
-    {file = "pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321"},
-    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa"},
-    {file = "pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d"},
-    {file = "pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324"},
-    {file = "pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9"},
-    {file = "pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb"},
-    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3"},
-    {file = "pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975"},
-    {file = "pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a"},
-    {file = "pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918"},
-    {file = "pytokens-0.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:da5baeaf7116dced9c6bb76dc31ba04a2dc3695f3d9f74741d7910122b456edc"},
-    {file = "pytokens-0.4.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:11edda0942da80ff58c4408407616a310adecae1ddd22eef8c692fe266fa5009"},
-    {file = "pytokens-0.4.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0fc71786e629cef478cbf29d7ea1923299181d0699dbe7c3c0f4a583811d9fc1"},
-    {file = "pytokens-0.4.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dcafc12c30dbaf1e2af0490978352e0c4041a7cde31f4f81435c2a5e8b9cabb6"},
-    {file = "pytokens-0.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:42f144f3aafa5d92bad964d471a581651e28b24434d184871bd02e3a0d956037"},
-    {file = "pytokens-0.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:34bcc734bd2f2d5fe3b34e7b3c0116bfb2397f2d9666139988e7a3eb5f7400e3"},
-    {file = "pytokens-0.4.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:941d4343bf27b605e9213b26bfa1c4bf197c9c599a9627eb7305b0defcfe40c1"},
-    {file = "pytokens-0.4.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3ad72b851e781478366288743198101e5eb34a414f1d5627cdd585ca3b25f1db"},
-    {file = "pytokens-0.4.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:682fa37ff4d8e95f7df6fe6fe6a431e8ed8e788023c6bcc0f0880a12eab80ad1"},
-    {file = "pytokens-0.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:30f51edd9bb7f85c748979384165601d028b84f7bd13fe14d3e065304093916a"},
-    {file = "pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de"},
-    {file = "pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a"},
-]
-
-[package.extras]
-dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "twine", "wheel"]
 
 [[package]]
 name = "pytz"
@@ -5841,18 +5633,6 @@ files = [
 linkml-runtime = "*"
 
 [[package]]
-name = "stevedore"
-version = "5.7.0"
-description = "Manage dynamic plugins for Python applications"
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed"},
-    {file = "stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3"},
-]
-
-[[package]]
 name = "tabulate"
 version = "0.9.0"
 description = "Pretty-print tabular data"
@@ -6377,4 +6157,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "5db3a83381bc9ae62f9e34d81dd5327ea6becd0eb96f78ae2cb2eaa0c1292151"
+content-hash = "bb563736d8fe9c12e9336d636872db6bb03297384f97f9a7c252e9585ff9ca98"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,15 +78,14 @@ pure-export = "nmdc_schema.dump_single_modality:cli"
 
 [dependency-groups]
 dev = [
-    "autopep8>=2.2.0,<3.0.0",
-    "bandit>=1.7.8,<2.0.0",
-    "black>=26.3.1,<27.0.0",
+    # ruff replaces autopep8/black (formatting), flake8 (pyflakes+pycodestyle),
+    # isort (import order), bandit (the S security rules), and pydocstyle (D).
+    # See [tool.ruff] below. mypy (types), pylint, vulture, and pyroma are kept
+    # because ruff does not (yet) fully cover them.
     "curies>=0.9.0,<1.0.0",
     "defusedxml>=0.7.1,<1.0.0",  # hardened XML parsing in src/scripts/ncbi_nmdc_exact_term_matching.py
     "exhaustion-check>=0.1.1,<0.2.0",  # for exhaustion-check, pretty-sort-yaml (also get-first-of-first)
     "fastjsonschema>=2.20.0,<3.0.0",
-    "flake8>=7.0.0,<8.0.0",
-    "isort>=5.13.2,<9.0.0",
     # linkml-store[llm] was a dependency but its llm → sqlite-utils chain
     # requires click>=8.3.1, which conflicts with linkml's click<8.2 cap.
     # Ontology alignment scripts (#2909, #2910) that need embeddings should
@@ -101,7 +100,6 @@ dev = [
     "oaklib>=0.6.23,<1.0.0",
     "pandas>=2.2.3,<4.0.0",
     "psycopg2-binary>=2.9.10,<3.0.0",
-    "pydocstyle>=6.3.0,<7.0.0",
     "pylint>=3.2.2,<5.0.0",
     "pyroma>=4.2,<6.0",
     "pytest>=8.4.2,<10.0.0",
@@ -154,6 +152,31 @@ build-backend = "poetry_dynamic_versioning.backend"
 # (excludes MongoDB integration tests and other tests outside tests/)
 # Module independence is checked by check_schema_self_containment.py instead
 testpaths = ["tests"]
+
+# ruff is the single linter + formatter, replacing black/autopep8 (format),
+# flake8 (E/F/W), isort (I), bandit (S security), and pydocstyle (D).
+[tool.ruff]
+# Generated artifacts, scratch notebooks, and the frozen released migrator
+# partials are not hand-maintained, so they are not linted.
+extend-exclude = [
+    "nmdc_schema/nmdc.py",
+    "nmdc_schema/nmdc_pydantic.py",
+    "nmdc_schema/nmdc_materialized_patterns.yaml",
+    "notebooks",
+    "nmdc_schema/migrators/partials",
+]
+
+[tool.ruff.lint]
+# Start with the high-signal, low-churn rules as a blocking gate (pyflakes).
+# Security rules (S) are run as a separate, non-blocking CI step until the
+# known src/scripts findings (#3164) are cleared, then folded in here.
+# Import order (I), bugbear (B), and pyupgrade (UP) are deferred to a separate
+# modernization pass because they would rewrite a large amount of code at once.
+select = ["F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Asserts are idiomatic in tests; bandit's B101 / ruff's S101 are noise there.
+"tests/**" = ["S101"]
 
 [tool.deptry]
 extend_exclude = [

--- a/src/scripts/schema_pattern_linting.py
+++ b/src/scripts/schema_pattern_linting.py
@@ -21,7 +21,7 @@ def main(schema_file):
         if len(classes_for_slot) == 0:
             slot_uri_suffix = f", {sv.slot_uri}" if sv.slot_uri else ""
             slot_children = schema_view.slot_children(sk)
-            slot_children_prefix = f"parent " if len(slot_children) > 0 else ""
+            slot_children_prefix = "parent " if len(slot_children) > 0 else ""
             print(f"No classes for {slot_children_prefix}slot {sk}{slot_uri_suffix}")
     print("\n")
 

--- a/src/scripts/task_specific_code/insert_many_pymongo.py
+++ b/src/scripts/task_specific_code/insert_many_pymongo.py
@@ -38,8 +38,8 @@ click_log.basic_config(logger)
     required=False,
     default=True,
     show_default=True,
-    help=f"Whether you want the script to set the `directConnection` flag when connecting to the MongoDB server. "
-         f"That is required by some MongoDB servers that belong to a replica set. ",
+    help="Whether you want the script to set the `directConnection` flag when connecting to the MongoDB server. "
+         "That is required by some MongoDB servers that belong to a replica set. ",
 )
 @click.option(
     "--database-name",
@@ -47,7 +47,7 @@ click_log.basic_config(logger)
     required=False,
     default="nmdc",
     show_default=True,
-    help=f"MongoDB database name",
+    help="MongoDB database name",
 )
 @click.option(
     "--validator-uri",
@@ -55,7 +55,7 @@ click_log.basic_config(logger)
     required=False,
     default="https://api.microbiomedata.org/metadata/json:validate",
     show_default=True,
-    help=f"URI of NMDC Schema-based validator",
+    help="URI of NMDC Schema-based validator",
 )
 def insert_many_pymongo(
     input_file,
@@ -82,16 +82,16 @@ def insert_many_pymongo(
     # Note: The validation endpoint currently returns `{"result": "All Okay!"}`
     #       when data is valid.
     #
-    logger.debug(f"Validating the JSON data.")
+    logger.debug("Validating the JSON data.")
     json_data = json.load(input_file)
     response = requests.post(validator_uri, json=json_data)
     assert response.status_code == 200, f"Failed to access validator at {validator_uri}"
     validation_result = response.json()
     if validation_result.get("result") == "All Okay!":
-        logger.debug(f"The JSON data is valid.")
+        logger.debug("The JSON data is valid.")
     else:
         logger.error(f"Validation result: {validation_result}")
-        raise ValueError(f"The JSON data is not valid.")
+        raise ValueError("The JSON data is not valid.")
 
     # Validate the MongoDB connection string and database name.
     mongo_client = pymongo.MongoClient(host=mongo_uri, directConnection=is_direct_connection)
@@ -109,7 +109,7 @@ def insert_many_pymongo(
             num_documents_provided = len(documents)
             logger.info(f"Inserted {num_documents_inserted} of {num_documents_provided} documents.")
             if num_documents_inserted < num_documents_provided:
-                logger.warning(f"Not all of the provided documents were inserted.")
+                logger.warning("Not all of the provided documents were inserted.")
         else:
             logger.warning(f'Skipping collection "{collection_name}" because no documents were provided for it.')
 


### PR DESCRIPTION
Consolidates the Python dev tooling onto `ruff` and adds it to CI, per the plan to remove tools that ruff subsumes and automate the rest.

**Removed** (all subsumed by ruff): `black`, `autopep8` (formatting), `flake8` (E/F/W), `isort` (I), `bandit` (the `S` security rules), `pydocstyle` (D). **Kept** (not fully covered by ruff): `mypy`, `pylint`, `vulture`, `pyroma`. `deptry` is unchanged.

**Added:**
- `[tool.ruff]` config in `pyproject.toml`: blocking `F` (pyflakes) gate; generated artifacts, `notebooks/`, and frozen `migrators/partials/` excluded. The `F` autofixes (unused imports, empty f-strings) are applied.
- `.github/workflows/lint.yaml`: `ruff check` (blocking) plus a non-blocking `ruff check --select S` security scan, mirroring the non-blocking zizmor job.
- `.github/dependabot.yml`: grouped weekly version updates for `github-actions` and `pip` (security updates/alerts were already on).
- `make lint` / `make format` targets.
- CLAUDE.md section documenting the tooling and the `yaml.safe_load`/`safe_dump`-only rule.

**Verified:** `ruff check` passes; actionlint clean (shellcheck+pyflakes); zizmor clean at default and pedantic.

**No consumer impact:** all changes are dev-group/CI/config; the published package and its runtime dependencies are unchanged.

**Deliberately deferred** (separate issues to avoid large churn here):
- One-time `ruff format` sweep then gate on format: #3166
- Clear `src/scripts` ruff `S` findings (timeouts, /tmp) then gate on `S`: #3164
- mypy typing cleanup: #3165
