### PR TITLE
post release: Run schema_pattern_linting in CI; add unescaped-dot and slot_group checks

### DIFF
--- a/.github/workflows/schema-pattern-lint.yml
+++ b/.github/workflows/schema-pattern-lint.yml
@@ -1,0 +1,57 @@
+name: Schema pattern lint (report)
+
+# Runs src/scripts/schema_pattern_linting.py on every PR and push to main and
+# surfaces its output in the job summary: orphan slots (no class), orphan enums
+# (no slot), subset usage, candidate unescaped literal dots in regex patterns,
+# and dangling slot_group references.
+#
+# Report-only for now: the step fails only if the script itself errors, not on
+# findings, because there is an existing orphan/backlog (see #2691, #2297,
+# #2298) and the unescaped-dot fixes land in #3200. Converting individual
+# checks to blocking gates is a follow-up tracked in #3202 and #3193.
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+permissions: {}  # default deny; the job below grants only what it needs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  schema-pattern-lint:
+    name: schema-pattern-lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # check out the repository to lint it
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install Poetry
+        run: pipx install poetry==2.4.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Run schema pattern linter (report to job summary)
+        run: |
+          poetry run python src/scripts/schema_pattern_linting.py \
+            --schema-file src/schema/nmdc.yaml | tee schema_pattern_lint.txt
+          {
+            echo '## schema_pattern_linting report'
+            echo '```'
+            cat schema_pattern_lint.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/schema-pattern-lint.yml
+++ b/.github/workflows/schema-pattern-lint.yml
@@ -46,6 +46,10 @@ jobs:
         run: poetry install
 
       - name: Run schema pattern linter (report to job summary)
+        # Explicit bash so the shell runs with -eo pipefail; otherwise the
+        # default `bash -e {0}` lacks pipefail and `tee` would mask a nonzero
+        # exit from the linter, letting a crash pass as a green report.
+        shell: bash
         run: |
           poetry run python src/scripts/schema_pattern_linting.py \
             --schema-file src/schema/nmdc.yaml | tee schema_pattern_lint.txt

--- a/src/scripts/schema_pattern_linting.py
+++ b/src/scripts/schema_pattern_linting.py
@@ -1,5 +1,6 @@
 import click
 import pprint
+import re
 
 from linkml_runtime import SchemaView
 from linkml_runtime.dumpers import yaml_dumper
@@ -71,6 +72,59 @@ def main(schema_file):
                     subset_usage[subset].append(ev.name)
 
     pprint.pprint(subset_usage)
+    print("\n")
+
+    print("Report of patterns with candidate unescaped literal dots:\n")
+    print("(a bare '.' between word characters, outside character classes; usually a CURIE")
+    print("prefix such as 'insdc.sra:' that should be written '\\.' so it is not a wildcard)\n")
+
+    def has_unescaped_prefix_dot(pattern_string):
+        # Drop character-class spans, where '.' is already a literal.
+        cleaned = re.sub(r'\[[^\]]*\]', '', pattern_string)
+        # A dot flanked by word characters; an escaped dot ('\\.') has a backslash
+        # immediately before it, so the preceding character is not a word character.
+        return re.search(r'[A-Za-z0-9]\.[A-Za-z0-9]', cleaned) is not None
+
+    def patterns_of(slot_definition):
+        found = []
+        if slot_definition.pattern:
+            found.append(slot_definition.pattern)
+        if slot_definition.structured_pattern and slot_definition.structured_pattern.syntax:
+            found.append(slot_definition.structured_pattern.syntax)
+        return found
+
+    seen_patterns = set()
+    for class_name in schema_view.all_classes().keys():
+        for slot in schema_view.class_induced_slots(class_name):
+            for pattern_string in patterns_of(slot):
+                key = (slot.name, pattern_string)
+                if key in seen_patterns:
+                    continue
+                if has_unescaped_prefix_dot(pattern_string):
+                    seen_patterns.add(key)
+                    print(f"slot {slot.name} (in class {class_name}): {pattern_string}")
+    for sk, sv in schema_slots.items():
+        for pattern_string in patterns_of(sv):
+            key = (sk, pattern_string)
+            if key in seen_patterns:
+                continue
+            if has_unescaped_prefix_dot(pattern_string):
+                seen_patterns.add(key)
+                print(f"slot {sk}: {pattern_string}")
+    print("\n")
+
+    print("Report of dangling slot_group references (slot_group value is not a defined slot):\n")
+    all_slot_names = set(schema_view.all_slots().keys())
+    seen_slot_groups = set()
+    for class_name in schema_view.all_classes().keys():
+        for slot in schema_view.class_induced_slots(class_name):
+            if slot.slot_group and slot.slot_group not in all_slot_names:
+                key = (class_name, slot.name, slot.slot_group)
+                if key in seen_slot_groups:
+                    continue
+                seen_slot_groups.add(key)
+                print(f"class {class_name}, slot {slot.name}: slot_group '{slot.slot_group}' is not a defined slot")
+    print("\n")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Makes the schema-element checks in `src/scripts/schema_pattern_linting.py` run continuously in CI, and extends them.

Script additions:
- **Candidate unescaped literal dots in patterns.** Flags `pattern` / `structured_pattern` regexes with a bare `.` between word characters outside a character class, the wildcard-instead-of-literal bug that #3200 fixes (for example `insdc.sra:` also matching `insdcXsra:`). Covers global slots and class-induced slots, so `slot_usage` overrides like `gene_function_id` are checked.
- **Dangling slot_group references.** Flags slots whose `slot_group` value is not a defined slot, the gap noted in #3029. The existing orphan-slot, orphan-enum, subset-usage, and whitespace-name reports are unchanged.

CI:
- New workflow `schema-pattern-lint.yml` runs the linter on every PR and push to `main` and posts the report to the job summary. Report-only: the step fails only if the script itself errors, not on findings, because there is an existing orphan backlog (#2691, #2297, #2298) and the unescaped-dot fixes are still in #3200. Converting individual checks to blocking gates is the follow-up.

Addresses #3202 (continuous run + slot_groups) and the detection half of #3193.

Note: the committed snapshot `assets/schema_pattern_linting.txt` is not regenerated here; its new sections appear on the next `make assets/schema_pattern_linting.txt`. The CI job is the live surface.
