### PR TITLE
Add no-op migrators for the 11.20.x patch series

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_20_0_to_11_20_1.py
+++ b/nmdc_schema/migrators/migrator_from_11_20_0_to_11_20_1.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: Since this migrator was created retroactively, we can include a link to the release notes as evidence that
+          no migration is necessary. Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.20.1
+    """
+
+    _from_version = "11.20.0"
+    _to_version = "11.20.1"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_20_1_to_11_20_2.py
+++ b/nmdc_schema/migrators/migrator_from_11_20_1_to_11_20_2.py
@@ -1,0 +1,17 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: Since this migrator was created retroactively, we can include a link to the release notes as evidence that
+          no migration is necessary. Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.20.2
+    """
+
+    _from_version = "11.20.1"
+    _to_version = "11.20.2"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass

--- a/nmdc_schema/migrators/migrator_from_11_20_2_to_11_20_3.py
+++ b/nmdc_schema/migrators/migrator_from_11_20_2_to_11_20_3.py
@@ -1,0 +1,19 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""
+    Migrates a database between two schemas.
+
+    Note: No migration is necessary. The 11.20.2 to 11.20.3 schema changes are purely additive: new
+          library-preparation slots and enums, plus a DataObject rule whose precondition is a new
+          data_object_type value, so no data valid under 11.20.2 becomes invalid under 11.20.3.
+          Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.20.3
+    """
+
+    _from_version = "11.20.2"
+    _to_version = "11.20.3"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""No upgrade needed."""
+        pass


### PR DESCRIPTION
The migrator chain stops at `migrator_from_11_19_1_to_11_20_0`. The 11.20.1 and 11.20.2 releases shipped schema changes without migrators, so the chain is broken across the 11.20.x patch series. This adds the three missing no-op migrators (11.20.0 to 11.20.1, 11.20.1 to 11.20.2, 11.20.2 to 11.20.3) to restore continuity, including the one needed for the upcoming 11.20.3 release.

All three increments are additive: new slots, new enums, new optional slots on LibraryPreparation, and one DataObject rule whose precondition is a new data_object_type value. No constraint on an already-released slot was tightened (checked added and removed constraint lines across all three diffs), so no data valid under the earlier schema becomes invalid. That is why each migrator is a no-op.

cc: @eecavanna 