### PR TITLE
Add FileTypeEnum permissible values for generic raw sequencing data

### DIFF
--- a/src/data/valid/DataObject-seq_instrument_data.yaml
+++ b/src/data/valid/DataObject-seq_instrument_data.yaml
@@ -1,0 +1,7 @@
+id: nmdc:dobj-99-izwYW6
+type: nmdc:DataObject
+name: my_amplicon_data.fastq.gz
+description: Raw data for amplicon experiment ABCD
+data_category: instrument_data
+file_size_bytes: 32787380
+data_object_type: Paired interleaved raw sequencing data

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -819,8 +819,8 @@ enums:
           file_name_pattern: '^.+_R2\.fastq(\.gz)?$'
 
       Unpaired raw sequencing data:
-        description: Reads from a sequencing insturment that generates data that is not paired
-        comments: 
+        description: Reads from a sequencing instrument that generates data that is not paired
+        comments:
           - Data from Oxford Nanopore and Pacific Biosciences can have a library layout of single
 
       Paired interleaved raw sequencing data:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -821,7 +821,7 @@ enums:
       Unpaired raw sequencing data:
         description: Reads from a single-end sequencing library (not forward/reverse pairs).
         comments:
-          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome reads, prefer the analyte-specific values above.
+          - Use when the analyte category is not part of the value, for example amplicon or isolate data. For metagenome or metatranscriptome reads, prefer the analyte-specific values above.
           - Oxford Nanopore and PacBio runs commonly have a single (unpaired) library layout.
         see_also:
           - https://www.ebi.ac.uk/ena/browser/about/read-formats
@@ -829,21 +829,21 @@ enums:
       Paired interleaved raw sequencing data:
         description: Paired-end reads with forward and reverse mates interleaved in a single file.
         comments:
-          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome interleaved reads, prefer "Metagenome Raw Reads" or "Metatranscriptome Raw Reads" above.
+          - Use when the analyte category is not part of the value, for example amplicon or isolate data. For metagenome or metatranscriptome interleaved reads, prefer "Metagenome Raw Reads" or "Metatranscriptome Raw Reads" above.
         see_also:
           - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
       Raw sequencing data read 1:
         description: Read 1 (forward) of a paired-end run, as a separate file.
         comments:
-          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome forward reads, prefer "Metagenome Raw Read 1" or "Metatranscriptome Raw Read 1" above.
+          - Use when the analyte category is not part of the value, for example amplicon or isolate data. For metagenome or metatranscriptome forward reads, prefer "Metagenome Raw Read 1" or "Metatranscriptome Raw Read 1" above.
         see_also:
           - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
       Raw sequencing data read 2:
         description: Read 2 (reverse) of a paired-end run, as a separate file.
         comments:
-          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome reverse reads, prefer "Metagenome Raw Read 2" or "Metatranscriptome Raw Read 2" above.
+          - Use when the analyte category is not part of the value, for example amplicon ingest or isolate data. For metagenome or metatranscriptome reverse reads, prefer "Metagenome Raw Read 2" or "Metatranscriptome Raw Read 2" above.
         see_also:
           - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -827,7 +827,11 @@ enums:
           - https://www.ebi.ac.uk/ena/browser/about/read-formats
 
       Paired interleaved raw sequencing data:
-        description: Interleaved sequencing data
+        description: Paired-end reads with forward and reverse mates interleaved in a single file.
+        comments:
+          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome interleaved reads, prefer "Metagenome Raw Reads" or "Metatranscriptome Raw Reads" above.
+        see_also:
+          - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
       Raw sequencing data read 1:
         description: Read 1 raw sequencing data, aka forward reads

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -819,9 +819,12 @@ enums:
           file_name_pattern: '^.+_R2\.fastq(\.gz)?$'
 
       Unpaired raw sequencing data:
-        description: Reads from a sequencing instrument that generates data that is not paired
+        description: Reads from a single-end sequencing library (not forward/reverse pairs).
         comments:
-          - Data from Oxford Nanopore and Pacific Biosciences can have a library layout of single
+          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome reads, prefer the analyte-specific values above.
+          - Oxford Nanopore and PacBio runs commonly have a single (unpaired) library layout.
+        see_also:
+          - https://www.ebi.ac.uk/ena/browser/about/read-formats
 
       Paired interleaved raw sequencing data:
         description: Interleaved sequencing data

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -834,7 +834,11 @@ enums:
           - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
       Raw sequencing data read 1:
-        description: Read 1 raw sequencing data, aka forward reads
+        description: Read 1 (forward) of a paired-end run, as a separate file.
+        comments:
+          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome forward reads, prefer "Metagenome Raw Read 1" or "Metatranscriptome Raw Read 1" above.
+        see_also:
+          - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
       Raw sequencing data read 2:
         description: Read 2 (reverse) of a paired-end run, as a separate file.

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -830,7 +830,11 @@ enums:
         description: Read 1 raw sequencing data, aka forward reads
 
       Raw sequencing data read 2:
-        description: Read 2 raw sequencing data, aka reverse reads
+        description: Read 2 (reverse) of a paired-end run, as a separate file.
+        comments:
+          - Use when the analyte category is not part of the value, for example NCBI/SRA ingest or isolate data. For metagenome or metatranscriptome reverse reads, prefer "Metagenome Raw Read 2" or "Metatranscriptome Raw Read 2" above.
+        see_also:
+          - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
       Direct Infusion FT-ICR MS Analysis Results:
         description: FT-ICR MS based molecular formula assignment results table

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -818,6 +818,19 @@ enums:
         annotations:
           file_name_pattern: '^.+_R2\.fastq(\.gz)?$'
 
+      Unpaired raw sequencing data:
+        description: Reads from a sequencing insturment that generates data that is not paired
+        comments: Data from Oxford Nanopore and Pacific Biosciences can have a library layout of single
+
+      Paired interleaved raw sequencing data:
+        description: Interleaved sequencing data
+
+      Raw sequencing data read 1:
+        description: Read 1 raw sequencing data, aka forward reads
+
+      Raw sequencing data read 2:
+        description: Read 2 raw sequencing data, aka reverse reads
+
       Direct Infusion FT-ICR MS Analysis Results:
         description: FT-ICR MS based molecular formula assignment results table
       

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -820,7 +820,8 @@ enums:
 
       Unpaired raw sequencing data:
         description: Reads from a sequencing insturment that generates data that is not paired
-        comments: Data from Oxford Nanopore and Pacific Biosciences can have a library layout of single
+        comments: 
+          - Data from Oxford Nanopore and Pacific Biosciences can have a library layout of single
 
       Paired interleaved raw sequencing data:
         description: Interleaved sequencing data

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -847,6 +847,13 @@ enums:
         see_also:
           - https://github.com/ncbi/sra-tools/wiki/HowTo:-fasterq-dump
 
+      SRA toolkit-accessible sequence data:
+        description: Files that are avaliable for download via SRA Toolkit by providing an INSDC accession
+        comments:
+           - File format will depend on options specified to SRA Toolkit
+        see_also:
+          - https://github.com/ncbi/sra-tools/wiki
+
       Direct Infusion FT-ICR MS Analysis Results:
         description: FT-ICR MS based molecular formula assignment results table
       


### PR DESCRIPTION
This PR adds generic permissible values for raw sequencing data & a new example data file. This is needed to support both isolate data (where the analyte category is not embedded in the permissible value) and more immediately to support ingest of data from NCBI.