### PR TITLE
Remove redundant inline examples from MIxS slot descriptions

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -587,6 +587,24 @@
 'del(.slots.host_body_product.examples)'
 '.slots.host_body_product.examples.[0].value = "mucus [UBERON:0000912]"'
 
+# Remove redundant inline examples from MIxS slot descriptions: the value is already
+# carried in the slot's examples metaslot, so the copy in the prose is a duplicate.
+# See CONTRIBUTING.md "Put example values in the examples metaslot, not in prose".
+# This block ONLY strips duplicate text from descriptions; it adds no examples and
+# changes no example types, so it does not touch the range/type audit (issue #2950).
+# Deferred to #2950: adding examples to slots that lack them (field, reservoir,
+# samp_well_name), retyping scalar examples to match wrapper-class ranges, and slots
+# whose inline value disagrees with the example (iwf, root_med_ph, root_med_regl,
+# samp_transport_cond).
+'.slots.basin.description |= "Name of the basin"'
+'.slots.root_med_carbon.description |= "Source of organic carbon in the culture rooting medium"'
+'.slots.root_med_solid.description |= "Specification of the solidifying agent in the culture rooting medium"'
+'.slots.samp_store_temp.description |= "Temperature at which sample was stored"'
+'.slots.api.description |= "API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity)"'
+'.slots.root_med_macronutr.description |= "Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S)"'
+'.slots.root_med_micronutr.description |= "Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo)"'
+'.slots.root_med_suppl.description |= "Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal"'
+
 # Remove upstream `.types` to avoid URI collisions with LinkML built-in/core types
 # during schema generation (for example, duplicate definitions of `date`).
 # This is an intentional compatibility normalization so generated projects use

--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -603,7 +603,7 @@
 '.slots.api.description |= "API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity)"'
 '.slots.root_med_macronutr.description |= "Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S)"'
 '.slots.root_med_micronutr.description |= "Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo)"'
-'.slots.root_med_suppl.description |= "Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal"'
+'.slots.root_med_suppl.description |= "Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics, activated charcoal"'
 
 # Remove upstream `.types` to avoid URI collisions with LinkML built-in/core types
 # during schema generation (for example, duplicate definitions of `date`).

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1317,7 +1317,7 @@ slots:
     annotations:
       Preferred_unit: degrees API
       units_alignment_excuse: non_ucum_unit
-    description: 'API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity) (e.g. 31.1   API)'
+    description: 'API gravity is a measure of how heavy or light a petroleum liquid is compared to water (source: https://en.wikipedia.org/wiki/API_gravity)'
     title: API gravity
     examples:
       - value: 31.1 API
@@ -1473,7 +1473,7 @@ slots:
       interpolated: true
       partial_match: true
   basin:
-    description: Name of the basin (e.g. Campos)
+    description: Name of the basin
     title: basin name
     examples:
       - value: Campos
@@ -5072,7 +5072,7 @@ slots:
     annotations:
       Expected_value: carbon source name;measurement value
       Preferred_unit: milligram per liter
-    description: Source of organic carbon in the culture rooting medium; e.g. sucrose
+    description: Source of organic carbon in the culture rooting medium
     title: rooting medium carbon
     examples:
       - value: sucrose
@@ -5085,7 +5085,7 @@ slots:
     annotations:
       Expected_value: macronutrient name;measurement value
       Preferred_unit: milligram per liter
-    description: Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S); e.g. KH2PO4 (170 mg/L)
+    description: Measurement of the culture rooting medium macronutrients (N,P, K, Ca, Mg, S)
     title: rooting medium macronutrients
     examples:
       - value: KH2PO4;170  milligram per liter
@@ -5098,7 +5098,7 @@ slots:
     annotations:
       Expected_value: micronutrient name;measurement value
       Preferred_unit: milligram per liter
-    description: Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo); e.g. H3BO3 (6.2 mg/L)
+    description: Measurement of the culture rooting medium micronutrients (Fe, Mn, Zn, B, Cu, Mo)
     title: rooting medium micronutrients
     examples:
       - value: H3BO3;6.2  milligram per liter
@@ -5130,7 +5130,7 @@ slots:
     slot_uri: MIXS:0000581
     range: TextValue
   root_med_solid:
-    description: Specification of the solidifying agent in the culture rooting medium; e.g. agar
+    description: Specification of the solidifying agent in the culture rooting medium
     title: rooting medium solidifier
     examples:
       - value: agar
@@ -5140,7 +5140,7 @@ slots:
     annotations:
       Expected_value: supplement name;measurement value
       Preferred_unit: milligram per liter
-    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal; e.g. nicotinic acid (0.5  mg/L)
+    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal
     title: rooting medium organic supplements
     examples:
       - value: nicotinic acid;0.5 milligram per liter
@@ -5354,7 +5354,7 @@ slots:
     annotations:
       Preferred_unit: degree Celsius
       storage_units: Cel
-    description: Temperature at which sample was stored, e.g. -80 degree Celsius
+    description: Temperature at which sample was stored
     title: sample storage temperature
     examples:
       - value: -80 Cel

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -5140,7 +5140,7 @@ slots:
     annotations:
       Expected_value: supplement name;measurement value
       Preferred_unit: milligram per liter
-    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics activated charcoal
+    description: Organic supplements of the culture rooting medium, such as vitamins, amino acids, organic acids, antibiotics, activated charcoal
     title: rooting medium organic supplements
     examples:
       - value: nicotinic acid;0.5 milligram per liter


### PR DESCRIPTION
Strip the example value from eight MIxS slot descriptions whose `examples` metaslot already carries it (basin, root_med_carbon, root_med_solid, samp_store_temp, api, root_med_macronutr, root_med_micronutr, root_med_suppl), via the yq customization asset. `mixs.yaml` regenerated; diff limited to those eight descriptions. No examples added, changed, or retyped. `samp_store_temp` is the slot from the now-closed #3267. Part of a 4-PR split; see #3276 (docs rendering).