### PR TITLE
Point contributors to the current prod Mongo tunnel doc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@
 BIOPORTAL_API_KEY=
 
 # --- MongoDB data dump (nmdc_schema/dump_single_modality.py:277-278) ---
-# For direct MongoDB access. Open an SSH tunnel to the source if needed.
+# For direct MongoDB access. Open an SSH tunnel to the source first.
+# Prod NMDC Mongo tunnel setup (prerequisites and steps, no secret values):
+# https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/mongodb-connection.md
 SOURCE_MONGO_USER=
 SOURCE_MONGO_PASS=

--- a/assets/misc/legacy_migration_notes.md
+++ b/assets/misc/legacy_migration_notes.md
@@ -1,3 +1,10 @@
+> **Superseded.** These notes describe the retired NERSC/SPIN tunnel
+> (`dtn01.nersc.gov` to `mongo-loadbalancer.nmdc.production.svc.spin.nersc.org`),
+> which no longer exists. For current production Mongo access through the
+> `jump-dev.microbiomedata.org` gateway, see
+> https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/mongodb-connection.md
+> Kept for historical reference.
+
 1. Learn about the NERSC sshproxy app, which generates 24-hour password-less keys:  https://www.nersc.gov/assets/Uploads/Using-sshproxy.pdf
 2. Download the NERSC's `sshproxy` app with the `scp` command on page 5 of the PDF. One caveat: the documentation recommends getting the app from `cori.nersc.gov`, which has been retired. So use `perlmutter.nersc.gov` or  `dtn01.nersc.gov`.
 3. Create a NERSC ssh key with the `sshproxy` command that was just downloaded. Use the `-u` option unless your NERSC username is identical to your local username. For examples, my local username is "XYZ" but my NERSC username is "xyz", so I enter `.sshproxy -u xyz`

--- a/nmdc_schema/dump_single_modality.py
+++ b/nmdc_schema/dump_single_modality.py
@@ -259,7 +259,9 @@ def dump_from_api(ctx, client_base_url, endpoint_prefix, page_size):
 @click.option('--mongo-db-name', default="nmdc", show_default=True, help='MongoDB database name')
 @click.option('--mongo-host', default="localhost", show_default=True,
               help='MongoDB host name/address.')
-@click.option('--mongo-port', default=27777, type=int, show_default=True, help='MongoDB port')
+@click.option('--mongo-port', default=27124, type=int, show_default=True,
+              help='MongoDB port. 27124 matches the jump-dev tunnel doc: '
+                   'https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/mongodb-connection.md')
 @click.option('--admin-db', default=None, help='MongoDB authentication source. Leave blank to not specify.')
 @click.option('--auth-mechanism', default=None, show_default=True,
               help='Authentication mechanism for MongoDB connection. Leave blank to not specify.')


### PR DESCRIPTION
Reaching production NMDC Mongo (to test migrators, verify data questions like #3259, etc.) goes through the jump-dev gateway, documented in `microbiomedata/nmdc-lakehouse/docs/mongodb-connection.md`. Nothing in this repo pointed there, and two things still referenced the retired NERSC/SPIN tunnel, so anyone following them would hit a host or port that no longer applies.

- `.env.example`: added a pointer to the lakehouse doc next to `SOURCE_MONGO_USER`/`SOURCE_MONGO_PASS`.
- `assets/misc/legacy_migration_notes.md`: marked the old recipe superseded, with a link to the current one. Kept for historical reference.
- `nmdc_schema/dump_single_modality.py`: changed the `--mongo-port` default from the retired SPIN port (27777) to the current tunnel port (27124), so the docs, the example env, and the tool all agree on one value.

No secrets are referenced, only variable names and the public doc URL.