### PR TITLE
Address Copilot review on #3238 (typos, unique IDs, SRX consistency)

### DIFF
--- a/src/data/valid/Database-danica-16s.yaml
+++ b/src/data/valid/Database-danica-16s.yaml
@@ -1,35 +1,35 @@
 #example record for MicroFlora Danica, MFD04222, SRX23662642
 material_processing_set:
-  - id: nmdc:libprp-99-abc122
+  - id: nmdc:libprp-99-d16s01
     name: Library preparation process for MFD04222
-    description: Amplicion library preparation targeting bacterial 16S genes with 8F and 1391R primers
+    description: Amplicon library preparation targeting bacterial 16S genes with 8F and 1391R primers
     type: nmdc:LibraryPreparation
     has_input:
       - nmdc:bsm-99-123abc
     has_output:
-      - nmdc:procsm-99-2a58f3
+      - nmdc:procsm-99-d16s02
     target_gene: 16S_rRNA
     lib_layout: single
     library_strategy: AMPLICON
     library_selection: PCR
     library_source: METAGENOMIC
 processed_sample_set:
-  - id: nmdc:procsm-99-2a58f3
+  - id: nmdc:procsm-99-d16s02
     name: npumi_16SrRNA_MFD04222
     description: Library for sequencing for MFD04222
     type: nmdc:ProcessedSample
 data_generation_set:
-  - id: nmdc:dgns-11-abc123
+  - id: nmdc:dgns-11-d16s03
     has_input:
-      - nmdc:procsm-99-2a58f3
+      - nmdc:procsm-99-d16s02
     has_output:
-      - nmdc:dobj-99-abc123
-    name: Run SRR28010109 for experiment SRX23627676 - MFD04222
+      - nmdc:dobj-99-d16s04
+    name: Run SRR28010109 for experiment SRX23662642 - MFD04222
     type: nmdc:NucleotideSequencing
     insdc_bioproject_identifiers:
       - bioproject:PRJNA1071982
     insdc_experiment_identifiers:
-      - insdc.sra:SRX23627676
+      - insdc.sra:SRX23662642
     analyte_category: amplicon_sequencing_assay
     instrument_used:
       - nmdc:inst-14-mr4abc
@@ -43,12 +43,12 @@ data_generation_set:
     associated_studies:
       - nmdc:sty-99-ebd802
 data_object_set:
-  - id: nmdc:dobj-99-abc123
+  - id: nmdc:dobj-99-d16s04
     name: Data file for run accession SRR28010109
     description: Data file for run accession SRR28010109
     insdc_run_identifiers:
       - insdc.run:SRR28010109
-    was_generated_by: nmdc:dgns-11-abc123
+    was_generated_by: nmdc:dgns-11-d16s03
     data_category: instrument_data
     data_object_type: SRA toolkit-accessible sequence data
     type: nmdc:DataObject

--- a/src/data/valid/Database-danica-bac-operon.yaml
+++ b/src/data/valid/Database-danica-bac-operon.yaml
@@ -1,28 +1,28 @@
 #example record for MicroFlora Danica, MFD01204, SRX23627676
 material_processing_set:
-  - id: nmdc:libprp-99-abc122
+  - id: nmdc:libprp-99-dbac01
     name: Library preparation process for MFD01204
-    description: Amplicion library preparation targeting bacterial rRNA operons using 8F and 2490R primers
+    description: Amplicon library preparation targeting bacterial rRNA operons using 8F and 2490R primers
     type: nmdc:LibraryPreparation
     has_input:
       - nmdc:bsm-99-123abc
     has_output:
-      - nmdc:procsm-99-2a58f3
+      - nmdc:procsm-99-dbac02
     lib_layout: single
     library_strategy: AMPLICON
     library_selection: PCR
     library_source: METAGENOMIC
 processed_sample_set:
-  - id: nmdc:procsm-99-2a58f3
+  - id: nmdc:procsm-99-dbac02
     name: pb_bacoperon_MFD01204
     description: Library for sequencing for MFD01204
     type: nmdc:ProcessedSample
 data_generation_set:
-  - id: nmdc:dgns-11-abc123
+  - id: nmdc:dgns-11-dbac03
     has_input:
-      - nmdc:procsm-99-2a58f3
+      - nmdc:procsm-99-dbac02
     has_output:
-      - nmdc:dobj-99-abc123
+      - nmdc:dobj-99-dbac04
     name: Run SRR27974041 for experiment SRX23627676 - MFD01204
     type: nmdc:NucleotideSequencing
     insdc_bioproject_identifiers:
@@ -42,12 +42,12 @@ data_generation_set:
     associated_studies:
       - nmdc:sty-99-ebd802
 data_object_set:
-  - id: nmdc:dobj-99-abc123
+  - id: nmdc:dobj-99-dbac04
     name: Data file for run accession SRR27974041
     description: Data file for run accession SRR27974041
     insdc_run_identifiers:
       - insdc.run:SRR27974041
-    was_generated_by: nmdc:dgns-11-abc123
+    was_generated_by: nmdc:dgns-11-dbac03
     data_category: instrument_data
     data_object_type: SRA toolkit-accessible sequence data
     type: nmdc:DataObject

--- a/src/data/valid/Database-danica-euk-operon.yaml
+++ b/src/data/valid/Database-danica-euk-operon.yaml
@@ -1,28 +1,28 @@
 #example record for MicroFlora Danica, MFD01204, SRX23627677
 material_processing_set:
-  - id: nmdc:libprp-99-abc122
+  - id: nmdc:libprp-99-deuk01
     name: Library preparation process for MFD01204
-    description: Amplicion library preparation targeting eukaryotic rRNA operons using 3NDF and 21R primers
+    description: Amplicon library preparation targeting eukaryotic rRNA operons using 3NDF and 21R primers
     type: nmdc:LibraryPreparation
     has_input:
       - nmdc:bsm-99-123abc
     has_output:
-      - nmdc:procsm-99-2a58f3
+      - nmdc:procsm-99-deuk02
     lib_layout: single
     library_strategy: AMPLICON
     library_selection: PCR
     library_source: METAGENOMIC
 processed_sample_set:
-  - id: nmdc:procsm-99-2a58f3
+  - id: nmdc:procsm-99-deuk02
     name: pb_eukoperon_MFD01204
     description: Library for sequencing for MFD01204
     type: nmdc:ProcessedSample
 data_generation_set:
-  - id: nmdc:dgns-11-abc123
+  - id: nmdc:dgns-11-deuk03
     has_input:
-      - nmdc:procsm-99-2a58f3
+      - nmdc:procsm-99-deuk02
     has_output:
-      - nmdc:dobj-99-abc123
+      - nmdc:dobj-99-deuk04
     name: Run SRR27974040 for experiment SRX23627677 - MFD01204
     type: nmdc:NucleotideSequencing
     insdc_bioproject_identifiers:
@@ -42,12 +42,12 @@ data_generation_set:
     associated_studies:
       - nmdc:sty-99-ebd802
 data_object_set:
-  - id: nmdc:dobj-99-abc123
+  - id: nmdc:dobj-99-deuk04
     name: Data file for run accession SRR27974040
-    description: Data file for run accession SRR27974040  
+    description: Data file for run accession SRR27974040
     insdc_run_identifiers:
       - insdc.run:SRR27974040
-    was_generated_by: nmdc:dgns-11-abc123
+    was_generated_by: nmdc:dgns-11-deuk03
     data_category: instrument_data
     data_object_type: SRA toolkit-accessible sequence data
     type: nmdc:DataObject


### PR DESCRIPTION
Addresses the seven Copilot review comments on 
- #3238

Targets this PR's own branch (`danica_amplicon_operon_example`) so #3238 keeps its history and authorship.

- **Typo:** "Amplicion" to "Amplicon" in all three descriptions.
- **Duplicate IDs:** the three files shared identical object IDs (`libprp-99-abc122`, `procsm-99-2a58f3`, `dgns-11-abc123`, `dobj-99-abc123`) with each other and with `Database-SAMN39871635_example.yaml`. `interleave_yaml.py` errors out when entities with shared `id`s aren't identical overall . Each file's defined objects now have unique IDs (`d16s*` / `dbac*` / `deuk*`) with in-file references updated.
- **SRX consistency (16s file):** the run name and `insdc_experiment_identifiers` said `SRX23627676`, but that accession belongs to the bac-operon run `SRR27974041`. Corrected to `SRX23662642`, the experiment for run `SRR28010109` / sample `MFD04222`. Verified against the SRA metadata mirror; it also matches the file's own header comment.

Shared reference-only IDs (`bsm-99-123abc`, `sty-99-ebd802`, `inst-14-*`) are left as is: they are not defined objects in these files, so they do not trip the dedup check.

Verified locally: all three validate as `Database` against a freshly materialized schema, and `interleave_yaml.py` now reports no duplicate IDs with the danica objects present in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)