### PR TITLE
Dependabot pip: versioning-strategy lockfile-only (stop propagating floor bumps to consumers)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,10 +15,20 @@ updates:
         patterns: ["*"]
 
   # Python dependencies (Dependabot reads pyproject.toml for the pip ecosystem).
+  #
+  # versioning-strategy: lockfile-only -> Dependabot updates ONLY poetry.lock,
+  # never the version floors in pyproject.toml. nmdc-schema is a library, so
+  # raising a [project.dependencies] floor would propagate a tighter constraint
+  # to consumers (submission-schema, nmdc-runtime, nmdc-server) and can force
+  # version changes in their environments. lockfile-only keeps our own lock at
+  # the latest compatible versions (what we want for CI) without forcing
+  # anything downstream. Deliberate floor changes (e.g. widening the linkml /
+  # click caps) are made by hand, with the release chain coordinated.
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: weekly
+    versioning-strategy: lockfile-only
     groups:
       python-dependencies:
         patterns: ["*"]


### PR DESCRIPTION
Sets `versioning-strategy: lockfile-only` on the pip Dependabot group.

**Why:** nmdc-schema is a library. With the default strategy, Dependabot raises the version **floors** in `pyproject.toml`'s `[project.dependencies]` (this is what [#3169](https://github.com/microbiomedata/nmdc-schema/pull/3169) did — it bumped `requests`, `curies`, `jsonschema`, `pymongo`, etc. floors). Those floors are published in the package metadata and **propagate to consumers** (submission-schema, nmdc-runtime, nmdc-server), forcing version changes in their environments.

`lockfile-only` makes Dependabot update **only `poetry.lock`** (which no downstream consumer uses), keeping our own CI/dev environment at the latest compatible versions, while never touching the published floors. Deliberate floor changes (for example widening the `linkml`/`click` caps to allow linkml 1.11) are made by hand, with the release chain coordinated.

This pairs with the existing repo guidance ("don't tighten the linkml pin without checking submission-schema") by removing the automated vector that could do exactly that.

Follow-up: [#3169](https://github.com/microbiomedata/nmdc-schema/pull/3169) (the floor-raising pip PR) should be closed; after this merges, Dependabot will regenerate a lockfile-only PR.
