### PR TITLE
Standardize QUDT prefix (qud to qudt)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,8 @@ Use typed subtypes (`exact_mappings`, `close_mappings`, `broad_mappings`,
 `narrow_mappings`, `related_mappings`) in preference to generic `mappings`.
 
 **Exception — keep `mappings` (generic) for:** schema.org properties
-(`schema:QuantityValue`, `schema:latitude`, etc.), QUDT (`qud:unit`,
-`qud:quantityValue`), and `prov:wasGeneratedBy`. These are
+(`schema:QuantityValue`, `schema:latitude`, etc.), QUDT (`qudt:unit`,
+`qudt:quantityValue`), and `prov:wasGeneratedBy`. These are
 *property-to-property* alignments where SKOS directional semantics
 (broader/narrower) don't apply. Do not "fix" these to `exact_mappings`.
 

--- a/src/schema/attribute_values.yaml
+++ b/src/schema/attribute_values.yaml
@@ -247,7 +247,7 @@ slots:
     aliases:
       - scale
     mappings:
-      - qud:unit
+      - qudt:unit
       - schema:unitCode
     range: string
 
@@ -277,7 +277,7 @@ slots:
     description: Links a quantity value to a number
     range: decimal
     mappings:
-      - qud:quantityValue
+      - qudt:quantityValue
       - schema:value
 
   has_minimum_numeric_value:
@@ -411,7 +411,7 @@ enums:
         exact_mappings:
           - UO:0000027
           - wikidata:Q25267
-          - qud:DEG_C
+          - qudt:DEG_C
           - OM:degreeCelsius
       cm:
         description: The Unified Code for Units of Measure (UCUM) representation of centimeter.

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -19,7 +19,7 @@ prefixes:
   linkml: "https://w3id.org/linkml/"
   nmdc: "https://w3id.org/nmdc/"
   prov: "http://www.w3.org/ns/prov#" # for startedAtTime, endedAtTime, Association, Activity, wasInformedBy, wasGeneratedBy, qualifiedAssociation
-  qud: "http://qudt.org/1.1/schema/qudt#"
+  qudt: "http://qudt.org/1.1/schema/qudt#"
   rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   ror: 'https://bioregistry.io/ror:' # https://ror.org/
   schema: "http://schema.org/"

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -33,7 +33,7 @@ prefixes:
   gtpo: "http://example.org/gtpo/"
   linkml: "https://w3id.org/linkml/"
   nmdc: "https://w3id.org/nmdc/"
-  qud: "http://qudt.org/1.1/schema/qudt#"
+  qudt: "http://qudt.org/1.1/schema/qudt#"
   rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   schema: "http://schema.org/"
   wgs84: "http://www.w3.org/2003/01/geo/wgs84_pos#"

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -104,7 +104,7 @@ prefixes:
   nmdc: "https://w3id.org/nmdc/"
   owl: "http://www.w3.org/2002/07/owl#"
   prov: "http://www.w3.org/ns/prov#" # for startedAtTime, endedAtTime, Association, Activity, wasInformedBy, wasGeneratedBy, qualifiedAssociation
-  qud: "http://qudt.org/1.1/schema/qudt#"
+  qudt: "http://qudt.org/1.1/schema/qudt#"
   rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   rdfs: "http://www.w3.org/2000/01/rdf-schema#"
   ror: 'https://bioregistry.io/ror:' # https://ror.org/

--- a/src/schema/nmdc_types.yaml
+++ b/src/schema/nmdc_types.yaml
@@ -8,7 +8,7 @@ license: https://creativecommons.org/publicdomain/zero/1.0/
 prefixes:
   UO: "http://purl.obolibrary.org/obo/UO_"
   linkml: "https://w3id.org/linkml/"
-  qud: "http://qudt.org/1.1/schema/qudt#"
+  qudt: "http://qudt.org/1.1/schema/qudt#"
 
 
 imports:


### PR DESCRIPTION
## Why

The schema declared the prefix `qud` for QUDT and used `qud:` in three mapping CURIEs, but the `description` prose already used the community-standard `qudt:` (for example `qudt:QuantityKind`), and [bioregistry](https://bioregistry.io/qudt) records `qudt` as the preferred prefix. That left the schema internally inconsistent (`qud` in declarations and CURIEs, `qudt` in prose) and externally non-standard on the prefix name.

This renames the prefix token `qud` to `qudt` in the four prefix declarations, the three mapping CURIEs (`qudt:unit`, `qudt:quantityValue`, `qudt:DEG_C`), and CLAUDE.md.

## Scope: prefix name only

The namespace URI is unchanged (`http://qudt.org/1.1/schema/qudt#`), so no CURIE changes what it resolves to. This is deliberately a pure rename.

The namespace-URI modernization and per-term IRI correctness are a separate topic, tracked in https://github.com/microbiomedata/nmdc-schema/issues/3260 (QUDT prefix: schema uses non-standard `qud` + deprecated 1.1 namespace). Verification for that follow-up found two things worth a real decision: QUDT's own current schema namespace uses a slash (`http://qudt.org/schema/qudt/`), which conflicts with bioregistry's hash form; and `DEG_C` is canonically `http://qudt.org/vocab/unit/DEG_C` (the QUDT unit vocabulary), not the schema namespace. Those are kept out of this PR.

## Verification

`SchemaView("src/schema/nmdc.yaml")` loads (80 classes, 874 slots); `qudt` resolves to the declared namespace, `qud` is gone, and the three CURIEs expand. Generated `nmdc_schema/` artifacts are intentionally not included; they are regenerated at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)