### PR TITLE
Fix false broad/narrow mapping direction (use related_mappings)

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -258,7 +258,7 @@ slots:
         description: The DOI links to an electronic document.
     exact_mappings:
       - OBI:0002110
-    narrow_mappings:
+    related_mappings:
       - edam.data:1188
 
   doi_provider:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1746,25 +1746,25 @@ slots:
     description: Number of 16s sequences detected, a subunit of prokaryotic ribosomes.
     range: integer
     minimum_value: 0
-    broad_mappings:
+    related_mappings:
       - OMIT:0013243
   num_5s:
     description: Number of 5s seqeuences detected, a subunit of ribosomes.
     range: integer
     minimum_value: 0
-    broad_mappings:
+    related_mappings:
       - OMIT:0013248
   num_23s:
     description: Number of 23 seqeuences detected, a subunit of ribosomes.
     minimum_value: 0
     range: integer
-    broad_mappings:
+    related_mappings:
       - OMIT:0013245
   num_t_rna:
     description: Number of transfer transfer RNAs.
     minimum_value: 0
     range: integer
-    broad_mappings:
+    related_mappings:
       - OMIT:0013250
   gtdbtk_domain:
     description: Taxonomic domain assigned by GTDB-Tk.

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1743,25 +1743,25 @@ slots:
     description: The quality of the metagenome-assembled genome based on MIMAG standards (https://doi.org/10.1038/nbt.3893).
     range: BinQualityEnum
   num_16s:
-    description: Number of 16s sequences detected, a subunit of prokaryotic ribosomes.
+    description: Number of 16S sequences detected, a subunit of prokaryotic ribosomes.
     range: integer
     minimum_value: 0
     related_mappings:
       - OMIT:0013243
   num_5s:
-    description: Number of 5s seqeuences detected, a subunit of ribosomes.
+    description: Number of 5S sequences detected, a subunit of ribosomes.
     range: integer
     minimum_value: 0
     related_mappings:
       - OMIT:0013248
   num_23s:
-    description: Number of 23 seqeuences detected, a subunit of ribosomes.
+    description: Number of 23S sequences detected, a subunit of ribosomes.
     minimum_value: 0
     range: integer
     related_mappings:
       - OMIT:0013245
   num_t_rna:
-    description: Number of transfer transfer RNAs.
+    description: Number of transfer RNAs.
     minimum_value: 0
     range: integer
     related_mappings:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -1373,7 +1373,7 @@ slots:
       - sample weight
     exact_mappings:
       - MS:1000004
-    broad_mappings:
+    related_mappings:
       - MIXS:0000111
     range: QuantityValue
     annotations:


### PR DESCRIPTION
First batch from #3250: fix six slot mappings whose `broad`/`narrow` direction asserts a subsumption that does not hold.

Per SKOS (now documented in `CLAUDE.md`), `broad_mappings` means the target subsumes the slot and `narrow_mappings` means the slot subsumes the target. Neither holds here:

- `num_16s` / `num_5s` / `num_23s` / `num_t_rna` `broad_mappings` → OMIT rRNA/tRNA molecules: a **count** of sequences is not subsumed by the molecule it counts.
- `input_mass` `broad_mappings` → `MIXS:0000111` (dna): a sample mass is not subsumed by a dna property.
- `doi_value` `narrow_mappings` → `edam.data:1188` (DOI): inverted; DOI is not narrower than the slot.

All six become `related_mappings`, which records the associative link without the false subsumption/inversion.

Scope: this PR only removes the demonstrably wrong **direction**. The deeper slot→class type mismatches (these targets are classes; ~27 exist repo-wide) are left for owner review under #3250. Docs-adjacent only; no generated artifacts committed.

Refs #3250
