### PR TITLE
Show member subsets and a subset's own in_subset on subset pages

### DIFF
--- a/src/doc-templates/subset.md.jinja2
+++ b/src/doc-templates/subset.md.jinja2
@@ -48,7 +48,7 @@ URI: {{ gen.link(element) }}
 {% endfor %}
 
 {# A subset can group other subsets; badge_topic does. #}
-{% for sub in schemaview.all_subsets().values() %}
+{% for sub in schemaview.all_subsets().values()|sort(attribute=sort_by) %}
     {%- if element.name in (sub.in_subset or []) %}
         {% set _ = subsets_in_subset.append(sub) %}
     {%- endif %}

--- a/src/doc-templates/subset.md.jinja2
+++ b/src/doc-templates/subset.md.jinja2
@@ -26,6 +26,7 @@ URI: {{ gen.link(element) }}
 {% set classes_in_subset = [] %}
 {% set slots_in_subset = [] %}
 {% set enums_in_subset = [] %}
+{% set subsets_in_subset = [] %}
 
 {# Collect classes, slots, and enumerations in subset #}
 {% for c in gen.all_class_objects()|sort(attribute=sort_by) %}
@@ -45,6 +46,26 @@ URI: {{ gen.link(element) }}
         {% set _ = enums_in_subset.append(e) %}
     {%- endif %}
 {% endfor %}
+
+{# A subset can group other subsets; badge_topic does. #}
+{% for sub in schemaview.all_subsets().values() %}
+    {%- if element.name in (sub.in_subset or []) %}
+        {% set _ = subsets_in_subset.append(sub) %}
+    {%- endif %}
+{% endfor %}
+
+{% if element.in_subset %}
+Member of: {% for s in element.in_subset %}{{ gen.link(schemaview.get_subset(s)) }}{% if not loop.last %}, {% endif %}{% endfor %}
+{% endif %}
+
+{% if subsets_in_subset %}
+## Subsets in subset
+| Subset | Description |
+| --- | --- |
+{% for sub in subsets_in_subset -%}
+| {{ gen.link(sub) }} | {{ shorten(sub.description) }} |
+{% endfor %}
+{% endif %}
 
 {% if classes_in_subset %}
 ## Classes in subset


### PR DESCRIPTION
Makes subset grouping visible on subset pages, in both directions. Fixes https://github.com/microbiomedata/nmdc-schema/issues/3346.

`subset.md.jinja2` collected classes, slots and enums and nothing else, so a subset whose members are other subsets rendered with an empty body. `badge_topic` is that case: its two members are the `biogeochemistry` and `host_information` subsets, and https://microbiomedata.github.io/nmdc-schema/BadgeTopic/ listed neither.

Two additions:

**Subsets in subset.** A member-subset table, collected the same way the other three kinds are. `BadgeTopic` now renders:

| Subset | Description |
| --- | --- |
| Biogeochemistry | Biosample slots holding measured biogeochemical analytes: nitrogen,... |
| HostInformation | Biosample slots describing the host organism a sample was taken from or... |

**Member of.** A subset's own `in_subset`, so the grouping is reachable from the member as well as from the group. `Biogeochemistry` now shows `Member of: BadgeTopic`.

Rendered output for all four subsets, confirming each section appears only where it applies:

| page | slots in subset | subsets in subset | member of |
| --- | --- | --- | --- |
| `JgiIsolate` | yes | no | no |
| `Biogeochemistry` | yes | no | yes |
| `HostInformation` | yes | no | yes |
| `BadgeTopic` | no | yes | no |

`JgiIsolate` is unchanged, which is the regression check that matters: it is the one subset predating this work.

Full test suite passes (87 tests).

Note these pages are also affected by the frontmatter collapse in https://github.com/microbiomedata/nmdc-schema/pull/3350. The two changes touch different parts of the same template and do not conflict, but subset pages will not read correctly until both are merged.

Closes https://github.com/microbiomedata/nmdc-schema/issues/3346
