### PR TITLE
Remove see_also links that point at closed issues

### DIFF
--- a/src/schema/attribute_values.yaml
+++ b/src/schema/attribute_values.yaml
@@ -259,10 +259,12 @@ slots:
     notes:
       - makes it easier to read example data files
       - required for polymorphic MongoDB collections
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/1048
-      - https://github.com/microbiomedata/nmdc-schema/issues/1233
-      - https://github.com/microbiomedata/nmdc-schema/issues/248
+    comments:
+      - >-
+        Deprecating this slot was proposed and rejected: without it, a document
+        read back from a polymorphic MongoDB collection cannot be resolved to the
+        class it instantiates. It is required on every class for that reason,
+        rather than as a convention inherited from LinkML.
     structured_aliases:
       - literal_form: workflow_execution_class
         contexts:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -106,9 +106,6 @@ classes:
         with range OntologyClass. The intent is that these slots point to NcbiTaxon instances specifically,
         but LinkML does not currently support constraining the term slot of a ControlledIdentifiedTermValue
         to a particular OntologyClass subclass.
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/2959
-      - https://github.com/microbiomedata/nmdc-schema/issues/2971
     close_mappings:
       - biolink:OrganismTaxon
 
@@ -269,9 +266,7 @@ classes:
     exact_mappings:
       - COB:0000022
     see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/2959
       - https://github.com/microbiomedata/nmdc-schema/issues/2803
-      - https://github.com/microbiomedata/nmdc-schema/issues/2971
 
   PlannedProcess:
     description: >-
@@ -718,9 +713,6 @@ slots:
         The global range stays OntologyClass. Organism is currently the only class that
         narrows classified_as to NcbiTaxon, via slot_usage. Extending that narrowing to
         other classes is tracked in https://github.com/microbiomedata/nmdc-schema/issues/3016.
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/2959
-      - https://github.com/microbiomedata/nmdc-schema/issues/3016
     narrow_mappings:
       - biolink:in_taxon
 

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -64,8 +64,6 @@ subsets:
         permissible value has a subset here. expert_curation is awarded from
         ProvenanceMetadata.source_system_of_record rather than from slot
         completeness, so it has no badge_topic subset.
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/3228
   biogeochemistry:
     description: >-
       Biosample slots holding measured biogeochemical analytes: nitrogen,
@@ -74,9 +72,6 @@ subsets:
       awarded the biogeochemistry badge.
     annotations:
       badge_minimum_slots: 2
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/3228
-      - https://github.com/microbiomedata/nmdc-schema/issues/3326
     in_subset:
       - badge_topic
   host_information:
@@ -91,9 +86,6 @@ subsets:
         data portal shows only badges a sample has earned.
     annotations:
       badge_minimum_slots: 2
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/3228
-      - https://github.com/microbiomedata/nmdc-schema/issues/3326
     in_subset:
       - badge_topic
 
@@ -261,8 +253,6 @@ slots:
       "Categorical description of the sample's salinity. Examples: halophile,
         halotolerant, hypersaline, huryhaline"
     range: string
-    see_also:
-      - https://github.com/microbiomedata/nmdc-metadata/pull/297
     notes:
       - "maps to gold:salinity"
 

--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -251,7 +251,7 @@ slots:
   salinity_category:
     description:
       "Categorical description of the sample's salinity. Examples: halophile,
-        halotolerant, hypersaline, huryhaline"
+        halotolerant, hypersaline, euryhaline"
     range: string
     notes:
       - "maps to gold:salinity"

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -1460,7 +1460,6 @@ classes:
         study, or a soil sample are Biosamples because they contain communities of organisms.
     see_also:
       - https://github.com/microbiomedata/nmdc-schema/issues/2803
-      - https://github.com/microbiomedata/nmdc-schema/issues/2961
 
   Site:
     class_uri: nmdc:Site

--- a/src/schema/external_identifiers.yaml
+++ b/src/schema/external_identifiers.yaml
@@ -246,8 +246,6 @@ slots:
         description: GOLD organism_v2 Campylobacter concisus 13826 (queried 2026-04-14)
     range: uriorcurie
     multivalued: true
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/2973
 
 
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -514,8 +514,6 @@ classes:
           interpolated: true
     close_mappings:
       - OBI:0000512
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/2978
 
   Culturing:
     class_uri: nmdc:Culturing
@@ -544,8 +542,6 @@ classes:
           interpolated: true
     close_mappings:
       - OBI:0001147
-    see_also:
-      - https://github.com/microbiomedata/nmdc-schema/issues/2978
 
   Extraction:
     class_uri: nmdc:Extraction

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -491,6 +491,13 @@ classes:
       A material processing that separates an organism from a mixed sample by
       selection techniques such as serial dilution, plating on selective media,
       and colony picking.
+    comments:
+      - >-
+        Added to model the biological steps between collecting an environmental
+        sample and having an OrganismSample ready for DNA extraction, which
+        previously had no process classes. Isolation, Culturing and the
+        extraction step are the three-step workflow a cultured isolate goes
+        through.
     slot_usage:
       id:
         structured_pattern:
@@ -517,6 +524,13 @@ classes:
       A material processing that grows an organism under controlled conditions.
       The input and output are both organism samples; the output is an expanded
       or maintained culture of the input organism.
+    comments:
+      - >-
+        Added to model the biological steps between collecting an environmental
+        sample and having an OrganismSample ready for DNA extraction, which
+        previously had no process classes. Isolation, Culturing and the
+        extraction step are the three-step workflow a cultured isolate goes
+        through.
     slot_usage:
       id:
         structured_pattern:

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -491,13 +491,6 @@ classes:
       A material processing that separates an organism from a mixed sample by
       selection techniques such as serial dilution, plating on selective media,
       and colony picking.
-    comments:
-      - >-
-        Added to model the biological steps between collecting an environmental
-        sample and having an OrganismSample ready for DNA extraction, which
-        previously had no process classes. Isolation, Culturing and the
-        extraction step are the three-step workflow a cultured isolate goes
-        through.
     slot_usage:
       id:
         structured_pattern:
@@ -524,13 +517,6 @@ classes:
       A material processing that grows an organism under controlled conditions.
       The input and output are both organism samples; the output is an expanded
       or maintained culture of the input organism.
-    comments:
-      - >-
-        Added to model the biological steps between collecting an environmental
-        sample and having an OrganismSample ready for DNA extraction, which
-        previously had no process classes. Isolation, Culturing and the
-        extraction step are the three-step workflow a cultured isolate goes
-        through.
     slot_usage:
       id:
         structured_pattern:

--- a/src/schema/subsets.md
+++ b/src/schema/subsets.md
@@ -66,7 +66,11 @@ Two of its entries are worth remembering, because they will come up again:
 ## Badge subsets
 
 A badge subset groups the slots whose completeness one metadata-quality badge
-measures. It is declared in `src/schema/basic_slots.yaml` and is itself a member
+measures. Grouping slots into scoreable sets follows the Metadata
+Coverage Index (Liolios et al. 2012,
+https://pmc.ncbi.nlm.nih.gov/articles/PMC3558968/), which measures completeness
+against a defined field grouping rather than against every field a record could
+carry. It is declared in `src/schema/basic_slots.yaml` and is itself a member
 of the `badge_topic` group subset (`in_subset: [badge_topic]`), which is how
 tooling and the sync test tell badge subsets apart from `jgi_isolate`. This uses
 the native subset mechanism rather than a custom annotation.


### PR DESCRIPTION
Removes the 19 `see_also` entries listed in https://github.com/microbiomedata/nmdc-schema/issues/3345, all of which pointed at closed issues or pull requests.

Distinct GitHub references in the merged schema go from 19 to 8. Ten `see_also` keys had no surviving items and were dropped with them. All edits are in hand-maintained source files; none of these references lived in the generated `mixs.yaml`, so no customization lines or regeneration were involved.

**The `type` slot's reasoning is preserved rather than deleted.** Its three links (https://github.com/microbiomedata/nmdc-schema/issues/248 deprecate type slot, https://github.com/microbiomedata/nmdc-schema/issues/1048 all classes should have a required type-designating slot, https://github.com/microbiomedata/nmdc-schema/issues/1233 MVP polymorphic planned_process_set) were together the only record of why the slot exists in its current form. That is now a comment on the slot:

> Deprecating this slot was proposed and rejected: without it, a document read back from a polymorphic MongoDB collection cannot be resolved to the class it instantiates. It is required on every class for that reason, rather than as a convention inherited from LinkML.

**One entry was deliberately kept and needs a reviewer's opinion.** `emsl_project_identifiers` has:

```yaml
see_also:
  - https://github.com/microbiomedata/nmdc-schema/issues/927#issuecomment-1802136437
```

The issue is closed, so the rule as stated would remove it, but this is a deep link to a specific comment rather than to a thread, and that comment is where the reasoning for the identifier pattern actually lives. Deleting it loses content with nowhere else to point. Happy to remove it if reviewers prefer the rule applied uniformly; it is a one-line change.

Three closed-issue references remain in the schema and are out of scope, because they sit in prose rather than in `see_also`: two in class comments and one inside a `description`. Those read as narrative context and are not presented to a user as a link to follow.

Verification: every file in `src/schema/` parses, the schema regenerates, and the full test suite passes (87 tests).

Closes https://github.com/microbiomedata/nmdc-schema/issues/3345
