### PR TITLE
Make yq download architechure-aware and version-pinned

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get update && \
 
 # Download and install yq.
 # Reference: https://github.com/mikefarah/yq#install
-RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq && \
+RUN ARCH="$(dpkg --print-architecture)" && \
+    wget "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_${ARCH}" -O /usr/bin/yq && \
     chmod +x /usr/bin/yq
 
 # Install Poetry, a package manager for Python (an alternative to pip).


### PR DESCRIPTION
On Apple Silicon the build container is arm64, so the hardcoded `yq_linux_amd64` ran only under emulation. This fetches the architecture-matching binary via `dpkg --print-architecture` and pins the release (v4.53.3, what `latest` resolved to during testing) so the build no longer depends on emulation being available or on `latest` drifting.

Closes #3207.