### PR TITLE
Fail CI if uv.lock is tracked

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,6 +18,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Guards against uv.lock being committed. This is a Poetry project; poetry.lock
+  # is the tracked lock file. A uv.lock is produced whenever someone runs uv here,
+  # and it has been committed and reverted twice (5c415c17a, 16b10a8e2). .gitignore
+  # covers the accidental case but not `git add -f` or an already-tracked file, so
+  # this check is the backstop. Delete this job if the project adopts uv, since
+  # uv.lock becomes the file to track then. See issue 2761.
+  lockfile-guard:
+    name: lockfile-guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # check out the repository to inspect its tracked files
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # `git ls-files` asks whether the file is TRACKED, which is the actual rule.
+      # A `test -f` would also fire on a contributor's git-ignored local copy.
+      - name: Fail if uv.lock is tracked
+        run: |
+          if git ls-files --error-unmatch uv.lock > /dev/null 2>&1; then
+            echo "::error file=uv.lock::uv.lock is tracked, but this is a Poetry project and poetry.lock is the tracked lock file. Remove it (git rm --cached uv.lock); it is already covered by .gitignore. See https://github.com/microbiomedata/nmdc-schema/issues/2761 if the project is moving to uv."
+            exit 1
+          fi
+          echo "OK: uv.lock is not tracked."
+
   ruff:
     name: ruff
     runs-on: ubuntu-latest


### PR DESCRIPTION
uv.lock has been committed and reverted twice (5c415c17a, 16b10a8e2). `.gitignore` catches the accidental case but not `git add -f`, and not a file that is already tracked, which is how both earlier occurrences got in.

The check is its own job rather than a step inside `ruff`, so it needs no Python and gets a distinct check name. That name is the thing worth adding to main's required status checks: main currently requires zero checks and `enforce_admins` is false, so a red job does not block a merge on its own.

`git ls-files` rather than `test -f`, because the rule is about the file being tracked. The same check then works locally without firing on a contributor's git-ignored copy.

Delete this job if https://github.com/microbiomedata/nmdc-schema/issues/2761 lands and uv becomes the lock tool. The job comment says so.

actionlint and zizmor are both clean on the edited workflow.
