### PR TITLE
Retroactively create "no op" migrators for schema releases that lack them

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_18_0_to_11_18_1.py
+++ b/nmdc_schema/migrators/migrator_from_11_18_0_to_11_18_1.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: Since this migrator was created retroactively, we can include a link to the release notes as evidence that
+          no migration is necessary. Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.18.1
+    """
+
+    _from_version = "11.18.0"
+    _to_version = "11.18.1"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_18_1_to_11_19_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_18_1_to_11_19_0.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: Since this migrator was created retroactively, we can include a link to the release notes as evidence that
+          no migration is necessary. Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.19.0
+    """
+
+    _from_version = "11.18.1"
+    _to_version = "11.19.0"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_19_0_to_11_19_1.py
+++ b/nmdc_schema/migrators/migrator_from_11_19_0_to_11_19_1.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: Since this migrator was created retroactively, we can include a link to the release notes as evidence that
+          no migration is necessary. Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.19.1
+    """
+
+    _from_version = "11.19.0"
+    _to_version = "11.19.1"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_19_1_to_11_20_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_19_1_to_11_20_0.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: Since this migrator was created retroactively, we can include a link to the release notes as evidence that
+          no migration is necessary. Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.20.0
+    """
+
+    _from_version = "11.19.1"
+    _to_version = "11.20.0"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass


### PR DESCRIPTION
On this branch, I created "no op" migrators for releases that did not require migration, but lacked "no op" migrators. "No op" migrators serve as an in-package indication that no transformation is necessary (application developers can even run these "no op" migrators—which perform _no operations_—if their standard operating procedures call for it).

They are the "`THIS PAGE INTENTIONALLY LEFT BLANK`" of the schema change world.

Fixes #3180 