### PR TITLE
Record the downstream effects of regenerating mixs.yaml

### DIFF
--- a/src/docs/mixs-v6.3.0-customizations.md
+++ b/src/docs/mixs-v6.3.0-customizations.md
@@ -303,6 +303,27 @@ poetry run linkml generate linkml --format yaml --materialize-patterns \
 yq eval '.slots.<slot>.pattern' /tmp/materialized.yaml
 ```
 
+### Downstream effects to check before regenerating
+
+Regenerating `mixs.yaml` is not a change contained to this repo. A MIxS slot's range, pattern, description, or
+example can reach production data and two user-facing interfaces. Check these before merging, not after releasing.
+
+| What can be affected | How to check |
+|---|---|
+| Production MongoDB records | A range change (for example TextValue to string) can leave existing documents invalid. Query `nmdc.biosample_set` for the slot before merging, and write a migrator if any documents would stop conforming |
+| Submission Portal / DataHarmonizer | `submission-schema` builds on this schema. Three slots are already hardcoded in `src/schema/nmdc.yaml` purely to keep it resolving. Slot renames and range changes are the risky ones |
+| Data Portal display | Slot descriptions and examples are what a submitter reads. Diff them and tell the Data Portal owners what changed |
+| Pinned consumers | `nmdc-runtime` and `nmdc-server` pin a schema version, so they pick a change up on their own schedule. `MAINTAINERS.md` covers the post-release notification |
+
+Two habits make this cheap. Read `git diff src/schema/mixs.yaml` rather than trusting a green build, since the
+build passing says nothing about whether a description changed under a submitter. And when a change alters what
+existing data must look like, say so in the PR body, because that is what tells a reviewer a migrator is needed.
+
+One question here has been open since 2022 and is still not answered in writing: whether description changes
+propagate to the Data Portal automatically or need coordination with the portal team. Until someone confirms it,
+assume coordination is required. See
+[consequences of changing MIxS import](https://github.com/microbiomedata/nmdc-schema/issues/299).
+
 ## Future Work
 
 ### TextValue to Enum Migrations

--- a/src/docs/mixs-v6.3.0-customizations.md
+++ b/src/docs/mixs-v6.3.0-customizations.md
@@ -303,10 +303,11 @@ poetry run linkml generate linkml --format yaml --materialize-patterns \
 yq eval '.slots.<slot>.pattern' /tmp/materialized.yaml
 ```
 
-### Downstream effects to check before regenerating
+### Downstream effects to check after regenerating, before merging
 
 Regenerating `mixs.yaml` is not a change contained to this repo. A MIxS slot's range, pattern, description, or
-example can reach production data and two user-facing interfaces. Check these before merging, not after releasing.
+example can reach production data and two user-facing interfaces. Regenerate first, then work through the table
+below against the resulting diff. Do this before merging, not after releasing.
 
 | What can be affected | How to check |
 |---|---|


### PR DESCRIPTION
`mixs-v6.3.0-customizations.md` explains how to change a MIxS slot. It did not say what changing one can break outside this repo, which is what https://github.com/microbiomedata/nmdc-schema/issues/299 has been asking since 2022. The answer existed only as a comment on that issue.

https://github.com/microbiomedata/nmdc-schema/issues/2801 and https://github.com/microbiomedata/nmdc-schema/issues/2802 cover the mechanical upgrade steps (bump the tag, regenerate, diff, test). Both stop at the repo boundary. This is the other half: production MongoDB, the Submission Portal and DataHarmonizer, Data Portal display, and the pinned consumers.

Deliberately not answered here: whether description changes reach the Data Portal automatically. Pajau asked in 2022, nobody has recorded an answer, and I am not going to invent one. It says to assume coordination is needed and links back to the issue, so the next person can close it with a fact instead of rediscovering the question.

Fixes #299