### PR TITLE
Replace deprecated linkml lint --validate-only with linkml validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ linkml-lint-all:
 .PHONY: linkml-validate-schema
 linkml-validate-schema:
 	@echo "Validating source schema files against LinkML metamodel..."
-	$(RUN) linkml lint --validate-only src/schema
+	$(RUN) linkml validate src/schema/*.yaml
 	@echo "All source schema files pass metamodel validation."
 
 .PHONY: check-dependencies

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ linkml-lint-all:
 .PHONY: linkml-validate-schema
 linkml-validate-schema:
 	@echo "Validating source schema files against LinkML metamodel..."
-	$(RUN) linkml validate src/schema/*.yaml
+	$(RUN) linkml validate $(SOURCE_SCHEMA_DIR)*.yaml
 	@echo "All source schema files pass metamodel validation."
 
 .PHONY: check-dependencies


### PR DESCRIPTION
linkml 1.11 deprecated `linkml lint --validate-only` (metamodel validation now always runs inside `lint`). The schema-vs-metamodel replacement is `linkml validate src/schema/*.yaml` (no `-s` means positional args are validated against the metamodel). Verified locally: "No issues found". Fixes the `DeprecationWarning: The option 'validate_only' is deprecated` seen during `make linkml-lint`.