### PR TITLE
Retarget the post-11.20.2 no-op migrator to 11.21.0

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_20_2_to_11_21_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_20_2_to_11_21_0.py
@@ -5,14 +5,14 @@ class Migrator(MigratorBase):
     r"""
     Migrates a database between two schemas.
 
-    Note: No migration is necessary. The 11.20.2 to 11.20.3 schema changes are purely additive: new
+    Note: No migration is necessary. The 11.20.2 to 11.21.0 schema changes are purely additive: new
           library-preparation slots and enums, plus a DataObject rule whose precondition is a new
-          data_object_type value, so no data valid under 11.20.2 becomes invalid under 11.20.3.
-          Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.20.3
+          data_object_type value, so no data valid under 11.20.2 becomes invalid under 11.21.0.
+          Release notes: https://github.com/microbiomedata/nmdc-schema/releases/tag/v11.21.0
     """
 
     _from_version = "11.20.2"
-    _to_version = "11.20.3"
+    _to_version = "11.21.0"
 
     def upgrade(self, commit_changes: bool = False) -> None:
         r"""No upgrade needed."""


### PR DESCRIPTION
The next release is a minor bump to **11.21.0**, not a patch (11.20.3), because it adds new modeling (library-preparation slots and enums in #3214, plus a conditional DataObject rule in #3215).

#3216 added a no-op migrator named `migrator_from_11_20_2_to_11_20_3`. This renames it to `migrator_from_11_20_2_to_11_21_0` and sets `_to_version = "11.21.0"` so the chain link matches the version that will actually be released. The two backfill migrators (11.20.0 to 11.20.1, 11.20.1 to 11.20.2) are unchanged.

Still a no-op: every change from 11.20.2 to 11.21.0 is additive, so no data valid under 11.20.2 becomes invalid. Should merge before the v11.21.0 release so no phantom 11.20.3 migrator remains on main.

sorry about that, @eecavanna 