### PR TITLE
Consolidate release-notes & versioning docs; remove dead CHANGELOG.md references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,6 @@ This is a Poetry repo. Sibling `submission-schema` migrated to `uv`; do not conf
 
 Migrator partials under `nmdc_schema/migrators/partials/migrator_from_X_to_Y/` are versioned snapshots of migrations that have already run against the production database. Do not make functional changes to them; they are the authoritative record of what ran. Explanatory comments are fine. New breaking schema changes get a new migrator, not an edit to an old one (and a breaking change with no production data may legitimately ship no migrator, with the reason noted in the PR).
 
-Whether a release needs a migrator at all is a conformance question, not a version-number question: if every database valid under the old schema is still valid under the new one, no migration is needed, and you record that fact with a no-op migrator rather than shipping nothing. Deletions are handled outside migrators. The authoritative explanation and the `make migrator` workflow are in [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md) (which this section does not duplicate); backfilling no-op migrators for past releases that lack them is tracked in [#3180](https://github.com/microbiomedata/nmdc-schema/issues/3180).
-
 ## Workflow security and linting (actionlint + zizmor)
 
 The GitHub Actions workflows in `.github/workflows/` are security-sensitive: they carry permissions, secrets, and the PyPI release path. Two static tools audit them:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ This is a Poetry repo. Sibling `submission-schema` migrated to `uv`; do not conf
 
 Migrator partials under `nmdc_schema/migrators/partials/migrator_from_X_to_Y/` are versioned snapshots of migrations that have already run against the production database. Do not make functional changes to them; they are the authoritative record of what ran. Explanatory comments are fine. New breaking schema changes get a new migrator, not an edit to an old one (and a breaking change with no production data may legitimately ship no migrator, with the reason noted in the PR).
 
+Whether a release needs a migrator at all is a conformance question, not a version-number question: if every database valid under the old schema is still valid under the new one, no migration is needed, and you record that fact with a no-op migrator rather than shipping nothing. Deletions are handled outside migrators. The authoritative explanation and the `make migrator` workflow are in [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md) (which this section does not duplicate); backfilling no-op migrators for past releases that lack them is tracked in [#3180](https://github.com/microbiomedata/nmdc-schema/issues/3180).
+
 ## Workflow security and linting (actionlint + zizmor)
 
 The GitHub Actions workflows in `.github/workflows/` are security-sensitive: they carry permissions, secrets, and the PyPI release path. Two static tools audit them:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ current policy below when adding or modifying developer tooling.
 
 The authoritative release procedure is the [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md). Pre-release mechanics and the dynamic-versioning setup are in the *Pre-release Process* section of [`CLAUDE.md`](CLAUDE.md). Version-number choice (major vs minor vs patch) and the release notes convention are in [`MAINTAINERS.md`](MAINTAINERS.md#making-a-pypi-release-of-the-nmdc-schema).
 
-Release notes come from GitHub's auto-generated notes, built from merged pull-request titles, so write PR titles to read as change-log entries. This repository does not keep a `CHANGELOG.md`.
+Release notes come from GitHub's auto-generated notes, built from merged pull request titles, so write PR titles to read as change log entries. This repository does not keep a `CHANGELOG.md`.
 
 [about-branches]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches
 [about-issues]: https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ familiar with the schema, the basics of the LinkML framework, and NMDC Best Prac
 - Never work on the main branch, always work on an issue/feature branch
 - Core developers can work on branches off origin rather than forks
 - Always create a PR on a branch to maximize transparency of what you are doing
-- When a PR makes data that was valid under the current schema invalid under the new schema, include a migrator. A breaking change with no affected production data should still ship a no-op migrator, with the reason noted in the PR. See [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md).
+- When a PR includes a breaking change, include a migration
 - PRs should be reviewed and merged in a timely fashion by the nmdc-schema technical leads
 - PRs that do not pass GitHub actions should never be merged
 - In the case of git conflicts, the contributor should try and resolve the conflict
@@ -176,7 +176,7 @@ current policy below when adding or modifying developer tooling.
 
 The authoritative release procedure is the [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md). Pre-release mechanics and the dynamic-versioning setup are in the *Pre-release Process* section of [`CLAUDE.md`](CLAUDE.md). Version-number choice (major vs minor vs patch) and the release-notes convention are in [`MAINTAINERS.md`](MAINTAINERS.md#making-a-pypi-release-of-the-nmdc-schema).
 
-Release notes come from GitHub's auto-generated notes, built from merged pull-request titles, so write PR titles to read as change-log entries. This repository does not keep a `CHANGELOG.md`. Whether a release needs a data migrator is covered under *When a PR ... include a migrator* above and in [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md).
+Release notes come from GitHub's auto-generated notes, built from merged pull-request titles, so write PR titles to read as change-log entries. This repository does not keep a `CHANGELOG.md`.
 
 [about-branches]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches
 [about-issues]: https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ familiar with the schema, the basics of the LinkML framework, and NMDC Best Prac
 - Never work on the main branch, always work on an issue/feature branch
 - Core developers can work on branches off origin rather than forks
 - Always create a PR on a branch to maximize transparency of what you are doing
-- When a PR includes a breaking change, include a migration
+- When a PR makes data that was valid under the current schema invalid under the new schema, include a migrator. A breaking change with no affected production data should still ship a no-op migrator, with the reason noted in the PR. See [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md).
 - PRs should be reviewed and merged in a timely fashion by the nmdc-schema technical leads
 - PRs that do not pass GitHub actions should never be merged
 - In the case of git conflicts, the contributor should try and resolve the conflict
@@ -174,7 +174,9 @@ current policy below when adding or modifying developer tooling.
 
 ### Making Releases
 
-TODO: Add to this section later
+The authoritative release procedure is the [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md). Pre-release mechanics and the dynamic-versioning setup are in the *Pre-release Process* section of [`CLAUDE.md`](CLAUDE.md). Version-number choice (major vs minor vs patch) and the release-notes convention are in [`MAINTAINERS.md`](MAINTAINERS.md#making-a-pypi-release-of-the-nmdc-schema).
+
+Release notes come from GitHub's auto-generated notes, built from merged pull-request titles, so write PR titles to read as change-log entries. This repository does not keep a `CHANGELOG.md`. Whether a release needs a data migrator is covered under *When a PR ... include a migrator* above and in [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md).
 
 [about-branches]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches
 [about-issues]: https://docs.github.com/en/issues/tracking-your-work-with-issues/about-issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ current policy below when adding or modifying developer tooling.
 
 ### Making Releases
 
-The authoritative release procedure is the [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md). Pre-release mechanics and the dynamic-versioning setup are in the *Pre-release Process* section of [`CLAUDE.md`](CLAUDE.md). Version-number choice (major vs minor vs patch) and the release-notes convention are in [`MAINTAINERS.md`](MAINTAINERS.md#making-a-pypi-release-of-the-nmdc-schema).
+The authoritative release procedure is the [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md). Pre-release mechanics and the dynamic-versioning setup are in the *Pre-release Process* section of [`CLAUDE.md`](CLAUDE.md). Version-number choice (major vs minor vs patch) and the release notes convention are in [`MAINTAINERS.md`](MAINTAINERS.md#making-a-pypi-release-of-the-nmdc-schema).
 
 Release notes come from GitHub's auto-generated notes, built from merged pull-request titles, so write PR titles to read as change-log entries. This repository does not keep a `CHANGELOG.md`.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@ To track changes made to the NMDC Schema, it is best maintained by following the
 4. Merge pull request once all the necessary changes have been made. If needed, tag other developers to review pull request. 
 5. Delete the issue branch (e.g., branch `issue-50`).
 
-This project previously used a manually curated [**Change log**](https://github.com/microbiomedata/nmdc-schema/blob/main/CHANGELOG.md). More recently, we have decided that GitHub's auto-generated release notes are sufficient. Commit and pull messages should be written with this in mind: they will become part of the repo's documentation. 
+Changes are recorded through GitHub's auto-generated release notes rather than a manually curated change log. Write commit and pull-request messages with this in mind: they become the source those notes are built from. See [Release notes](#release-notes) below for details.
 
 When the pull request is merged into the `main` branch, new documentation will be generated for the changed schema.
 
@@ -28,45 +28,62 @@ The changes can be cecked locally with `make all test`
 
 ## Making a PyPI release of the NMDC Schema
 
-The NMDC Schema is deployed to [PyPI](https://pypi.org/project/nmdc-schema/) using the [pypi-publish](https://github.com/microbiomedata/nmdc-schema/blob/main/.github/workflows/pypi-publish.yml) github action.
+> The authoritative, step-by-step release procedure is the
+> [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md).
+> Pre-release (release-candidate) mechanics and the `poetry-dynamic-versioning` setup
+> are documented in the *Pre-release Process* section of
+> [`CLAUDE.md`](CLAUDE.md). This section keeps only the version-numbering guidelines
+> and the release-notes convention; follow the runbook for the current steps.
 
-### Steps for making a release
-1. Generate the set of artifacts by running `make clean` followed by `make all`.
+The package is published to [PyPI](https://pypi.org/project/nmdc-schema/) by the
+[pypi-publish](https://github.com/microbiomedata/nmdc-schema/blob/main/.github/workflows/pypi-publish.yaml)
+GitHub Action, which fires when a GitHub release is published. The package version is
+derived from the git tag by `poetry-dynamic-versioning`; there is no `version` field to
+hand-edit before a release.
 
-2. If **#1** succeeds and changes have been made to the schema, update the `version` [nmdc.yaml](https://github.com/microbiomedata/nmdc-schema/blob/main/src/schema/nmdc.yaml) using semantic versioning (i.e., `<major number>`**.** `<minor number>`**.**`<patch number>`). 
-  
-    #### Guidelines for updating semantic version
-    * If the change **breaks** backward compatibility, update the **major** number.
-      Examples:
-      - Removing a class, slot, or enum
-    * If functionality is added and the change **does not** break backward compatibility, update the **minor** number.
-      Examples:
-      - Adding a class, slot, or enum
-      - Deprecating a class, slot, or enum
-    * If the change neither adds functionality nor breaks backward compatibility, update the **patch** number.
-      Examples:
-      - Fixing typos
-      - Adding comments or annotations
-      
-**Note:** Changes can be made to the Python package (e.g., functionality added to the CLI) that do not affect the schema. In these cases, the schema version does not need to be changed, only the PyPI version needs to be updated.
+### Guidelines for updating semantic version
 
-3. If **#1** succeeds:
-  * Make the sure the sections of the [Change log](https://github.com/microbiomedata/nmdc-schema/blob/main/CHANGELOG.md) (discussed above) have been updated appropriately.
-  * Change the `Current (update before releasing)` section of the [Change log](https://github.com/microbiomedata/nmdc-schema/blob/main/CHANGELOG.md) into a hyperlink that matches the tag you assign to the release in step **#4** below.  
-  For example, if the tag assigned for the release is `1.0.0`, change the section to:  
-  ```
-  [2021.07.01rc1](https://github.com/microbiomedata/nmdc-schema/releases/tag/1.0.0)
-  ```
-4. Create a GitHub release of the schema using the `Releases -> Draft new release` links. The tag of the release must conform to the semantic versioning format `<major number>.<minor number>.<patch number>` (see semantic versioning guidelines above). The value of this tag needs to match the value you assigned to the `Current (update before releasing)` section in the [Change log](https://github.com/microbiomedata/nmdc-schema/blob/main/CHANGELOG.md) (discussed above).
+The release tag uses the semantic-versioning format `<major>.<minor>.<patch>`, prefixed
+with `v` (e.g. `v11.20.0`). Pre-release tags add a `-rc.N` suffix (e.g. `v11.20.0-rc.1`).
 
-5. Give the release the same name as the semantic version tag you created in **#4**.
+* If the change **breaks** backward compatibility, update the **major** number.
+  Examples:
+  - Removing a class, slot, or enum
+* If functionality is added and the change **does not** break backward compatibility,
+  update the **minor** number. Examples:
+  - Adding a class, slot, or enum
+  - Deprecating a class, slot, or enum
+* If the change neither adds functionality nor breaks backward compatibility, update the
+  **patch** number. Examples:
+  - Fixing typos
+  - Adding comments or annotations
 
-6. Fill in the changes made for this release. This is most easily done by copying the information you recorded in the [Change log](https://github.com/microbiomedata/nmdc-schema/blob/main/CHANGELOG.md).
+**Note:** Changes can be made to the Python package (e.g. CLI functionality) that do not
+affect the schema. The version still advances because it tracks the git tag; such a change
+is a patch-level release.
 
-7. Click `Publish release` button. This fires the action to update the [PyPI package](https://pypi.org/project/nmdc-schema/).
+Whether a release needs a data migrator is a separate, conformance-based question covered
+in [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md) and the
+*Released migrators* notes in [`CLAUDE.md`](CLAUDE.md), not a function of which version
+number changes.
+
+### Release notes
+
+Release notes are GitHub's **auto-generated** notes (the *Generate release notes* button
+on the release form), built from merged pull-request titles plus a compare link. Write PR
+titles so they read as change-log entries. Larger releases may add a short hand-written
+**Highlights** section above the generated list; see the
+[v11.20.0 notes](https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.20.0) for
+an example.
+
+This repository previously kept a manually curated `CHANGELOG.md`. It was retired on
+2024-06-14 (PR [#209](https://github.com/microbiomedata/nmdc-schema/pull/209)) in favor of
+the auto-generated notes. Do not reintroduce a `CHANGELOG.md` without recording the
+decision against
+[#2876](https://github.com/microbiomedata/nmdc-schema/issues/2876).
 
 ### Notify NMDC Schema users
-After the new version has been released on PyPI, notify the [nmdc-runtime](https://github.com/microbiomedata/nmdc-runtime) and the `metadata` channel on the NMDC slack group that the `nmdc-schema` has been updated.
+After the new version is on PyPI, notify [nmdc-runtime](https://github.com/microbiomedata/nmdc-runtime) and the `metadata` channel on the NMDC Slack that `nmdc-schema` has been updated.
 
 ## Maintaining the Documentation
 Do **not** git add the files in `docs`. Custom documentation is added to (or edited in) the `src/docs/` directory.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,7 +20,7 @@ To track changes made to the NMDC Schema, it is best maintained by following the
 4. Merge pull request once all the necessary changes have been made. If needed, tag other developers to review pull request. 
 5. Delete the issue branch (e.g., branch `issue-50`).
 
-Changes are recorded through GitHub's auto-generated release notes rather than a manually curated change log. Write commit and pull-request messages with this in mind: they become the source those notes are built from. See [Release notes](#release-notes) below for details.
+Changes are recorded through GitHub's auto-generated release notes rather than a manually curated change log. Write commit and pull-request messages with this in mind: they are the source those notes are built from. See [Release notes](#release-notes) below for details.
 
 When the pull request is merged into the `main` branch, new documentation will be generated for the changed schema.
 
@@ -37,7 +37,7 @@ The changes can be cecked locally with `make all test`
 
 The package is published to [PyPI](https://pypi.org/project/nmdc-schema/) by the
 [pypi-publish](https://github.com/microbiomedata/nmdc-schema/blob/main/.github/workflows/pypi-publish.yaml)
-GitHub Action, which fires when a GitHub release is published. The package version is
+GitHub Action, which fires on the GitHub release `created` event. The package version is
 derived from the git tag by `poetry-dynamic-versioning`; there is no `version` field to
 hand-edit before a release.
 
@@ -74,8 +74,8 @@ an example.
 This repository previously kept a manually curated `CHANGELOG.md`. It was retired on
 2024-06-14 in commit
 [010ef75d2](https://github.com/microbiomedata/nmdc-schema/commit/010ef75d22c50d6b7cfa7eed825d0b99bbd74789)
-in favor of the auto-generated notes. Do not reintroduce a `CHANGELOG.md` without recording
-the decision against
+in favor of the auto-generated notes. Do not reintroduce a `CHANGELOG.md` without first
+documenting the decision in
 [Audit versioning guidelines and compliance](https://github.com/microbiomedata/nmdc-schema/issues/2876).
 
 ### Notify NMDC Schema users

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -62,11 +62,6 @@ with `v` (e.g. `v11.20.0`). Pre-release tags add a `-rc.N` suffix (e.g. `v11.20.
 affect the schema. The version still advances because it tracks the git tag; such a change
 is a patch-level release.
 
-Whether a release needs a data migrator is a separate, conformance-based question covered
-in [`nmdc_schema/migrators/README.md`](nmdc_schema/migrators/README.md) and the
-*Released migrators* notes in [`CLAUDE.md`](CLAUDE.md), not a function of which version
-number changes.
-
 ### Release notes
 
 Release notes are GitHub's **auto-generated** notes (the *Generate release notes* button

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -33,7 +33,7 @@ The changes can be cecked locally with `make all test`
 > Pre-release (release candidate) mechanics and the `poetry-dynamic-versioning` setup
 > are documented in the *Pre-release Process* section of
 > [`CLAUDE.md`](CLAUDE.md). This section keeps only the version-numbering guidelines
-> and the release-notes convention; follow the runbook for the current steps.
+> and the release notes convention; follow the runbook for the current steps.
 
 The package is published to [PyPI](https://pypi.org/project/nmdc-schema/) by the
 [pypi-publish](https://github.com/microbiomedata/nmdc-schema/blob/main/.github/workflows/pypi-publish.yaml)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -79,7 +79,7 @@ documenting the decision in
 [Audit versioning guidelines and compliance](https://github.com/microbiomedata/nmdc-schema/issues/2876).
 
 ### Notify NMDC Schema users
-After the new version is on PyPI, notify [nmdc-runtime](https://github.com/microbiomedata/nmdc-runtime) and the `metadata` channel on the NMDC Slack that `nmdc-schema` has been updated.
+After the new version is on PyPI, notify [nmdc-runtime](https://github.com/microbiomedata/nmdc-runtime) and the `metadata` channel on the NMDC Slack workspace that `nmdc-schema` has been updated.
 
 ## Maintaining the Documentation
 Do **not** git add the files in `docs`. Custom documentation is added to (or edited in) the `src/docs/` directory.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -72,10 +72,11 @@ titles so they read as change-log entries. Larger releases may add a short hand-
 an example.
 
 This repository previously kept a manually curated `CHANGELOG.md`. It was retired on
-2024-06-14 (PR [#209](https://github.com/microbiomedata/nmdc-schema/pull/209)) in favor of
-the auto-generated notes. Do not reintroduce a `CHANGELOG.md` without recording the
-decision against
-[#2876](https://github.com/microbiomedata/nmdc-schema/issues/2876).
+2024-06-14 in commit
+[010ef75d2](https://github.com/microbiomedata/nmdc-schema/commit/010ef75d22c50d6b7cfa7eed825d0b99bbd74789)
+in favor of the auto-generated notes. Do not reintroduce a `CHANGELOG.md` without recording
+the decision against
+[Audit versioning guidelines and compliance](https://github.com/microbiomedata/nmdc-schema/issues/2876).
 
 ### Notify NMDC Schema users
 After the new version is on PyPI, notify [nmdc-runtime](https://github.com/microbiomedata/nmdc-runtime) and the `metadata` channel on the NMDC Slack that `nmdc-schema` has been updated.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,7 +30,7 @@ The changes can be cecked locally with `make all test`
 
 > The authoritative, step-by-step release procedure is the
 > [infra-admin release runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md).
-> Pre-release (release-candidate) mechanics and the `poetry-dynamic-versioning` setup
+> Pre-release (release candidate) mechanics and the `poetry-dynamic-versioning` setup
 > are documented in the *Pre-release Process* section of
 > [`CLAUDE.md`](CLAUDE.md). This section keeps only the version-numbering guidelines
 > and the release-notes convention; follow the runbook for the current steps.


### PR DESCRIPTION
## Why

Our maintainer-facing docs repeated and contradicted themselves about release notes and versioning. This consolidates them into single authoritative spots and cross-links the rest. Scoped to release-notes / CHANGELOG / versioning only; no content under `nmdc_schema/migrators/` is modified. The "when is a migrator required" documentation is handled in https://github.com/microbiomedata/nmdc-schema/pull/3185 (Document when a data migrator is required (conformance rule + no-op convention)).

## What this fixes

**The CHANGELOG.md contradiction.** `CHANGELOG.md` was retired on 2024-06-14 in commit https://github.com/microbiomedata/nmdc-schema/commit/010ef75d22c50d6b7cfa7eed825d0b99bbd74789 (delete CHANGELOG.md), and `MAINTAINERS.md` already said so, yet the release steps just below still told maintainers to "update the Change log" and "copy from the Change log" (four dead links to the deleted file). Removed those steps; release notes now come from GitHub's auto-generated notes, which matches actual practice since 2024.

**Stale release procedure.** The step-by-step in `MAINTAINERS.md` duplicated the [infra-admin runbook](https://github.com/microbiomedata/infra-admin/blob/main/releases/nmdc-schema.md) (already the authoritative source per `CLAUDE.md`) and contradicted current setup: it described a manual `nmdc.yaml` version bump (we use `poetry-dynamic-versioning` from the git tag) and linked `pypi-publish.yml` (actual: `.yaml`). Replaced the duplicated procedure with a pointer to the runbook + `CLAUDE.md`, keeping the semver guidelines as the single canonical copy and fixing the staleness.

**Empty section.** `CONTRIBUTING.md` "Making Releases" was a `TODO`; filled with cross-references.

## Notes

- The migrators README (~line 56) and the infra-admin runbook still point at the deleted `CHANGELOG.md` for "version number guidelines." Those live in other paths, so they are not touched here; tracked in https://github.com/microbiomedata/nmdc-schema/issues/2427 (infra-admin's documentation about making an nmdc-schema release expects a CHANGELOG.md files with versioning guidance).
- The open questions about semver bump definitions (e.g. is deprecation minor?) stay in https://github.com/microbiomedata/nmdc-schema/issues/2876 (Audit versioning guidelines and compliance).

Refs:
- https://github.com/microbiomedata/nmdc-schema/issues/2876 (Audit versioning guidelines and compliance)
- https://github.com/microbiomedata/nmdc-schema/issues/2427 (infra-admin's documentation about making an nmdc-schema release expects a CHANGELOG.md files with versioning guidance)
