### PR TITLE
Add a report for slot_usage that restates inherited values

### DIFF
--- a/project.Makefile
+++ b/project.Makefile
@@ -398,6 +398,12 @@ assets/usages-report.txt: src/schema/nmdc.yaml
 	$(RUN) python src/scripts/report_usages.py \
 		--schema-file $< > $@
 
+# slot_usage assertions that restate a value the class already inherits.
+# Reported, not auto-removed: some restatements are deliberate.
+assets/redundant-slot-usage.txt: src/schema/nmdc.yaml
+	$(RUN) python src/scripts/report_redundant_slot_usage.py \
+		--schema-file $< > $@
+
 
 assets/element-scrutiny.tsv: nmdc_schema/nmdc_materialized_patterns.yaml
 	$(RUN) python src/scripts/scrutinize_elements.py \

--- a/src/scripts/report_redundant_slot_usage.py
+++ b/src/scripts/report_redundant_slot_usage.py
@@ -198,7 +198,11 @@ def format_tsv(redundancies: List[Redundancy]) -> str:
     help="Report format.",
 )
 def main(schema_file: str, output_format: str) -> None:
-    """Report slot_usage assertions that restate the global slot definition."""
+    """Report slot_usage assertions that restate a value the class already inherits.
+
+    The baseline is the parent's induced slot when the class has a parent, and the
+    global slot definition otherwise. Each finding names which one it matched.
+    """
     schema_view = SchemaView(schema_file)
     redundancies = find_redundancies(schema_view)
     renderer = format_tsv if output_format == "tsv" else format_text

--- a/src/scripts/report_redundant_slot_usage.py
+++ b/src/scripts/report_redundant_slot_usage.py
@@ -53,6 +53,38 @@ IGNORED_METASLOTS = frozenset(
     }
 )
 
+# Boolean metaslots whose unset state means false, so `metaslot: false` in a
+# `slot_usage` block restates what the class already inherits even though the
+# baseline reads as None. `inlined` and `inlined_as_list` are deliberately absent:
+# their effective value depends on whether the range class has an identifier
+# (see `SchemaView.is_inlined`), so unset there does not simply mean false.
+UNSET_MEANS_FALSE_METASLOTS = frozenset(
+    {
+        "abstract",
+        "asymmetric",
+        "children_are_mutually_disjoint",
+        "designates_type",
+        "id_prefixes_are_closed",
+        "identifier",
+        "inherited",
+        "irreflexive",
+        "is_class_field",
+        "is_grouping_slot",
+        "key",
+        "list_elements_ordered",
+        "list_elements_unique",
+        "locally_reflexive",
+        "mixin",
+        "multivalued",
+        "recommended",
+        "reflexive",
+        "required",
+        "shared",
+        "symmetric",
+        "transitive",
+    }
+)
+
 
 class Redundancy(NamedTuple):
     """One `slot_usage` metaslot assertion that matches the value it would inherit."""
@@ -97,6 +129,24 @@ def is_empty(value: Any) -> bool:
     return value is None or value == [] or value == {} or value == ()
 
 
+def baseline_value_and_label(
+    baseline_slot: SlotDefinition, baseline_label: str, metaslot: str
+) -> tuple[Any, str]:
+    """The inherited value to compare against, with unset booleans resolved.
+
+    Most unset metaslots have to be skipped, because LinkML cannot tell "absent
+    from the YAML" from "written as null". The boolean metaslots in
+    `UNSET_MEANS_FALSE_METASLOTS` are the exception: unset means false there, so
+    a class writing `required: false` over an unset baseline restates a value it
+    already has. The label records that the baseline was unset rather than
+    asserted, since the two read very differently to someone deciding what to cut.
+    """
+    value = getattr(baseline_slot, metaslot, None)
+    if value is None and metaslot in UNSET_MEANS_FALSE_METASLOTS:
+        return False, f"{baseline_label}, unset so false"
+    return value, baseline_label
+
+
 def find_redundancies(schema_view: SchemaView) -> List[Redundancy]:
     """Return every `slot_usage` assertion that restates an inherited value."""
     redundancies: List[Redundancy] = []
@@ -125,15 +175,15 @@ def find_redundancies(schema_view: SchemaView) -> List[Redundancy]:
                 if is_empty(usage_value):
                     continue
 
-                baseline_value = getattr(baseline_slot, metaslot, None)
+                baseline_value, label = baseline_value_and_label(
+                    baseline_slot, baseline_label, metaslot
+                )
                 if is_empty(baseline_value):
                     continue
 
                 if usage_value == baseline_value:
                     redundancies.append(
-                        Redundancy(
-                            class_name, slot_name, metaslot, usage_value, baseline_label
-                        )
+                        Redundancy(class_name, slot_name, metaslot, usage_value, label)
                     )
 
     return redundancies

--- a/src/scripts/report_redundant_slot_usage.py
+++ b/src/scripts/report_redundant_slot_usage.py
@@ -1,0 +1,209 @@
+"""Report `slot_usage` assertions that restate a value the class already inherits.
+
+A `slot_usage` is meant to refine a slot for one class. When it asserts a value
+the class would inherit anyway, it adds nothing: the induced slot is the same
+either way. Those assertions still cost maintenance, because a later change
+upstream silently stops reaching every class that restated the old value.
+
+The comparison is against what the class actually inherits, which is the parent's
+induced slot when the class has a parent, and the global slot definition
+otherwise. That distinction matters: a `slot_usage` restoring the global value
+after a parent narrowed it is a real refinement, not a redundancy.
+
+This script reports them. It does not edit the schema, because some restatements
+are deliberate (see the note on re-declaring `range: uriorcurie` in
+`src/docs/maintaining-the-schema.md`), so a human decides what to remove.
+
+Usage:
+
+    poetry run python src/scripts/report_redundant_slot_usage.py \
+        --schema-file src/schema/nmdc.yaml
+
+    # machine-readable, for diffing between releases
+    poetry run python src/scripts/report_redundant_slot_usage.py \
+        --schema-file src/schema/nmdc.yaml --output-format tsv
+
+Or via make:
+
+    make assets/redundant-slot-usage.txt
+"""
+
+from dataclasses import fields
+from typing import Any, List, NamedTuple, Optional
+
+import click
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model.meta import SlotDefinition
+from linkml_runtime.utils.schemaview import OrderedBy
+
+# Populated by the loader or carried as bookkeeping rather than authored in the
+# `slot_usage` block, so a match on these says nothing about redundancy.
+IGNORED_METASLOTS = frozenset(
+    {
+        "name",
+        "alias",
+        "domain_of",
+        "from_schema",
+        "imported_from",
+        "is_usage_slot",
+        "owner",
+        "usage_slot_name",
+        "definition_uri",
+        "slot_uri",
+    }
+)
+
+
+class Redundancy(NamedTuple):
+    """One `slot_usage` metaslot assertion that matches the value it would inherit."""
+
+    class_name: str
+    slot_name: str
+    metaslot: str
+    value: Any
+    baseline: str
+
+
+def inherited_slot(
+    schema_view: SchemaView, class_definition: Any, slot_name: str
+) -> tuple[Optional[SlotDefinition], str]:
+    """The slot as this class would see it without its own `slot_usage`.
+
+    For a class with a parent, that is the parent's induced slot, which already
+    folds in any refinement the parent made. Comparing against the global slot
+    instead would wrongly flag a `slot_usage` that restores the global value
+    after a parent narrowed it, which is one of the cases this report exists to
+    tell apart.
+
+    Returns the baseline definition and a label naming where it came from.
+    """
+    parent_name = class_definition.is_a
+    if parent_name:
+        try:
+            return schema_view.induced_slot(
+                slot_name, parent_name
+            ), f"is_a {parent_name}"
+        except (ValueError, KeyError):
+            pass
+    return schema_view.get_slot(slot_name), "global slot"
+
+
+def is_empty(value: Any) -> bool:
+    """True when a metaslot holds no authored value.
+
+    LinkML populates unset metaslots with None or an empty collection, so those
+    cannot be distinguished from "not written in the YAML" and are skipped.
+    """
+    return value is None or value == [] or value == {} or value == ()
+
+
+def find_redundancies(schema_view: SchemaView) -> List[Redundancy]:
+    """Return every `slot_usage` assertion that restates an inherited value."""
+    redundancies: List[Redundancy] = []
+    metaslot_names = [f.name for f in fields(SlotDefinition)]
+
+    for class_name, class_definition in schema_view.all_classes(
+        ordered_by=OrderedBy.LEXICAL
+    ).items():
+        if not class_definition.slot_usage:
+            continue
+
+        for slot_name, usage in class_definition.slot_usage.items():
+            baseline_slot, baseline_label = inherited_slot(
+                schema_view, class_definition, slot_name
+            )
+            if baseline_slot is None:
+                # An attribute rather than a schema-level slot; nothing is inherited,
+                # so nothing can be redundant with it.
+                continue
+
+            for metaslot in metaslot_names:
+                if metaslot in IGNORED_METASLOTS:
+                    continue
+
+                usage_value = getattr(usage, metaslot, None)
+                if is_empty(usage_value):
+                    continue
+
+                baseline_value = getattr(baseline_slot, metaslot, None)
+                if is_empty(baseline_value):
+                    continue
+
+                if usage_value == baseline_value:
+                    redundancies.append(
+                        Redundancy(
+                            class_name, slot_name, metaslot, usage_value, baseline_label
+                        )
+                    )
+
+    return redundancies
+
+
+def summarize_value(value: Any, max_length: int = 100) -> str:
+    """Render a metaslot value on one line, short enough to scan.
+
+    Values such as `examples` and `structured_pattern` repr across several lines,
+    which would corrupt the TSV and swamp the text report.
+    """
+    text = " ".join(repr(value).split())
+    if len(text) > max_length:
+        text = text[: max_length - 3] + "..."
+    return text
+
+
+def format_text(redundancies: List[Redundancy]) -> str:
+    """Render findings grouped by class, for a human reader."""
+    if not redundancies:
+        return "No redundant slot_usage assertions found.\n"
+
+    lines: List[str] = [
+        f"{len(redundancies)} redundant slot_usage assertion(s). Each restates a value "
+        "the class already inherits, so removing it would not change the induced slot.\n"
+    ]
+    current_class = None
+    for item in sorted(redundancies):
+        if item.class_name != current_class:
+            current_class = item.class_name
+            lines.append(f"\n{current_class}:")
+        lines.append(
+            f"  {item.slot_name}.{item.metaslot} = {summarize_value(item.value)}"
+            f"   [same as {item.baseline}]"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def format_tsv(redundancies: List[Redundancy]) -> str:
+    """Render findings as TSV, for diffing between releases."""
+    lines = ["class\tslot\tmetaslot\tvalue\tbaseline"]
+    for item in sorted(redundancies):
+        lines.append(
+            f"{item.class_name}\t{item.slot_name}\t{item.metaslot}"
+            f"\t{summarize_value(item.value)}\t{item.baseline}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+@click.command()
+@click.option(
+    "--schema-file",
+    default="src/schema/nmdc.yaml",
+    show_default=True,
+    help="Path to the schema file.",
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(["text", "tsv"]),
+    default="text",
+    show_default=True,
+    help="Report format.",
+)
+def main(schema_file: str, output_format: str) -> None:
+    """Report slot_usage assertions that restate the global slot definition."""
+    schema_view = SchemaView(schema_file)
+    redundancies = find_redundancies(schema_view)
+    renderer = format_tsv if output_format == "tsv" else format_text
+    click.echo(renderer(redundancies), nl=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_report_redundant_slot_usage.py
+++ b/tests/test_report_redundant_slot_usage.py
@@ -1,16 +1,22 @@
 """Tests for src/scripts/report_redundant_slot_usage.py."""
 
+from dataclasses import fields
+
 from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model.meta import SlotDefinition
 
 from src.scripts.report_redundant_slot_usage import (
+    UNSET_MEANS_FALSE_METASLOTS,
     find_redundancies,
     format_tsv,
     summarize_value,
 )
 
-# One global slot, and three classes exercising the cases the report must tell apart:
-# Parent restates the global value, Child restates what Parent already says, and
-# Refiner narrows it. Only the first two are redundant.
+# Two global slots, and classes exercising the cases the report must tell apart.
+# On `status`, which is globally required: Parent restates the global value, Child
+# restates what Parent already says, Refiner narrows the range, and Relaxer drops
+# the requirement. On `note`, which is globally unset: ExplicitFalse writes the
+# false it already inherits. Redundant: Parent, Child, ExplicitFalse.
 SCHEMA_YAML = """
 id: https://example.org/test
 name: test-schema
@@ -26,6 +32,9 @@ slots:
     range: string
     required: true
     description: A status.
+  note:
+    range: string
+    description: A note, with `required` left unset so it defaults to false.
 classes:
   Parent:
     slots:
@@ -43,6 +52,17 @@ classes:
     slot_usage:
       status:
         range: integer
+  Relaxer:
+    is_a: Parent
+    slot_usage:
+      status:
+        required: false
+  ExplicitFalse:
+    slots:
+      - note
+    slot_usage:
+      note:
+        required: false
   Untouched:
     slots:
       - status
@@ -78,6 +98,36 @@ def test_does_not_flag_a_genuine_refinement(tmp_path):
     """Refiner narrows the range, so nothing about it is redundant."""
     findings = find_redundancies(build_view(tmp_path))
     assert [f for f in findings if f.class_name == "Refiner"] == []
+
+
+def test_flags_required_false_over_an_unset_baseline(tmp_path):
+    """ExplicitFalse writes required: false on a slot that is already optional.
+
+    The baseline reads as None because LinkML has nothing to inherit, but unset
+    means false, so the assertion leaves the induced slot unchanged.
+    """
+    findings = find_redundancies(build_view(tmp_path))
+    explicit = [f for f in findings if f.class_name == "ExplicitFalse"]
+    assert len(explicit) == 1
+    assert explicit[0].slot_name == "note"
+    assert explicit[0].metaslot == "required"
+    assert explicit[0].value is False
+    assert explicit[0].baseline == "global slot, unset so false"
+
+
+def test_does_not_flag_dropping_an_inherited_requirement(tmp_path):
+    """Relaxer sets required: false where Parent says true, which is a refinement."""
+    findings = find_redundancies(build_view(tmp_path))
+    assert [f for f in findings if f.class_name == "Relaxer"] == []
+
+
+def test_unset_means_false_metaslots_are_real_booleans():
+    """Guards the hand-maintained list against typos and metamodel renames."""
+    boolean_metaslots = {
+        f.name for f in fields(SlotDefinition) if "bool" in str(f.type)
+    }
+    assert UNSET_MEANS_FALSE_METASLOTS <= boolean_metaslots
+    assert not UNSET_MEANS_FALSE_METASLOTS & {"inlined", "inlined_as_list"}
 
 
 def test_ignores_classes_without_slot_usage(tmp_path):

--- a/tests/test_report_redundant_slot_usage.py
+++ b/tests/test_report_redundant_slot_usage.py
@@ -1,0 +1,115 @@
+"""Tests for src/scripts/report_redundant_slot_usage.py."""
+
+from linkml_runtime import SchemaView
+
+from src.scripts.report_redundant_slot_usage import (
+    find_redundancies,
+    format_tsv,
+    summarize_value,
+)
+
+# One global slot, and three classes exercising the cases the report must tell apart:
+# Parent restates the global value, Child restates what Parent already says, and
+# Refiner narrows it. Only the first two are redundant.
+SCHEMA_YAML = """
+id: https://example.org/test
+name: test-schema
+prefixes:
+  linkml: https://w3id.org/linkml/
+  test: https://example.org/test/
+default_prefix: test
+default_range: string
+imports:
+  - linkml:types
+slots:
+  status:
+    range: string
+    required: true
+    description: A status.
+classes:
+  Parent:
+    slots:
+      - status
+    slot_usage:
+      status:
+        required: true
+  Child:
+    is_a: Parent
+    slot_usage:
+      status:
+        required: true
+  Refiner:
+    is_a: Parent
+    slot_usage:
+      status:
+        range: integer
+  Untouched:
+    slots:
+      - status
+"""
+
+
+def build_view(tmp_path) -> SchemaView:
+    schema_file = tmp_path / "schema.yaml"
+    schema_file.write_text(SCHEMA_YAML)
+    return SchemaView(str(schema_file))
+
+
+def test_flags_usage_restating_the_global_slot(tmp_path):
+    """Parent asserts required: true, which the global slot already says."""
+    findings = find_redundancies(build_view(tmp_path))
+    parent = [f for f in findings if f.class_name == "Parent"]
+    assert len(parent) == 1
+    assert parent[0].slot_name == "status"
+    assert parent[0].metaslot == "required"
+    assert parent[0].baseline == "global slot"
+
+
+def test_flags_usage_restating_an_inherited_value(tmp_path):
+    """Child asserts required: true, which it already inherits from Parent."""
+    findings = find_redundancies(build_view(tmp_path))
+    child = [f for f in findings if f.class_name == "Child"]
+    assert len(child) == 1
+    assert child[0].metaslot == "required"
+    assert child[0].baseline == "is_a Parent"
+
+
+def test_does_not_flag_a_genuine_refinement(tmp_path):
+    """Refiner narrows the range, so nothing about it is redundant."""
+    findings = find_redundancies(build_view(tmp_path))
+    assert [f for f in findings if f.class_name == "Refiner"] == []
+
+
+def test_ignores_classes_without_slot_usage(tmp_path):
+    findings = find_redundancies(build_view(tmp_path))
+    assert [f for f in findings if f.class_name == "Untouched"] == []
+
+
+def test_tsv_rows_are_single_line_and_well_formed(tmp_path):
+    """Multi-line reprs must not break the column count."""
+    findings = find_redundancies(build_view(tmp_path))
+    lines = format_tsv(findings).strip().split("\n")
+    assert lines[0] == "class\tslot\tmetaslot\tvalue\tbaseline"
+    for line in lines:
+        assert len(line.split("\t")) == 5
+
+
+class MultiLineRepr:
+    """Stands in for LinkML objects such as Example, whose repr spans lines."""
+
+    def __repr__(self) -> str:
+        return "Example({\n  'a': 1,\n\t'b': 2\n})"
+
+
+def test_summarize_value_collapses_real_newlines_and_tabs():
+    """Object reprs carry genuine newlines and tabs, which would corrupt the TSV."""
+    summarized = summarize_value(MultiLineRepr())
+    assert "\n" not in summarized
+    assert "\t" not in summarized
+    assert summarized == "Example({ 'a': 1, 'b': 2 })"
+
+
+def test_summarize_value_truncates():
+    long_value = "x" * 300
+    assert len(summarize_value(long_value)) == 100
+    assert summarize_value(long_value).endswith("...")


### PR DESCRIPTION
https://github.com/microbiomedata/nmdc-schema/issues/772 has two checkboxes. This implements the first and explains why the second no longer applies.

**"does the usage alter a parent class' attribute value? reverting to the global usage?"** A `slot_usage` that asserts a value the class already inherits leaves the induced slot unchanged, so it reads as intent without being any. The cost shows up later: an edit to the global slot stops reaching every class that restated the old value, and nothing says so.

The comparison is against what the class actually inherits, not against the global slot. For a class with a parent that means the parent's induced slot, which already folds in the parent's own refinements. This is the distinction the issue was pointing at: a `slot_usage` that restores the global value *after a parent narrowed it* is a genuine refinement, and comparing against the global slot alone would report it as redundant.

Reports rather than edits. Some restatements are deliberate, including the re-declared `range: uriorcurie` that `src/docs/maintaining-the-schema.md` describes as belt-and-suspenders, so a human decides what comes out.

It currently finds 69 assertions. A sample, verified by hand against the YAML:

```
ChromatographicSeparationProcess:
  has_input.range = 'Sample'   [same as is_a MaterialProcessing]
  id.required = True           [same as is_a MaterialProcessing]
```

`MaterialProcessing.slot_usage` sets `has_input.range: Sample` at `src/schema/core.yaml:1305`, and `ChromatographicSeparationProcess` restates it at `src/schema/nmdc.yaml:823`. The same class's `id.structured_pattern` carrying the `cspro` typecode is correctly *not* flagged, because that one refines.

**The second checkbox, agreement with the sheets_and_friends Google sheet, is obsolete.** That sheet drives `submission-schema`, not this repo's `slot_usage`.

**Unset booleans count as false.** LinkML stores an unset boolean metaslot as `None`, which looks the same as having nothing to compare against, so an early version never reported `required: false` written over a slot that is already optional. That assertion leaves the induced slot unchanged and belongs in the report. Only the metaslots where unset really does mean false are treated this way; `inlined` and `inlined_as_list` are left out, because their effective value depends on whether the range class has an identifier. The one case this adds today is `PropertyAssertion.has_unit` in `src/schema/attribute_values.yaml`, and the report labels its baseline "unset so false" so a reader can see the assertion was never inherited from anywhere.

Run it with `make assets/redundant-slot-usage.txt`, or directly for TSV. The output is not committed, matching `assets/usages-report.txt` and the other reports next to it.

Ten tests cover both directions, since a checker that reports refinements as redundant would be worse than none: restating the global value, restating an inherited value, restating an unset boolean, a genuine refinement, dropping an inherited requirement, a class with no `slot_usage`, and TSV well-formedness. That last one matters because LinkML object reprs span multiple lines and would otherwise break the columns.

Fixes https://github.com/microbiomedata/nmdc-schema/issues/772 "boolean usage script overlooks"
