### PR TITLE
Stop the doc frontmatter fence collapsing onto the next line

### DIFF
--- a/src/doc-templates/class.md.jinja2
+++ b/src/doc-templates/class.md.jinja2
@@ -2,7 +2,8 @@
 search:
   boost: {% if element.deprecated %}0.5{% else %}10.0{% endif %}
 ---
-{%- from "_macros.jinja2" import shorten -%}
+
+{% from "_macros.jinja2" import shorten %}
 
 {%- if element.title %}
     {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}

--- a/src/doc-templates/enum.md.jinja2
+++ b/src/doc-templates/enum.md.jinja2
@@ -2,7 +2,8 @@
 search:
   boost: {% if element.deprecated %}0.5{% else %}2.0{% endif %}
 ---
-{%- from "_macros.jinja2" import shorten -%}
+
+{% from "_macros.jinja2" import shorten %}
 
 # Enum: {{ gen.name(element) }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong> {% endif %}
 

--- a/src/doc-templates/slot.md.jinja2
+++ b/src/doc-templates/slot.md.jinja2
@@ -2,7 +2,8 @@
 search:
   boost: {% if element.deprecated %}0.5{% else %}5.0{% endif %}
 ---
-{%- from "_macros.jinja2" import shorten -%}
+
+{% from "_macros.jinja2" import shorten %}
 
 {%- if element.title %}
     {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}

--- a/src/doc-templates/subset.md.jinja2
+++ b/src/doc-templates/subset.md.jinja2
@@ -2,7 +2,8 @@
 search:
   boost: {% if element.deprecated %}0.5{% else %}1.0{% endif %}
 ---
-{%- from "_macros.jinja2" import shorten -%}
+
+{% from "_macros.jinja2" import shorten %}
 
 # Subset: {{ gen.name(element) }}
 

--- a/src/doc-templates/type.md.jinja2
+++ b/src/doc-templates/type.md.jinja2
@@ -1,0 +1,170 @@
+---
+search:
+  boost: {% if element.deprecated %}0.5{% else %}1.0{% endif %}
+---
+
+{% if element.title and element.title != element.name %}
+    {%- set title = element.title ~ ' (' ~ element.name ~ ')' -%}
+{%- else %}
+    {%- set title = gen.name(element) -%}
+{%- endif -%}
+
+# Type: {{ title }} {% if element.deprecated %} <span style="color: red;"><strong> (DEPRECATED) </strong></span> {% endif %}
+
+{% if element.description %}
+{% set element_description_lines = element.description.split('\n') %}
+{% for element_description_line in element_description_lines %}
+_{{ element_description_line }}_
+{% endfor %}
+{% endif %}
+
+<div data-search-exclude markdown="1">
+
+URI: {{ gen.uri_link(element) }}
+
+## Type Properties
+
+| Property | Value |
+| --- | --- |
+{%- if element.typeof %}
+| Type Of | {{ gen.link(element.typeof) }} |
+{%- endif %}
+{%- if element.base %}
+| Base | `{{ element.base }}` |
+{%- endif %}
+{%- if element.uri %}
+| Type URI | {{ gen.uri_link(element.uri) }} |
+{%- endif %}
+{%- if element.repr %}
+| Representation | `{{ element.repr }}` |
+{%- endif %}
+{%- if element.union_of %}
+| Union Of | {{ gen.links(element.union_of) | join(', ') }} |
+{%- endif %}
+
+{%- set has_basic_constraints = element.minimum_value is not none or element.maximum_value is not none or element.pattern %}
+
+{%- if has_basic_constraints %}
+## Value Constraints
+
+| Property | Value |
+| --- | --- |
+{%- if element.minimum_value is not none or element.maximum_value is not none %}
+| Numeric Range | {{ gen.number_value_range(element) }} |
+{%- endif %}
+{%- if element.pattern %}
+| Regex Pattern | `{{ element.pattern }}` |
+{%- endif %}
+
+{% endif %}
+{%- set has_advanced_constraints = element.structured_pattern or element.equals_string
+    or element.equals_string_in or element.equals_number or element.unit or element.implicit_prefix %}
+
+{%- if has_advanced_constraints %}
+<details>
+<summary>Additional Constraints</summary>
+
+{%- if element.structured_pattern %}
+**Structured Pattern:**
+
+- **Syntax:** `{{ element.structured_pattern.syntax }}`
+- **Interpolated:** {{ element.structured_pattern.interpolated }}
+{%- if element.structured_pattern.partial_match %}
+- **Partial Match:** Yes
+{%- endif %}
+{%- endif %}
+
+{%- if element.equals_string %}
+**Must Equal:** `{{ element.equals_string }}`
+{%- endif %}
+
+{%- if element.equals_string_in %}
+**Must Be One Of:** {{ element.equals_string_in | join(', ') }}
+{%- endif %}
+
+{%- if element.equals_number %}
+**Must Equal:** {{ element.equals_number }}
+{%- endif %}
+
+{%- if element.unit %}
+**Unit:**
+
+| Property | Value |
+| --- | --- |
+{%- if element.unit.symbol %}
+| symbol | {{ element.unit.symbol }} |
+{%- endif %}
+{%- if element.unit.abbreviation %}
+| abbreviation | {{ element.unit.abbreviation }} |
+{%- endif %}
+{%- if element.unit.descriptive_name %}
+| descriptive_name | {{ element.unit.descriptive_name }} |
+{%- endif %}
+{%- if element.unit.ucum_code %}
+| ucum_code | {{ element.unit.ucum_code }} |
+{%- endif %}
+{%- if element.unit.derivation %}
+| derivation | {{ element.unit.derivation }} |
+{%- endif %}
+{%- if element.unit.iec61360code %}
+| iec61360code | {{ element.unit.iec61360code }} |
+{%- endif %}
+{%- if element.unit.has_quantity_kind %}
+| has_quantity_kind | {{ gen.uri_link(element.unit.has_quantity_kind) }} |
+{%- endif %}
+{%- if element.unit.exact_mappings %}
+| exact_mappings | {% for m in element.unit.exact_mappings %}{{ gen.uri_link(m) }}{% if not loop.last %}, {% endif %}{% endfor %} |
+{%- endif %}
+{%- endif %}
+
+{%- if element.implicit_prefix %}
+**Implicit Prefix:** {{ element.implicit_prefix }}
+{%- endif %}
+
+</details>
+{% endif %}
+
+{%- set has_expressions = element.any_of or element.all_of or element.exactly_one_of or element.none_of %}
+
+{%- if has_expressions %}
+<details>
+<summary>Type Expressions</summary>
+
+{%- if element.any_of %}
+**Any Of:** Value must satisfy at least one of these expressions
+
+{%- for expr in element.any_of %}
+- {{ expr }}
+{%- endfor %}
+{%- endif %}
+
+{%- if element.all_of %}
+**All Of:** Value must satisfy all of these expressions
+
+{%- for expr in element.all_of %}
+- {{ expr }}
+{%- endfor %}
+{%- endif %}
+
+{%- if element.exactly_one_of %}
+**Exactly One Of:** Value must satisfy exactly one of these expressions
+
+{%- for expr in element.exactly_one_of %}
+- {{ expr }}
+{%- endfor %}
+{%- endif %}
+
+{%- if element.none_of %}
+**None Of:** Value must not satisfy any of these expressions
+
+{%- for expr in element.none_of %}
+- {{ expr }}
+{%- endfor %}
+{%- endif %}
+
+</details>
+{% endif %}
+
+{% include "common_metadata.md.jinja2" %}
+
+</div>

--- a/tests/test_doc_template_frontmatter.py
+++ b/tests/test_doc_template_frontmatter.py
@@ -1,0 +1,83 @@
+"""Guard the YAML frontmatter block in the documentation templates.
+
+Each page template opens with a frontmatter block that mkdocs reads for search
+ranking:
+
+    ---
+    search:
+      boost: 1.0
+    ---
+
+If the construct immediately after the closing ``---`` strips whitespace to its
+left (a Jinja tag opening with ``{%-``), the closing fence collapses onto the
+following line and mkdocs stops recognizing the block. It then renders as body
+text, so every affected page opens with ``search: boost: 1.0 ---# Subset: ...``
+and its search boost is silently inoperative.
+
+That is what happened in
+https://github.com/microbiomedata/nmdc-schema/issues/3344, across 153 enum and
+subset pages plus 25 type pages. The class and slot templates were correct only
+by accident: the construct after their fence happened to emit a newline.
+
+These tests are string checks on the templates rather than a docs build, so they
+run in milliseconds and need no generated artifact.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "src" / "doc-templates"
+
+# A closing fence followed by any amount of blank space and then a
+# whitespace-stripping Jinja tag. The strip eats the newline after the fence.
+COLLAPSING_FENCE = re.compile(r"^---\n\s*\{%-", re.MULTILINE)
+
+
+def _templates_with_frontmatter():
+    for path in sorted(TEMPLATE_DIR.glob("*.md.jinja2")):
+        text = path.read_text()
+        if text.startswith("---\n"):
+            yield path, text
+
+
+class TestDocTemplateFrontmatter(unittest.TestCase):
+    def test_templates_with_frontmatter_are_found(self):
+        """Fail loudly if the templates move, rather than passing vacuously."""
+        self.assertTrue(
+            list(_templates_with_frontmatter()),
+            f"no templates with frontmatter found in {TEMPLATE_DIR}",
+        )
+
+    def test_closing_fence_is_not_followed_by_a_stripping_tag(self):
+        for path, text in _templates_with_frontmatter():
+            with self.subTest(template=path.name):
+                self.assertIsNone(
+                    COLLAPSING_FENCE.search(text),
+                    f"{path.name}: the closing '---' is followed by a "
+                    f"whitespace-stripping Jinja tag ('{{%-'), which collapses "
+                    f"the fence onto the next line and breaks the frontmatter. "
+                    f"Use '{{%' there instead.",
+                )
+
+    def test_frontmatter_block_closes_on_its_own_line(self):
+        for path, text in _templates_with_frontmatter():
+            with self.subTest(template=path.name):
+                lines = text.split("\n")
+                closing = next(
+                    (i for i, line in enumerate(lines[1:], start=1) if line == "---"),
+                    None,
+                )
+                self.assertIsNotNone(
+                    closing, f"{path.name}: frontmatter block is never closed"
+                )
+                self.assertNotEqual(
+                    lines[closing + 1].strip()[:1],
+                    "#",
+                    f"{path.name}: a heading sits directly after the closing "
+                    f"fence with no blank line between them",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the frontmatter collapse described in https://github.com/microbiomedata/nmdc-schema/issues/3344.

Measured by regenerating the full documentation set before and after:

| | malformed frontmatter |
| --- | --- |
| before | 178 of 1164 pages |
| after | 0 (2 pages have no frontmatter by design: `index.md` and `NMDC.md`) |

Nothing was newly broken by the change.

The cause is whitespace control. When the construct after the closing `---` opens with `{%-`, the strip eats the newline after the fence and the fence lands on the following line, so mkdocs stops recognizing the block and renders it as body text. Affected pages opened with `search: boost: 1.0 ---# Subset: ...` and their search boost never took effect.

Three changes:

**The four local templates** (`subset`, `enum`, `class`, `slot`) now put a blank line after the fence and use a non-stripping `{% from %}`. `class` and `slot` were rendering correctly before, but only by accident: the construct after their fence happened to emit a newline. They are now explicit rather than lucky.

**`type.md.jinja2` is vendored** into `src/doc-templates/` with the same fix. This accounts for 25 of the 178 pages. LinkML 1.11.1's built-in type template has the identical defect, and there was no local override, so those pages could not be fixed any other way. The repository already vendors eight templates, so this follows existing practice. Upstream report to follow.

**A regression test** (`tests/test_doc_template_frontmatter.py`) asserts that no template's closing fence is followed by a whitespace-stripping tag or by a heading with no blank line between. It is a string check on the templates, so it runs in milliseconds and needs no generated artifact. Verified it fails when the defect is reintroduced.

The test is deliberately stricter than the bug: it forbids the risky construct rather than trying to predict which templates survive it by luck. That is what made `class` and `slot` fragile in the first place.

Closes https://github.com/microbiomedata/nmdc-schema/issues/3344
