### PR TITLE
Drop the dimensionless placeholder unit from two has_raw_values

### DIFF
--- a/assets/yq-for-mixs-customizations.txt
+++ b/assets/yq-for-mixs-customizations.txt
@@ -1016,7 +1016,7 @@
 # calcium: MIxS example is umol/L, a soil-solution concentration; NMDC uses mg/kg, the solid-phase value, which is not interconvertible without the extraction ratio.
 '.slots.calcium.examples = [{"description": "A solid-phase soil measurement, in milligram per kilogram of dry soil. A calcium concentration measured in soil solution is a different basis and cannot be converted to a per-dry-mass value without the extraction ratio.", "object": {"type": "nmdc:QuantityValue", "has_raw_value": "2774.35 mg/kg", "has_numeric_value": 2774.35, "has_unit": "mg/kg"}}]'
 # carb_nitro_ratio: MIxS example value 0.417361111 would mean nitrogen exceeds carbon, which cannot occur; NMDC uses 20.6, consistent with organic-rich soil.
-'.slots.carb_nitro_ratio.examples = [{"description": "A dimensionless ratio, so has_unit is 1. Mineral soils are near 10 and organic soils reach 30 or more; a value below 1 would mean nitrogen exceeds carbon, which does not occur in soil or other organic matter.", "object": {"type": "nmdc:QuantityValue", "has_raw_value": "20.6 1", "has_numeric_value": 20.6, "has_unit": "1"}}]'
+'.slots.carb_nitro_ratio.examples = [{"description": "A dimensionless ratio, so has_unit is 1. Mineral soils are near 10 and organic soils reach 30 or more; a value below 1 would mean nitrogen exceeds carbon, which does not occur in soil or other organic matter.", "object": {"type": "nmdc:QuantityValue", "has_raw_value": "20.6", "has_numeric_value": 20.6, "has_unit": "1"}}]'
 # chlorophyll: MIxS example is mg/m3; NMDC uses the numerically identical ug/L, the notation present in production data.
 '.slots.chlorophyll.examples = [{"description": "Microgram per liter, which is the same concentration as milligram per cubic meter (1 ug/L equals 1 mg/m3).", "object": {"type": "nmdc:QuantityValue", "has_raw_value": "13 ug/L", "has_numeric_value": 13, "has_unit": "ug/L"}}]'
 # diss_inorg_carb: MIxS example is umol/kg, the standard oceanographic unit; NMDC uses mg/L, the unit present in production data.
@@ -1053,7 +1053,7 @@
 '.slots.rel_humidity_out.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "12 %", "has_numeric_value": 12, "has_unit": "%"}}]'
 '.slots.root_med_ph.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "7.5 [pH]", "has_numeric_value": 7.5, "has_unit": "[pH]"}}]'
 '.slots.occup_density_samp.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "0.1 1/[sft_i]", "has_numeric_value": 0.1, "has_unit": "1/[sft_i]"}}]'
-'.slots.occup_samp.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "10 1", "has_numeric_value": 10, "has_unit": "1"}}]'
+'.slots.occup_samp.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "10", "has_numeric_value": 10, "has_unit": "1"}}]'
 '.slots.iwf.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "0.79 1", "has_numeric_value": 0.79, "has_unit": "1"}}]'
 '.slots.rel_air_humidity.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "0.8 1", "has_numeric_value": 0.8, "has_unit": "1"}}]'
 '.slots.surf_humidity.examples = [{"object": {"type": "nmdc:QuantityValue", "has_raw_value": "0.1 1", "has_numeric_value": 0.1, "has_unit": "1"}}]'

--- a/src/schema/mixs.yaml
+++ b/src/schema/mixs.yaml
@@ -1893,7 +1893,7 @@ slots:
       - description: A dimensionless ratio, so has_unit is 1. Mineral soils are near 10 and organic soils reach 30 or more; a value below 1 would mean nitrogen exceeds carbon, which does not occur in soil or other organic matter.
         object:
           type: nmdc:QuantityValue
-          has_raw_value: 20.6 1
+          has_raw_value: "20.6"
           has_numeric_value: 20.6
           has_unit: "1"
     keywords:
@@ -4565,7 +4565,7 @@ slots:
     examples:
       - object:
           type: nmdc:QuantityValue
-          has_raw_value: 10 1
+          has_raw_value: "10"
           has_numeric_value: 10
           has_unit: "1"
     slot_uri: MIXS:0000772


### PR DESCRIPTION
Part of https://github.com/microbiomedata/nmdc-schema/issues/3310

`carb_nitro_ratio` and `occup_samp` carried `has_raw_value: "20.6 1"` and `"10 1"`. `1` is the UCUM placeholder for dimensionless, not something a submitter would ever type into that field, and upstream MIxS writes both examples bare (`'0.417361111'`, `'10'`). Introduced by 5c5185f03, which built `has_raw_value` as numeric plus unit; right for a real unit, wrong for the placeholder.

These two are the unblocked half of issue 3310. Their `storage_units` already agrees with `has_unit`, so there is no modeling question to settle first.

The other three (`iwf`, `rel_air_humidity`, `surf_humidity`) are deliberately untouched. They assert `storage_units: "%"` against `has_unit: "1"`, so dropping the suffix alone would leave `0.8` on a slot documented as percent. Those wait on https://github.com/microbiomedata/nmdc-schema/issues/3295, and 3310 stays open tracking them.

`src/schema/mixs.yaml` was updated by running the two edited customization lines through `eval yq` under bash, which is what `makefiles/mixs.Makefile` does, rather than by a full regeneration. 71 tests pass.

Surfaced while building submission-schema against `11.23.0rc1`, where the malformed raw values on the contested three break `test_examples`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)