### PR TITLE
Correct two documented facts about slot_usage cascading and readonly metaslots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,10 +212,17 @@ hand-edited schema YAML files under `src/schema/`. If they appear in
 generated files (like `mixs.yaml`), the build pipeline in
 `makefiles/mixs.Makefile` strips them via `yq eval`.
 
-The 12 readonly slots: `definition_uri`, `domain_of`, `from_schema`,
-`generation_date`, `imported_from`, `is_usage_slot`, `metamodel_version`,
-`owner`, `source_file`, `source_file_date`, `source_file_size`,
-`usage_slot_name`.
+The 12 readonly slots split across two metamodel element types. Tooling that
+filters on them needs the distinction; a list of all 12 read as slot-level has
+already produced a false bug report.
+
+On `SlotDefinition` (7), so reachable on a slot or in `slot_usage`:
+`definition_uri`, `domain_of`, `from_schema`, `imported_from`, `is_usage_slot`,
+`owner`, `usage_slot_name`.
+
+On `SchemaDefinition` (5), never present on a slot even after induction:
+`generation_date`, `metamodel_version`, `source_file`, `source_file_date`,
+`source_file_size`.
 
 Context: PR #2696 (dematerialize mixs.yaml), issue #2663.
 

--- a/src/docs/developer-docs.md
+++ b/src/docs/developer-docs.md
@@ -86,9 +86,16 @@ for details.
 ### What are LinkML readonly metaslots and why shouldn't I assert them?
 
 The LinkML metamodel defines 12 **readonly** slots that are automatically populated
-by the schema loader or generators: `definition_uri`, `domain_of`, `from_schema`,
-`generation_date`, `imported_from`, `is_usage_slot`, `metamodel_version`, `owner`,
-`source_file`, `source_file_date`, `source_file_size`, `usage_slot_name`.
+by the schema loader or generators. They belong to two different metamodel element
+types, which matters when writing tooling that filters on them.
+
+Seven are on `SlotDefinition`, so they can appear on a slot or in a `slot_usage`
+block: `definition_uri`, `domain_of`, `from_schema`, `imported_from`,
+`is_usage_slot`, `owner`, `usage_slot_name`.
+
+Five are on `SchemaDefinition` and describe the file a schema was read from. They
+never appear on a slot, even after induction: `generation_date`, `metamodel_version`,
+`source_file`, `source_file_date`, `source_file_size`.
 
 **Do not add these to hand-edited schema YAML files** under `src/schema/`. The
 loader fills them in at runtime, so asserting them is redundant and can cause

--- a/src/docs/maintaining-the-schema.md
+++ b/src/docs/maintaining-the-schema.md
@@ -140,9 +140,19 @@ these gold_biosample_identifiers would all be web-resolvable.
 
 We can limit the values that go into any slot by using a `pattern` constraint. We can also use the `id_prefixes` constraint
 to limit the prefixes that are used in whatever slot has been declared to be the identifier of a class.
-(Attributes of a class are supposed to be cascaded to subclasses, via the `is_a` attribute.
-This may not always be the case though. In the nmdc-schema we have been using a belt-and-suspenders approach of 
-re-declaring the `uriorcurie` range )
+
+Constraints written in a class's `slot_usage` do cascade to subclasses through `is_a`, so there is no need to
+restate an inherited value defensively. An earlier version of this page described a belt-and-suspenders practice of
+re-declaring the `uriorcurie` range for that reason. No class does that, and restating an inherited value is now
+treated as something to remove: `src/scripts/report_redundant_slot_usage.py` finds them and
+`tests/test_no_redundant_slot_usage.py` fails CI when a new one appears.
+
+Restating costs something real. A class that repeats a value it already inherits stops tracking the parent, so a
+later edit upstream silently does not reach it.
+
+One inheritance path does drop values, and it is not this one: a *slot* that inherits from another slot through
+slot-level `is_a` loses a falsy value such as `minimum_value: 0`. That is [linkml issue 3845](https://github.com/linkml/linkml/issues/3845)
+and it does not affect class `slot_usage`.
 
 All prefixes used in the `id_prefixes` constraint must be defined in the schema. 
 We should have a standing practice of reflecting on the declared `id_prefixes`, and removing prefixes that haven't been used yet

--- a/src/scripts/report_redundant_slot_usage.py
+++ b/src/scripts/report_redundant_slot_usage.py
@@ -10,9 +10,12 @@ induced slot when the class has a parent, and the global slot definition
 otherwise. That distinction matters: a `slot_usage` restoring the global value
 after a parent narrowed it is a real refinement, not a redundancy.
 
-This script reports them. It does not edit the schema, because some restatements
-are deliberate (see the note on re-declaring `range: uriorcurie` in
-`src/docs/maintaining-the-schema.md`), so a human decides what to remove.
+This script reports them. It does not edit the schema, because a restatement can
+be deliberate, so a human decides what to remove. `PropertyAssertion.has_unit`
+asserting `required: false` is the one currently kept: its baseline is unset
+rather than asserted, and it documents the conditional requirement its own
+description spells out. `tests/test_no_redundant_slot_usage.py` records it as the
+single expected exception.
 
 Usage:
 


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-schema/issues/3356

Two documented facts did not match the schema, and both produced wrong conclusions in the last day.

**The belt-and-suspenders passage.** `maintaining-the-schema.md` justified restating an inherited value on the grounds that cascading "may not always be the case", and offered re-declaring the `uriorcurie` range as the example. No class re-declares `id.range` in a `slot_usage`, so the example did not exist, and the premise does not hold either: constraints written in a class `slot_usage` do cascade through `is_a`. That passage was cited as authority in https://github.com/microbiomedata/nmdc-schema/pull/3334 and https://github.com/microbiomedata/nmdc-schema/pull/3351.

Replaced with the current practice, which is the opposite: restatements are reported by `report_redundant_slot_usage.py` and a new one fails CI in `test_no_redundant_slot_usage.py`. The real failure mode is kept, with a pointer to it: slot-level `is_a` does drop a falsy value such as `minimum_value: 0`, which is [linkml issue 3845](https://github.com/linkml/linkml/issues/3845) and does not affect class `slot_usage`.

**The readonly metaslots.** `developer-docs.md` and `CLAUDE.md` both listed all 12 without saying they span two metamodel element types. Only 7 are on `SlotDefinition`; `generation_date`, `metamodel_version`, `source_file`, `source_file_date`, and `source_file_size` are `SchemaDefinition` and never appear on a slot, even after induction. A reviewer read the list as slot-level and reported a defect in `report_redundant_slot_usage.py` that could not occur, rebutted at https://github.com/microbiomedata/nmdc-schema/pull/3334#issuecomment-5285910509.

Both splits verified against `fields(SlotDefinition)` and `fields(SchemaDefinition)`: the 7 and the 5 are disjoint and total 12.

Docs only, no schema or code changes.
