### PR TITLE
Update `adapters` regex pattern to allow for multiple `ATCG` characters

### DIFF
--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -7173,7 +7173,7 @@ slots:
       - value: AATGATACGGCGACCACCGAGATCTACACGCT;CAAGCAGAAGACGGCATACGAGAT
     slot_uri: MIXS:0000048
     structured_pattern:
-      syntax: ^{dna_bases};{dna_bases}$
+      syntax: ^{dna_bases}+;{dna_bases}+$
       interpolated: true
       partial_match: true
   samp_collec_device:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -157,7 +157,7 @@ settings:
   boolean: '(?:yes|no)'  # a non-capturing group matching either 'yes' or 'no'
   country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   date_time_stamp: '(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d)(:([0-5]\d))?(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?'  # ISO 8601 timestamp; seconds optional; alias of 'timestamp'
-  dna_bases: '[ACGT]+'
+  dna_bases: '[ACGT]'
   DOI: 'doi:10\.\d{2,9}/.*'
   duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
   float: '[-+]?[0-9]*\.?[0-9]+'

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -157,7 +157,7 @@ settings:
   boolean: '(?:yes|no)'  # a non-capturing group matching either 'yes' or 'no'
   country: ([^\s-]{1,2}|[^\s-]+.+[^\s-]+)
   date_time_stamp: '(\d{4})(-(0[1-9]|1[0-2])(-(0[1-9]|[12]\d|3[01])(T([01]\d|2[0-3]):([0-5]\d)(:([0-5]\d))?(\.\d+)?(Z|([+-][01]\d:[0-5]\d))?)?)?)?'  # ISO 8601 timestamp; seconds optional; alias of 'timestamp'
-  dna_bases: '[ACGT]'
+  dna_bases: '[ACGT]+'
   DOI: 'doi:10\.\d{2,9}/.*'
   duration: P(?:(?:\d+D|\d+M(?:\d+D)?|\d+Y(?:\d+M(?:\d+D)?)?)(?:T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S))?|T(?:\d+H(?:\d+M(?:\d+S)?)?|\d+M(?:\d+S)?|\d+S)|\d+W)
   float: '[-+]?[0-9]*\.?[0-9]+'


### PR DESCRIPTION
On this branch, I changed a regex pattern used for the `adapters` slot so that the slot's example value matches the pattern (previously, it did not). Fixes #3222

I opted to edit the pattern at the **slot** level instead of editing the shared `dna_bases` pattern because a different slot (one named `pcr_adapters`) also uses that shared pattern, and I didn't want to affect that slot. That slot's example value also doesn't match the pattern, but it _still_ wouldn't, even if I updated the shared `dna_bases` pattern to accept multiple consecutive `ATCG` characters, since the example value uses letters beyond `ATCG`. I have filed a ticket about that, here: #3224 

Finally, naming the shared pattern `...bases` but having it only match a single base (character) is counterintuitive to me. I recommend either naming it `...base` or updating the pattern so it does match multiple bases (characters). I had originally updated the pattern (see first commit on this branch, reverted by the second commit on this branch), but then realized the `pcr_adapters` slot's example value would _still_ not match it, so opted to make a narrower change and leave the `pcr_adapters` slot alone.