### PR TITLE
Implement function that returns mapping from class name to typecodes

### DIFF
--- a/nmdc_schema/id_helpers.py
+++ b/nmdc_schema/id_helpers.py
@@ -3,11 +3,13 @@ This module contains helper functions related to schema element identifiers.
 """
 
 import re
+from functools import lru_cache
 from typing import Dict, List, Optional
 
 from nmdc_schema.get_nmdc_view import ViewGetter
 
 
+@lru_cache
 def get_compatible_typecodes(slot_pattern: str) -> List[str]:
     r"""
     Returns the typecodes, if any, that the schema says values of the specified `id` field can contain.
@@ -61,6 +63,7 @@ def get_compatible_typecodes(slot_pattern: str) -> List[str]:
     return typecodes
 
 
+@lru_cache
 def get_typecode_for_future_ids(slot_pattern: str) -> Optional[str]:
     r"""
     Returns the typecode, if any, that schema authors want future values of the specified `id` field to contain.
@@ -80,6 +83,7 @@ def get_typecode_for_future_ids(slot_pattern: str) -> Optional[str]:
     return compatible_typecodes[0] if len(compatible_typecodes) > 0 else None
 
 
+@lru_cache
 def get_class_name_to_typecode_map() -> Dict[str, List[str]]:
     r"""
     Returns a dictionary in which each key is the name of a schema class and each value is a list of all the typecodes

--- a/nmdc_schema/id_helpers.py
+++ b/nmdc_schema/id_helpers.py
@@ -92,15 +92,15 @@ def get_class_name_to_typecode_map() -> dict[str, list[str]]:
     True
     >>> all(isinstance(v, list) for v in d.values())  # all dict values are lists
     True
-    >>> "NamedThing" in d  # schema class lacking an `id` field compatible with any typecodes
+    >>> "NamedThing" in d  # schema class lacking an `id` slot compatible with any typecodes
     True
     >>> d["NamedThing"]
     []
-    >>> "Biosample" in d  # schema class having an `id` field compatible with one typecode
+    >>> "Biosample" in d  # schema class having an `id` slot compatible with one typecode
     True
     >>> d["Biosample"]
     ['bsm']
-    >>> "MassSpectrometry" in d  # schema class having an `id` field compatible with multiple typecodes
+    >>> "MassSpectrometry" in d  # schema class having an `id` slot compatible with multiple typecodes
     True
     >>> sorted(d["MassSpectrometry"])
     ['dgms', 'omprc']

--- a/nmdc_schema/id_helpers.py
+++ b/nmdc_schema/id_helpers.py
@@ -3,7 +3,7 @@ This module contains helper functions related to schema element identifiers.
 """
 
 import re
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from nmdc_schema.get_nmdc_view import ViewGetter
 
@@ -80,7 +80,7 @@ def get_typecode_for_future_ids(slot_pattern: str) -> Optional[str]:
     return compatible_typecodes[0] if len(compatible_typecodes) > 0 else None
 
 
-def get_class_name_to_typecode_map() -> dict[str, list[str]]:
+def get_class_name_to_typecode_map() -> Dict[str, List[str]]:
     r"""
     Returns a dictionary in which each key is the name of a schema class and each value is a list of all the typecodes
     compatible with the `id` slot of that class.

--- a/nmdc_schema/id_helpers.py
+++ b/nmdc_schema/id_helpers.py
@@ -5,6 +5,8 @@ This module contains helper functions related to schema element identifiers.
 import re
 from typing import List, Optional
 
+from nmdc_schema.get_nmdc_view import ViewGetter
+
 
 def get_compatible_typecodes(slot_pattern: str) -> List[str]:
     r"""
@@ -76,3 +78,56 @@ def get_typecode_for_future_ids(slot_pattern: str) -> Optional[str]:
     """
     compatible_typecodes = get_compatible_typecodes(slot_pattern)
     return compatible_typecodes[0] if len(compatible_typecodes) > 0 else None
+
+
+def get_class_name_to_typecode_map() -> dict[str, list[str]]:
+    r"""
+    Returns a dictionary in which each key is the name of a schema class and each value is a list of all the typecodes
+    compatible with the `id` slot of that class.
+
+    >>> d = get_class_name_to_typecode_map()
+    >>> isinstance(d, dict)  # returns a dict
+    True
+    >>> all(isinstance(k, str) for k in d.keys())  # all dict keys are strings
+    True
+    >>> all(isinstance(v, list) for v in d.values())  # all dict values are lists
+    True
+    >>> "NamedThing" in d  # schema class lacking an `id` field compatible with any typecodes
+    True
+    >>> d["NamedThing"]
+    []
+    >>> "Biosample" in d  # schema class having an `id` field compatible with one typecode
+    True
+    >>> d["Biosample"]
+    ['bsm']
+    >>> "MassSpectrometry" in d  # schema class having an `id` field compatible with multiple typecodes
+    True
+    >>> sorted(d["MassSpectrometry"])
+    ['dgms', 'omprc']
+    """
+
+    # Make a dictionary in which each key is the name of a schema class and each value is the definition of that class.
+    view_getter = ViewGetter()
+    schema_view = view_getter.get_view()
+    class_definitions_by_class_name = schema_view.all_classes()
+
+    # Make a dictionary in which each key is the name of a schema class and each value is a list of all the typecodes
+    # compatible with the `id` slot of that class.
+    class_name_to_typecodes_map = dict()
+    for class_name, class_definition in class_definitions_by_class_name.items():
+
+        # Ensure this class name appears in the resulting dictionary, regardless of whether its `id` slot is compatible
+        # with any typecodes. That way, all class names end up in the resulting dictionary.
+        if class_name not in class_name_to_typecodes_map:
+            class_name_to_typecodes_map[class_name] = list()
+
+        # Determine whether the `id` slot of this class is compatible with any typecodes and, if it is, add them to the
+        # list.
+        slot_definitions_for_class = schema_view.class_induced_slots(class_name)
+        for slot_definition in slot_definitions_for_class:
+            if slot_definition.name == "id":
+                if slot_definition.pattern is not None:
+                    compatible_typecodes = get_compatible_typecodes(slot_definition.pattern)
+                    class_name_to_typecodes_map[class_name].extend(compatible_typecodes)
+
+    return class_name_to_typecodes_map

--- a/src/scripts/make_typecode_to_class_map.py
+++ b/src/scripts/make_typecode_to_class_map.py
@@ -96,6 +96,9 @@ def get_collection_names_for_class_name(class_name: str) -> List[str]:
 def main():
     r"""
     Generates a Markdown document containing a table that can be used to map typecodes to schema classes.
+
+    TODO: Refactor this function to use the newly-implemented `get_class_name_to_typecode_map` function
+          defined in `nmdc_schema/id_helpers.py`.
     """
 
     # Initialize the data structure that will map each class name to


### PR DESCRIPTION
On this branch, I implemented a function in `nmdc_schema/id_helpers.py` named `get_class_name_to_typecode_map`, which people (e.g. developers of downstream applications) can use to get a mapping from schema class name to the typecode(s) compatible with the `id` slot, if any, of that schema class.

A note regarding maintenance: The doctests currently reference specific classes that exist in the schema. When I had an option, I tried to choose classes I thought were unlikely to be removed from the schema.

Fixes #3079