### PR TITLE
Align Docker image with CI: Python 3.12 and poetry==2.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.12
 
 WORKDIR /nmdc-schema
 
@@ -12,7 +12,7 @@ RUN wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
     chmod +x /usr/bin/yq
 
 # Install Poetry, a package manager for Python (an alternative to pip).
-RUN pip install "poetry>=2.3.0"
+RUN pip install "poetry==2.4.1"
 
 # Install the project's Python dependencies.
 ADD ./poetry.lock    /nmdc-schema/poetry.lock


### PR DESCRIPTION
The Docker build generates release artifacts under Python 3.10 and a floating `poetry>=2.3.0`, while the `pypi-publish` workflow that actually publishes uses Python 3.12 and `poetry==2.4.1`. This aligns the image with CI so the documented build path matches the publish path. A test build under 3.10 produced artifacts content-identical to the committed ones (only the generation timestamp differed), so this is consistency hygiene rather than a correctness fix.

- #3206.