### PR TITLE
Replace email address with URL of web page containing email address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in this project, please report it respo
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please [email the NMDC team](https://microbiomedata.org/contact/) so they can review it privately.
+Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please email your report to [the NMDC team](https://microbiomedata.org/contact/) so they can review it privately.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ If you discover a security vulnerability in this project, please report it respo
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please email your report to [support@microbiomedata.org](mailto:support@microbiomedata.org) so the maintainers can review it privately.
+Instead, please use [GitHub private vulnerability reporting](https://github.com/microbiomedata/nmdc-schema/security/advisories/new) for this repository. If that is unavailable, please [email the NMDC team](https://microbiomedata.org/contact/) so they can review it privately.
 
 ## Scope
 


### PR DESCRIPTION
On this branch, I replaced an occurrence of an email address with a link to a web page containing that email address (in addition to other contact methods).

Fixes #3158