### PR TITLE
Remove slot_usage assertions that restate inherited values

### DIFF
--- a/project.Makefile
+++ b/project.Makefile
@@ -398,6 +398,13 @@ assets/usages-report.txt: src/schema/nmdc.yaml
 	$(RUN) python src/scripts/report_usages.py \
 		--schema-file $< > $@
 
+# Every induced slot value, for diffing across a refactor that should not change
+# meaning. Run before and after the change; an empty diff is the proof.
+# Not a prerequisite of anything: it is a hand-run gate, not a build artifact.
+assets/induced-slots.tsv: src/schema/nmdc.yaml
+	$(RUN) python src/scripts/dump_induced_slots.py \
+		--schema-file $< > $@
+
 # slot_usage assertions that restate a value the class already inherits.
 # Reported, not auto-removed: some restatements are deliberate.
 assets/redundant-slot-usage.txt: src/schema/nmdc.yaml

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -209,7 +209,6 @@ classes:
       - ref_biomaterial
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:orgn-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -414,7 +413,6 @@ classes:
       - websites
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:sty-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -523,7 +521,6 @@ classes:
       description:
         required: true
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:dobj-{id_shoulder}-{id_blade}$"
           interpolated: true

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -66,7 +66,6 @@ classes:
       - is_root
     slot_usage:
       id:
-        pattern: '^[a-zA-Z0-9][a-zA-Z0-9_\.]+:[a-zA-Z0-9_][a-zA-Z0-9_\-\/\.,]*$'
         notes:
           - The identifiers for terms from external ontologies can't have their ids constrained to the nmdc namespace
     exact_mappings:
@@ -528,7 +527,6 @@ classes:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(wfmag|wfmb|wfmgan|wfmgas|wfmsa|wfmp|wfmt|wfmtan|wfmtas|wfmtex|wfnom|wfrbt|wfrqc)-{id_shoulder}-{id_blade}{id_version}$|{id_nmdc_prefix}:(omprc|dgms|dgns)-{id_shoulder}-{id_blade}$"
           interpolated: true
-        range: DataEmitterProcess
       data_object_type:
         required: true
       data_category:
@@ -584,7 +582,6 @@ classes:
           syntax: "{id_nmdc_prefix}:(bsm|osm|procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
       associated_studies:
-        range: Study
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(sty)-{id_shoulder}-{id_blade}$"
           interpolated:

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -257,7 +257,6 @@ classes:
       - substances_volume
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:chcpr-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -277,7 +276,6 @@ classes:
       - gold_analysis_project_identifiers
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmgan-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -319,7 +317,6 @@ classes:
       - soil_type
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:frsite-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -946,7 +943,6 @@ classes:
           - value: "100"
 
       id:
-        required: true
         description: An NMDC assigned unique identifier for a biosample submitted to NMDC.
         structured_pattern:
           syntax: "{id_nmdc_prefix}:bsm-{id_shoulder}-{id_blade}$"
@@ -1343,7 +1339,6 @@ classes:
 
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -1373,7 +1368,6 @@ classes:
       - analysis_type
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:osm-{id_shoulder}-{id_blade}$"
           interpolated: true

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -934,7 +934,6 @@ classes:
 
       elev:
         title: elevation, meters
-        range: float
         comments:
           - All elevations must be reported in meters. Provide the numerical portion only.
           - Please use https://www.advancedconverter.com/map-tools/find-altitude-by-coordinates,
@@ -968,13 +967,6 @@ classes:
       env_medium:
         required: true
 
-      associated_studies:
-        required: true
-        range: Study
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:sty-{id_shoulder}-{id_blade}$"
-          interpolated: true
-
       fire:
         comments:
           - Provide the date the fire occurred. If extended burning occurred provide the date range.
@@ -985,7 +977,6 @@ classes:
           - is "to" acceptable? Is there a better way to request that be written?
         annotations:
           Expected_value: date string
-        range: string
         pattern: ^[12]\d{3}(?:(?:-(?:0[1-9]|1[0-2]))(?:-(?:0[1-9]|[12]\d|3[01]))?)?(\s+to\s+[12]\d{3}(?:(?:-(?:0[1-9]|1[0-2]))(?:-(?:0[1-9]|[12]\d|3[01]))?)?)?$
       flooding:
         annotations:
@@ -998,13 +989,11 @@ classes:
         todos:
           - is "to" acceptable? Is there a better way to request that be written?
           - What about if the "day" isn't known? Is this ok?
-        range: string
       extreme_event:
         examples:
           - value: 1980-05-18, volcanic eruption
         annotations:
           Expected_value: date, string
-        range: string
       slope_aspect:
         comments:
           - Aspect is the orientation of slope, measured clockwise in degrees from 0 to 360,
@@ -1059,22 +1048,9 @@ classes:
         todos:
           - I think it's weird the way GSC writes the title. I recommend this change. Thoughts?
       cur_vegetation:
-        description:
-          Vegetation classification from one or more standard classification
-          systems, or agricultural crop
         comments:
           - Values provided here can be specific species of vegetation or vegetation regions
           - See for vegetation regions- https://education.nationalgeographic.org/resource/vegetation-region
-        examples:
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: deciduous forest
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: forest
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: Bauhinia variegata
         todos:
           - Recommend changing this from text value to some king of ontology?
       cur_vegetation_meth:
@@ -1113,22 +1089,6 @@ classes:
         examples:
           - value: https://doi.org/10.1016/j.geoderma.2019.113898
           - value: doi:10.1016/j.geoderma.2019.113898
-      link_addit_analys:
-        examples:
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: 'https://doi.org/10.1111/j.1574-6941.2011.01140.x'
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: 'doi:10.1111/j.1574-6941.2011.01140.x'
-      link_climate_info:
-        examples:
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: 'https://www.int-res.com/abstracts/cr/v14/n3/p161-173/'
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: 'doi:10.3354/cr014161'
       local_class_meth:
         examples:
           - value: https://www.nrcs.usda.gov/resources/education-and-teaching-materials/the-twelve-orders-of-soil-taxonomy
@@ -1164,7 +1124,6 @@ classes:
           Expected_value: string
           Preferred_unit: gram per gram or cubic centimeter per cubic centimeter
         multivalued: true
-        range: string
         examples:
           - value: 0.75 g water/g dry soil
           - value: 75% water holding capacity
@@ -1188,12 +1147,6 @@ classes:
         comments:
           - This can include a link to the instrument used or a citation for the method.
       tot_carb:
-        examples:
-          - object:
-              type: nmdc:QuantityValue
-              has_raw_value: 1 ug/L
-              has_numeric_value: 1
-              has_unit: ug/L
         todos:
           - is this inorganic and organic? both? could use some clarification.
           - ug/L doesn't seem like the right units. Should check this slots usage in databases and re-evaluate.
@@ -1213,16 +1166,6 @@ classes:
         comments:
           - Describe how samples were composited or sieved.
           - Use 'sample link' to indicate which samples were combined.
-        examples:
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: combined 2 cores | 4mm sieved
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: 4 mm sieved and homogenized
-          - object:
-              type: nmdc:TextValue
-              has_raw_value: 50 g | 5 cores | 2 mm sieved
         todos:
           - check validation and examples
       climate_environment:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -483,7 +483,6 @@ classes:
           syntax: "{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$"
           interpolated: true
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:poolp-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -497,7 +496,6 @@ classes:
       and colony picking.
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:isnp-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -526,7 +524,6 @@ classes:
       or maintained culture of the input organism.
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:cultp-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -572,7 +569,6 @@ classes:
           syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:extrp-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -616,7 +612,6 @@ classes:
           syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:libprp-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -645,7 +640,6 @@ classes:
           syntax: "{id_nmdc_prefix}:bsm-{id_shoulder}-{id_blade}$"
           interpolated: true
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:clsite-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -677,7 +671,6 @@ classes:
       - sampled_portion
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:subspr-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -715,7 +708,6 @@ classes:
       - duration
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:mixpro-{id_shoulder}-{id_blade}$"
       has_input:
@@ -753,7 +745,6 @@ classes:
       - volume
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:filtpr-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -786,7 +777,6 @@ classes:
       substances_used:
         description: The substance(s) that a processed sample is stored in.
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:storpr-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -816,7 +806,6 @@ classes:
       - temperature
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:cspro-{id_shoulder}-{id_blade}$"
       has_input:
@@ -848,7 +837,6 @@ classes:
       - substances_used
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:dispro-{id_shoulder}-{id_blade}$"
           interpolated: true

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -472,9 +472,6 @@ classes:
       has_input:
         minimum_cardinality: 2
         required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       has_output:
         required: true
         minimum_cardinality: 1
@@ -559,15 +556,11 @@ classes:
     slot_usage:
       has_input:
         required: true
-        range: Sample
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(bsm|osm|procsm)-{id_shoulder}-{id_blade}$"
           interpolated: true
       has_output:
         required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       id:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:extrp-{id_shoulder}-{id_blade}$"
@@ -603,14 +596,8 @@ classes:
     slot_usage:
       has_input:
         required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       has_output:
         required: true
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       id:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:libprp-{id_shoulder}-{id_blade}$"
@@ -678,18 +665,8 @@ classes:
         description: The output volume of the SubSampling Process.
       mass:
         description: The output mass of the SubSampling Process.
-      has_input:
-        range: Sample
-        structured_pattern: # MAM 2024-05-22 isn't that inherited from a parent class?
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       has_output:
-        range: ProcessedSample
         description: The subsample.
-        structured_pattern: # MAM 2024-05-22 isn't that inherited from a parent class?
-          syntax: "{id_nmdc_prefix}:(procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
-
   MixingProcess:
     class_uri: nmdc:MixingProcess
     description: >
@@ -710,13 +687,7 @@ classes:
       id:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:mixpro-{id_shoulder}-{id_blade}$"
-      has_input:
-        range: Sample
-        structured_pattern: # MAM 2024-05-22 isn't that inherited from a parent class?
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       has_output:
-        range: ProcessedSample
         description: The mixed sample.
         structured_pattern:
           syntax: "{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$"
@@ -750,13 +721,7 @@ classes:
           interpolated: true
       volume:
         description: The volume of sample filtered.
-      has_input:
-        range: Sample
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       has_output:
-        range: ProcessedSample
         structured_pattern:
           syntax: "{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$"
           interpolated: true
@@ -808,13 +773,7 @@ classes:
       id:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:cspro-{id_shoulder}-{id_blade}$"
-      has_input:
-        range: Sample
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(bsm|procsm)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       has_output:
-        range: ProcessedSample
         structured_pattern:
           syntax: "{id_nmdc_prefix}:procsm-{id_shoulder}-{id_blade}$"
           interpolated: true

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -52,7 +52,6 @@ classes:
       - insdc_assembly_identifiers
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmgas-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -101,7 +100,6 @@ classes:
       - insdc_assembly_identifiers
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmtas-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -124,7 +122,6 @@ classes:
       - gold_analysis_project_identifiers
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmtan-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -161,7 +158,6 @@ classes:
       - img_identifiers
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmtex-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -196,7 +192,6 @@ classes:
       - img_identifiers
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmag-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -227,7 +222,6 @@ classes:
       - output_read_count
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfrqc-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -249,7 +243,6 @@ classes:
     is_a: WorkflowExecution
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfrbt-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -276,7 +269,6 @@ classes:
       - c13_isotopologue_count
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmb-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -308,7 +300,6 @@ classes:
       - total_protein_count
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfmp-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true
@@ -332,7 +323,6 @@ classes:
       - peak_assignment_count
     slot_usage:
       id:
-        required: true
         structured_pattern:
           syntax: "{id_nmdc_prefix}:wfnom-{id_shoulder}-{id_blade}{id_version}$"
           interpolated: true

--- a/src/schema/workflow_execution_activity.yaml
+++ b/src/schema/workflow_execution_activity.yaml
@@ -127,14 +127,6 @@ classes:
           interpolated: true
       img_identifiers:
         maximum_cardinality: 1
-      has_input:
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$"
-          interpolated: true
-      has_output:
-        structured_pattern:
-          syntax: "{id_nmdc_prefix}:(dobj)-{id_shoulder}-{id_blade}$"
-          interpolated: true
       was_informed_by:
         structured_pattern:
           syntax: "{id_nmdc_prefix}:(omprc|dgns)-{id_shoulder}-{id_blade}$"

--- a/src/scripts/dump_induced_slots.py
+++ b/src/scripts/dump_induced_slots.py
@@ -1,0 +1,76 @@
+"""Dump every induced slot value in the schema, for diffing across a refactor.
+
+A change that claims not to alter the schema's meaning can be checked by running
+this before and after and diffing. An empty diff proves no induced slot moved,
+for every class and every slot at once.
+
+This is not the same check as diffing `nmdc_schema/nmdc_materialized_patterns.yaml`.
+That artifact is built with `--no-materialize-attributes`, so it does not expand
+per-class induced slots, and a change to an inherited `required` or `range` does not
+show up in it. This does expand them, which is why it was the gate used when removing
+redundant `slot_usage` assertions (see `report_redundant_slot_usage.py`).
+
+Usage:
+
+    poetry run python src/scripts/dump_induced_slots.py > before.tsv
+    # make the change
+    poetry run python src/scripts/dump_induced_slots.py > after.tsv
+    diff before.tsv after.tsv
+
+Output is one row per class, slot, and populated metaslot, sorted so the diff is
+stable. Roughly 18k rows for the current schema; it runs in about a second.
+"""
+
+from dataclasses import fields
+
+import click
+from linkml_runtime import SchemaView
+from linkml_runtime.linkml_model.meta import SlotDefinition
+
+# Recorded by the loader from where an element was read, so they say nothing about
+# meaning and would add noise to a diff of the same schema at two commits.
+PROVENANCE_METASLOTS = frozenset(
+    {"from_schema", "imported_from", "source_file", "owner"}
+)
+
+
+def dump(schema_view: SchemaView) -> list[str]:
+    """Every populated metaslot of every induced slot, as sorted TSV rows."""
+    metaslots = sorted(
+        f.name for f in fields(SlotDefinition) if f.name not in PROVENANCE_METASLOTS
+    )
+    rows: list[str] = []
+    for class_name in sorted(schema_view.all_classes()):
+        for slot_name in sorted(schema_view.class_slots(class_name)):
+            try:
+                induced = schema_view.induced_slot(slot_name, class_name)
+            except (ValueError, KeyError) as error:
+                rows.append(
+                    f"{class_name}\t{slot_name}\t<ERROR>\t{type(error).__name__}"
+                )
+                continue
+            for metaslot in metaslots:
+                value = getattr(induced, metaslot, None)
+                if value is None or value == [] or value == {} or value == ():
+                    continue
+                # Collapse multi-line reprs so one value stays one row.
+                rows.append(
+                    f"{class_name}\t{slot_name}\t{metaslot}\t{' '.join(repr(value).split())}"
+                )
+    return rows
+
+
+@click.command()
+@click.option(
+    "--schema-file",
+    default="src/schema/nmdc.yaml",
+    show_default=True,
+    help="Path to the schema file.",
+)
+def main(schema_file: str) -> None:
+    """Dump every induced slot value, for diffing a refactor against its baseline."""
+    click.echo("\n".join(dump(SchemaView(schema_file))))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_no_redundant_slot_usage.py
+++ b/tests/test_no_redundant_slot_usage.py
@@ -1,0 +1,40 @@
+"""Guard against reintroducing `slot_usage` that restates an inherited value.
+
+A ratchet, not a snapshot. It asserts the count does not grow, so a new redundant
+assertion fails here rather than accumulating unnoticed. The exhaustive check that
+a removal changed no meaning is `src/scripts/dump_induced_slots.py`, run before and
+after and diffed; that one needs a baseline and so does not belong in the suite.
+"""
+
+from linkml_runtime import SchemaView
+
+from src.scripts.report_redundant_slot_usage import find_redundancies
+
+SCHEMA_FILE = "src/schema/nmdc.yaml"
+
+# `PropertyAssertion.has_unit` asserts `required: false` over a baseline that is unset
+# rather than asserted. It restates the default, so the report flags it, but it is kept
+# on purpose: it documents the conditional requirement its description spells out, and
+# it becomes a genuine relaxation rather than a restatement if `AttributeValue` ever
+# requires `has_unit`. Removing it would be a silent loss of that marker.
+EXPECTED = {("PropertyAssertion", "has_unit", "required")}
+
+
+def test_no_unexpected_redundant_slot_usage():
+    findings = find_redundancies(SchemaView(SCHEMA_FILE))
+    actual = {(f.class_name, f.slot_name, f.metaslot) for f in findings}
+    unexpected = actual - EXPECTED
+    assert not unexpected, (
+        f"{len(unexpected)} slot_usage assertion(s) restate a value the class already "
+        f"inherits: {sorted(unexpected)}. Remove them, or add to EXPECTED with a reason. "
+        f"See src/scripts/report_redundant_slot_usage.py."
+    )
+
+
+def test_expected_exception_is_still_present():
+    """If this fails, EXPECTED is stale and should shrink rather than be ignored."""
+    findings = find_redundancies(SchemaView(SCHEMA_FILE))
+    actual = {(f.class_name, f.slot_name, f.metaslot) for f in findings}
+    assert EXPECTED <= actual, (
+        f"EXPECTED no longer occurs and should be pruned: {EXPECTED - actual}"
+    )


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-schema/issues/3349

Removes 68 of the 69 `slot_usage` assertions that restate a value the class already inherits. The induced slot is unchanged by every one of them; what they cost is that an edit to the parent silently stops reaching each class that restated the old value.

Pure deletions, 140 lines, no additions to the schema.

| commit | what |
|---|---|
| `598ca79` | 31 `id.required: true` restatements |
| `33436d9` | `has_input` / `has_output` from `MaterialProcessing`, and `Biosample` restating `Sample` |
| `8ed7149` | the gate and a ratchet test |

Nine `slot_usage` entries had every metaslot flagged, so the slot key went with them.

## How this is verified

Diffing `nmdc_schema/nmdc_materialized_patterns.yaml` does not answer the question. It is built with `--no-materialize-attributes`, so per-class induced slots are never expanded, and a changed inherited `required` or `range` would not appear in it.

`src/scripts/dump_induced_slots.py` expands them: 18408 rows in about a second. Run before and after, the diff is empty. That is the proof that nothing here changed meaning, for every class and slot at once rather than a sample.

```bash
make assets/induced-slots.tsv   # before
# apply the change
make assets/induced-slots.tsv   # after, then diff
```

It is deliberately not a prerequisite of any other target, since it is a hand-run gate rather than a build artifact. Reusable for any future refactor claiming to preserve meaning.

`linkml validate src/schema/nmdc.yaml` reports no issues, and the Python tests pass.

## The one kept, and why

`PropertyAssertion.has_unit.required: false` stays. Its baseline is unset rather than asserted, so it restates a default rather than a value, and it documents the conditional requirement its own description spells out ("required only when numeric value is present"). If `AttributeValue` ever requires `has_unit`, that assertion stops being a restatement and becomes a genuine relaxation, so the marker is worth keeping.

Related: no `slot_usage` in the schema relaxes an inherited constraint today. Checked `required` true to false and loosened `minimum_value` / `maximum_value`; zero hits.

## Ratchet rather than snapshot

`tests/test_no_redundant_slot_usage.py` asserts nothing redundant exists beyond that one documented exception, so a new one fails in CI instead of accumulating. A committed snapshot of all 18408 values would instead need regenerating on every legitimate schema change and would fail loudly for correct work.

## Follow-up, not in this PR

`src/docs/maintaining-the-schema.md` cites re-declaring the `uriorcurie` range as deliberate belt-and-suspenders practice. No class does that in a `slot_usage`, so the example needs replacing with a real one.
