### PR TITLE
Remove redundant inline examples from MIxS slot descriptions

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -587,20 +587,23 @@
 'del(.slots.host_body_product.examples)'
 '.slots.host_body_product.examples.[0].value = "mucus [UBERON:0000912]"'
 
-# Relocate misplaced example values out of descriptions into the examples metaslot.
-# Scoped to TextValue name/label slots; see CONTRIBUTING.md "Put example values in the
-# examples metaslot, not in prose". Measurement/QuantityValue slots are deliberately
-# excluded here: their example handling belongs with the units work (issue #2950).
-'.slots.field.description |= "Name of the hydrocarbon field"'
-'.slots.field.examples = [{"value": "Albacora"}]'
-'.slots.reservoir.description |= "Name of the reservoir"'
-'.slots.reservoir.examples = [{"value": "Carapebus"}]'
-'.slots.samp_well_name.description |= "Name of the well where sample was taken"'
-'.slots.samp_well_name.examples = [{"value": "BXA1123"}]'
-# examples already present; strip only the redundant inline value from the description
+# Remove redundant inline examples from MIxS slot descriptions: the value is already
+# carried in the slot's examples metaslot, so the copy in the prose is a duplicate.
+# See CONTRIBUTING.md "Put example values in the examples metaslot, not in prose".
+# This block ONLY strips duplicate text from descriptions; it adds no examples and
+# changes no example types, so it does not touch the range/type audit (issue #2950).
+# Deferred to #2950: adding examples to slots that lack them (field, reservoir,
+# samp_well_name), retyping scalar examples to match wrapper-class ranges, and slots
+# whose inline value disagrees with the example (iwf, root_med_ph, root_med_regl,
+# samp_transport_cond).
 '.slots.basin.description |= "Name of the basin"'
 '.slots.root_med_carbon.description |= "Source of organic carbon in the culture rooting medium"'
 '.slots.root_med_solid.description |= "Specification of the solidifying agent in the culture rooting medium"'
+'.slots.samp_store_temp.description |= "Temperature at which sample was stored"'
+'.slots.api.description |= "API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity)"'
+'.slots.root_med_macronutr.description |= "Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S)"'
+'.slots.root_med_micronutr.description |= "Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo)"'
+'.slots.root_med_suppl.description |= "Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal"'
 
 # Remove upstream `.types` to avoid URI collisions with LinkML built-in/core types
 # during schema generation (for example, duplicate definitions of `date`).

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -587,6 +587,21 @@
 'del(.slots.host_body_product.examples)'
 '.slots.host_body_product.examples.[0].value = "mucus [UBERON:0000912]"'
 
+# Relocate misplaced example values out of descriptions into the examples metaslot.
+# Scoped to TextValue name/label slots; see CONTRIBUTING.md "Put example values in the
+# examples metaslot, not in prose". Measurement/QuantityValue slots are deliberately
+# excluded here: their example handling belongs with the units work (issue #2950).
+'.slots.field.description |= "Name of the hydrocarbon field"'
+'.slots.field.examples = [{"value": "Albacora"}]'
+'.slots.reservoir.description |= "Name of the reservoir"'
+'.slots.reservoir.examples = [{"value": "Carapebus"}]'
+'.slots.samp_well_name.description |= "Name of the well where sample was taken"'
+'.slots.samp_well_name.examples = [{"value": "BXA1123"}]'
+# examples already present; strip only the redundant inline value from the description
+'.slots.basin.description |= "Name of the basin"'
+'.slots.root_med_carbon.description |= "Source of organic carbon in the culture rooting medium"'
+'.slots.root_med_solid.description |= "Specification of the solidifying agent in the culture rooting medium"'
+
 # Remove upstream `.types` to avoid URI collisions with LinkML built-in/core types
 # during schema generation (for example, duplicate definitions of `date`).
 # This is an intentional compatibility normalization so generated projects use

--- a/src/doc-templates/common_metadata.md.jinja2
+++ b/src/doc-templates/common_metadata.md.jinja2
@@ -8,10 +8,10 @@
 
 {% if element.examples %}
 ## Examples
-| Value |
-| --- |
+| Example | Description |
+| --- | --- |
 {% for x in element.examples -%}
-| {{ x.value }} |
+| {% if x.value is not none %}{{ x.value }}{% elif x.object is not none %}{% if x.object is iterable and x.object is not string %}{% set ns = namespace(sep='') %}{% for k in x.object %}{% if k|string|first != '_' %}{{ ns.sep }}{{ k }}: {{ x.object[k] }}{% set ns.sep = '; ' %}{% endif %}{% endfor %}{% else %}{{ x.object }}{% endif %}{% endif %} | {% if x.description is not none %}{{ x.description }}{% endif %} |
 {% endfor %}
 {% endif -%}
 

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1317,7 +1317,7 @@ slots:
     annotations:
       Preferred_unit: degrees API
       units_alignment_excuse: non_ucum_unit
-    description: 'API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g. 31.1   API)'
+    description: 'API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity)'
     title: API gravity
     examples:
       - value: 31.1 API
@@ -2684,13 +2684,11 @@ slots:
     range: TextValue
     inlined_as_list: true
   field:
-    description: Name of the hydrocarbon field
+    description: Name of the hydrocarbon field (e.g. Albacora)
     title: field name
     slot_uri: MIXS:0000291
     range: TextValue
     recommended: true
-    examples:
-      - value: Albacora
   filter_type:
     description: A device which removes solid particulates or airborne molecular contaminants
     title: filter type
@@ -4834,13 +4832,11 @@ slots:
     slot_uri: MIXS:0000821
     range: RelSampLocEnum
   reservoir:
-    description: Name of the reservoir
+    description: Name of the reservoir (e.g. Carapebus)
     title: reservoir name
     slot_uri: MIXS:0000303
     range: TextValue
     recommended: true
-    examples:
-      - value: Carapebus
   resins_pc:
     annotations:
       Preferred_unit: percent
@@ -5089,7 +5085,7 @@ slots:
     annotations:
       Expected_value: macronutrient name;measurement value
       Preferred_unit: milligram per liter
-    description: Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
+    description: Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S)
     title: rooting medium macronutrients
     examples:
       - value: KH2PO4;170  milligram per liter
@@ -5102,7 +5098,7 @@ slots:
     annotations:
       Expected_value: micronutrient name;measurement value
       Preferred_unit: milligram per liter
-    description: Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
+    description: Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo)
     title: rooting medium micronutrients
     examples:
       - value: H3BO3;6.2  milligram per liter
@@ -5144,7 +5140,7 @@ slots:
     annotations:
       Expected_value: supplement name;measurement value
       Preferred_unit: milligram per liter
-    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid (0.5  mg/L)
+    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal
     title: rooting medium organic supplements
     examples:
       - value: nicotinic acid;0.5 milligram per liter
@@ -5358,7 +5354,7 @@ slots:
     annotations:
       Preferred_unit: degree Celsius
       storage_units: Cel
-    description: Temperature at which sample was stored, e.g. -80 degree Celsius
+    description: Temperature at which sample was stored
     title: sample storage temperature
     examples:
       - value: -80 Cel
@@ -5481,15 +5477,13 @@ slots:
     slot_uri: MIXS:0000827
     range: SampWeatherEnum
   samp_well_name:
-    description: Name of the well where sample was taken
+    description: Name of the well (e.g. BXA1123) where sample was taken
     title: sample well name
     keywords:
       - sample
     slot_uri: MIXS:0000296
     range: TextValue
     recommended: true
-    examples:
-      - value: BXA1123
   saturates_pc:
     annotations:
       Preferred_unit: percent

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1473,7 +1473,7 @@ slots:
       interpolated: true
       partial_match: true
   basin:
-    description: Name of the basin (e.g. Campos)
+    description: Name of the basin
     title: basin name
     examples:
       - value: Campos
@@ -2684,11 +2684,13 @@ slots:
     range: TextValue
     inlined_as_list: true
   field:
-    description: Name of the hydrocarbon field (e.g. Albacora)
+    description: Name of the hydrocarbon field
     title: field name
     slot_uri: MIXS:0000291
     range: TextValue
     recommended: true
+    examples:
+      - value: Albacora
   filter_type:
     description: A device which removes solid particulates or airborne molecular contaminants
     title: filter type
@@ -4832,11 +4834,13 @@ slots:
     slot_uri: MIXS:0000821
     range: RelSampLocEnum
   reservoir:
-    description: Name of the reservoir (e.g. Carapebus)
+    description: Name of the reservoir
     title: reservoir name
     slot_uri: MIXS:0000303
     range: TextValue
     recommended: true
+    examples:
+      - value: Carapebus
   resins_pc:
     annotations:
       Preferred_unit: percent
@@ -5072,7 +5076,7 @@ slots:
     annotations:
       Expected_value: carbon source name;measurement value
       Preferred_unit: milligram per liter
-    description: Source of organic carbon in the culture rooting medium; e.g. sucrose
+    description: Source of organic carbon in the culture rooting medium
     title: rooting medium carbon
     examples:
       - value: sucrose
@@ -5130,7 +5134,7 @@ slots:
     slot_uri: MIXS:0000581
     range: TextValue
   root_med_solid:
-    description: Specification of the solidifying agent in the culture rooting medium; e.g. agar
+    description: Specification of the solidifying agent in the culture rooting medium
     title: rooting medium solidifier
     examples:
       - value: agar
@@ -5477,13 +5481,15 @@ slots:
     slot_uri: MIXS:0000827
     range: SampWeatherEnum
   samp_well_name:
-    description: Name of the well (e.g. BXA1123) where sample was taken
+    description: Name of the well where sample was taken
     title: sample well name
     keywords:
       - sample
     slot_uri: MIXS:0000296
     range: TextValue
     recommended: true
+    examples:
+      - value: BXA1123
   saturates_pc:
     annotations:
       Preferred_unit: percent


### PR DESCRIPTION
## Why

Follows the convention added in #3273 (CONTRIBUTING.md, "Put example values in the `examples` metaslot, not in prose"), applied to MIxS-derived slots. Where a description repeats a value that is already in the slot's `examples`, the copy in the prose is a duplicate and is removed.

## What

Via `assets/yq-for-mixs-customizations.txt` (MIxS slots are changed there, not by hand-editing generated `mixs.yaml`), strip the redundant inline value from eight slot descriptions whose `examples` already carry it:

`basin`, `root_med_carbon`, `root_med_solid`, `samp_store_temp`, `api`, `root_med_macronutr`, `root_med_micronutr`, `root_med_suppl`.

`samp_store_temp` is the slot from the externally-opened, now-closed #3267. `src/schema/mixs.yaml` is regenerated; the MIxS source is pinned (GSC mixs v6.3.0), so the diff is exactly these eight descriptions.

## Deliberately not in scope

This PR **adds no examples and changes no example types**, to stay clear of the range/type audit in #2950. Left for that work:

- Adding examples to slots that only carry the value inline and have no `examples` block (`field`, `reservoir`, `samp_well_name`, and the measurement slots).
- Fixing examples whose value disagrees with the description (`iwf`, `root_med_ph`, `root_med_regl`, `samp_transport_cond`) and the `elev` example (`100 meter` on a `float` range).
- Retyping scalar examples on wrapper-class ranges. Note the roadmap here: `TextValue` is slated to be replaced by plain `string`, and `TimestampValue` by JSON-friendly temporal ranges or rigorously-patterned strings. Their current scalar `value:` examples are therefore already forward-compatible and should not be objectified. The real objectification target is the `QuantityValue` slots (plus a decision on `ControlledTermValue`/`GeolocationValue`).

Draft pending review.