### PR TITLE
Add isolate permissible values to  NucelotideSequencingEnum and examples

### DIFF
--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -5,7 +5,7 @@
     - nmdc:sty-00-555xxx
   has_input:
     - nmdc:procsm-11-0wxpzf08
-   has_output:
+  has_output:
     - nmdc:dobj-12-12c89s
 - id: nmdc:omprc-97-gKlQlF
   type: nmdc:NucleotideSequencing

--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -1,7 +1,7 @@
-- id: nmdc:omprc-98-gKlQlF
-  type: nmdc:NucleotideSequencing
-  analyte_category: isolate_genome 
-  associated_studies:
-    - nmdc:sty-00-555xxx
-  has_input:
-    - nmdc:procsm-11-0wxpzf08
+id: nmdc:omprc-98-gKlQlF
+type: nmdc:NucleotideSequencing
+analyte_category: isolate_genome 
+associated_studies:
+  - nmdc:sty-00-555xxx
+has_input:
+  - nmdc:procsm-11-0wxpzf08

--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -5,4 +5,3 @@
     - nmdc:sty-00-555xxx
   has_input:
     - nmdc:procsm-11-0wxpzf08
-  

--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -1,0 +1,14 @@
+- id: nmdc:omprc-98-gKlQlF
+  type: nmdc:NucleotideSequencing
+  analyte_category: isolate_genome 
+  associated_studies:
+    - nmdc:sty-00-555xxx
+  has_input:
+  - nmdc:procsm-11-0wxpzf08
+- id: nmdc:omprc-97-gKlQlF
+  type: nmdc:NucleotideSequencing
+  analyte_category: isolate_transcriptome 
+  associated_studies:
+    - nmdc:sty-00-555xxx
+  has_input:
+  - nmdc:procsm-11-0wxpzwy

--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -1,8 +1,8 @@
-id: nmdc:omprc-98-gKlQlF
-type: nmdc:NucleotideSequencing
-analyte_category: isolate_genome 
-associated_studies:
-  - nmdc:sty-00-555xxx
-has_input:
-  - nmdc:procsm-11-0wxpzf08
+- id: nmdc:omprc-98-gKlQlF
+  type: nmdc:NucleotideSequencing
+  analyte_category: isolate_genome 
+  associated_studies:
+    - nmdc:sty-00-555xxx
+  has_input:
+    - nmdc:procsm-11-0wxpzf08
   

--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -1,18 +1,8 @@
-- id: nmdc:omprc-98-gKlQlF
-  type: nmdc:NucleotideSequencing
-  analyte_category: isolate_genome 
-  associated_studies:
-    - nmdc:sty-00-555xxx
-  has_input:
-    - nmdc:procsm-11-0wxpzf08
-  has_output:
-    - nmdc:dobj-12-12c89s
-- id: nmdc:omprc-97-gKlQlF
-  type: nmdc:NucleotideSequencing
-  analyte_category: isolate_transcriptome 
-  associated_studies:
-    - nmdc:sty-00-555xxx
-  has_input:
-    - nmdc:procsm-11-0wxpzwy
-  has_output:
-    - nmdc:dobj-12-12c89s
+id: nmdc:omprc-98-gKlQlF
+type: nmdc:NucleotideSequencing
+analyte_category: isolate_genome 
+associated_studies:
+  - nmdc:sty-00-555xxx
+has_input:
+  - nmdc:procsm-11-0wxpzf08
+  

--- a/src/data/valid/NucleotideSequencing-isolate.yaml
+++ b/src/data/valid/NucleotideSequencing-isolate.yaml
@@ -4,11 +4,15 @@
   associated_studies:
     - nmdc:sty-00-555xxx
   has_input:
-  - nmdc:procsm-11-0wxpzf08
+    - nmdc:procsm-11-0wxpzf08
+   has_output:
+    - nmdc:dobj-12-12c89s
 - id: nmdc:omprc-97-gKlQlF
   type: nmdc:NucleotideSequencing
   analyte_category: isolate_transcriptome 
   associated_studies:
     - nmdc:sty-00-555xxx
   has_input:
-  - nmdc:procsm-11-0wxpzwy
+    - nmdc:procsm-11-0wxpzwy
+  has_output:
+    - nmdc:dobj-12-12c89s

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -1434,7 +1434,13 @@ enums:
       amplicon_sequencing_assay:
         meaning: OBI:0002767
         title: Amplicon
-        
+      isolate_genome:
+        description: Sequencing of a single organism's genome, typically from a pure culture or isolate.
+        title: Isolate Genome
+      isolate_transcriptome:
+        description: Sequencing of a single organism's transcriptome, typically from a pure culture or isolate.
+        meaning: OBI:0002768
+        title: Isolate Transcriptome    
   MassSpectrometryEnum:
     permissible_values:
       metaproteome:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -1440,7 +1440,8 @@ enums:
       isolate_transcriptome:
         description: Sequencing of a single organism's transcriptome, typically from a pure culture or isolate.
         meaning: OBI:0002768
-        title: Isolate Transcriptome    
+        title: Isolate Transcriptome
+
   MassSpectrometryEnum:
     permissible_values:
       metaproteome:

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -1439,7 +1439,6 @@ enums:
         title: Isolate Genome
       isolate_transcriptome:
         description: Sequencing of a single organism's transcriptome, typically from a pure culture or isolate.
-        meaning: OBI:0002768
         title: Isolate Transcriptome
 
   MassSpectrometryEnum:


### PR DESCRIPTION
This PR adds permissible values for isolates to NucelotideSequencingEnum that mirror what was done on https://microbiomedata.github.io/nmdc-schema/AnalysisTypeEnum/