### PR TITLE
Remove inline example from sample storage temperature description

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -52,6 +52,9 @@
 'del(.slots.plant_growth_med.annotations)'
 '.slots.plant_struc.description |= "Name of plant structure the sample was obtained from; for Plant Ontology (PO) terms, see http://obofoundry.org/ontology/po.html, e.g. petiole epidermis (PO:0000051). If an individual flower is sampled, the sex of it can be recorded here."'
 
+# Keep samp_store_temp's concrete value in examples, not in its description (#2466)
+'.slots.samp_store_temp.description = "Temperature at which the sample was stored."'
+
 '.slots.env_broad_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_local_scale.is_a |= "mixs_env_triad_field"'
 '.slots.env_medium.is_a |= "mixs_env_triad_field"'


### PR DESCRIPTION
## Summary

- add a durable MIxS customization for `samp_store_temp` that keeps its description definition-only
- retain `-80 Cel` in the slot’s structured `examples` field
- leave generated `src/schema/mixs.yaml` untouched, following the repository’s current generated-schema policy

Closes #2466

## Verification

Applied the exact new expression from `assets/yq-for-mixs-customizations.txt` to a local copy of the current generated schema with yq 4.53.3, then asserted:

- description: `Temperature at which the sample was stored.`
- first example: `-80 Cel`
- `git diff --check`