### PR TITLE
Pin poetry 2.4.1 in CI + add poetry check gate (fix lock-sync drift)

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==2.4.1
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Install Poetry.
-        run: pipx install poetry
+        run: pipx install poetry==2.4.1
 
       - name: Set up Python 3.
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==2.4.1
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==2.4.1
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -45,6 +45,9 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         run: poetry install
+
+      - name: Verify lockfile is in sync with pyproject.toml
+        run: poetry check
 
       #----------------------------------------------
       #              build, test, and quality checks

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,11 +43,12 @@ jobs:
       #----------------------------------------------
       # install dependencies if cache does not exist 
       #----------------------------------------------
+      - name: Verify lockfile is in sync with pyproject.toml
+        run: poetry check
+
       - name: Install dependencies
         run: poetry install
 
-      - name: Verify lockfile is in sync with pyproject.toml
-        run: poetry check
 
       #----------------------------------------------
       #              build, test, and quality checks

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install Poetry
       run: |
-        pipx install poetry
+        pipx install poetry==2.4.1
         pipx inject poetry "poetry-dynamic-versioning[plugin]"
 
     - name: Set up Python

--- a/.github/workflows/test-pages-build.yaml
+++ b/.github/workflows/test-pages-build.yaml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: pipx install poetry==2.4.1
 
       - name: Set up Python 3
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ Build prerequisites and gotchas:
 
 This is a Poetry repo. Sibling `submission-schema` migrated to `uv`; do not confuse the two.
 
+- **Use poetry 2.4.1** (pinned in every CI workflow via `pipx install poetry==2.4.1`). The `poetry.lock` content-hash is poetry-version-sensitive: a different poetry version can report the lock as "out of sync with pyproject.toml" even when the dependencies are unchanged. Align dev/container poetry to the pinned version. CI runs `poetry check` (in `main.yaml`) to catch real pyproject/lock drift in PRs rather than on a teammate's fresh install. To sync after editing pyproject: `poetry lock` (no `--regenerate` unless you intend to bump versions).
+
 - Never create a `uv.lock` here, and never run `uv add`, `uv sync`, or `uv lock`. If a stray `uv.lock` appears, delete it before committing.
 - Before tightening any pin in `pyproject.toml` (especially `linkml`), check that `submission-schema` still resolves. nmdc-schema is a library, so a tighter pin propagates to consumers even when nmdc-schema itself does not exercise the feature. `linkml` and `linkml-runtime` versions must be paired (a runtime release can drop something the matching `linkml` references).
 - `pyproject.toml` conventions: upper-bound policy (packages at 1.0 or above cap at the next major, pre-1.0 cap at the next minor); PEP 508 form (`"pkg>=min,<max"`, not the Poetry caret); alphabetical ordering within each dependency group; runtime deps in `[project.dependencies]`, dev tools in `[dependency-groups] dev`, `deptry` in its own `deps` group; transitive packages pinned for security are also added to `[tool.deptry] per_rule_ignores.DEP002`; comments cite the issue number that motivated a pin.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,13 +2,16 @@
 
 ## Prerequisites
 
-This project requires **Poetry >=2.2.0** for local development. The `pyproject.toml` uses
-[PEP 735 dependency groups](https://peps.python.org/pep-0735/) (`[dependency-groups]`), which
-require Poetry 2.2.0 or later. Poetry 2.3.0+ is recommended — earlier 2.2.x versions have
-[known bugs](https://github.com/python-poetry/poetry/issues/10632) with `poetry add -G` and
-`poetry remove` on PEP 735 groups, and the lock file hash doesn't track dependency-group
-changes until 2.3.0. These bugs don't affect `poetry install` (which is all CI needs), but
-they can bite local development workflows.
+This project pins **Poetry 2.4.1** (CI installs `poetry==2.4.1` in every workflow; use the
+same version locally). The `pyproject.toml` uses
+[PEP 735 dependency groups](https://peps.python.org/pep-0735/) (`[dependency-groups]`). The
+`poetry.lock` content-hash only tracks dependency-group changes from **Poetry 2.3.0 onward**
+([poetry#10632](https://github.com/python-poetry/poetry/issues/10632)), so a poetry older than
+that (or simply different from the version that wrote the lock) computes a different hash and
+reports the lock as "out of sync with pyproject.toml" even when nothing changed. CI now runs
+`poetry check`, so an unpinned/mismatched local poetry will also disagree with CI — align on
+2.4.1. After editing `pyproject.toml`, run `poetry lock` (not `--regenerate` unless you intend
+to bump versions) and commit the lock.
 
 ```shell
 # Check your version


### PR DESCRIPTION
Addresses the `poetry.lock` out-of-sync reports on release day.

**Cause (toolchain, not a real dep mismatch):** the lock's `content-hash` is poetry-version-sensitive — `poetry check` passes on 2.4.1 and fails on <=2.2 for the *same* pyproject+lock. So teammates on different poetry versions see 'out of sync' even when nothing changed.

**Fix:**
- Pin every workflow to `pipx install poetry==2.4.1` (the version the committed lock matches).
- Add a `poetry check` step in `main.yaml` so real pyproject/lock drift fails CI in the PR (per Eric's 'sync before it hits main').
- Document the pin + the `poetry lock` sync step in CLAUDE.md.

Dev/container poetry should align to 2.4.1. Does not block v11.20.0 (the release build already runs latest poetry).