### PR TITLE
Validate example data structurally, not just unit alignment

### DIFF
--- a/project.Makefile
+++ b/project.Makefile
@@ -108,7 +108,8 @@ examples/output/Biosample-exhaustive-pretty-sorted.yaml: src/data/valid/Database
 #   ssh -i {YOUR_GATEWAY_KEY} -L 27124:runtime-api-mongodb-headless.nmdc-prod.svc.cluster.local:27017 \
 #       -o ServerAliveInterval=60 ssh-mongo@jump-dev.microbiomedata.org
 # then connect to localhost:27124 with directConnection=true. The authoritative procedure, including
-# how to obtain the gateway key, is microbiomedata/nmdc-lakehouse/docs/mongodb-connection.md
+# how to obtain the gateway key, is
+# https://github.com/microbiomedata/nmdc-lakehouse/blob/main/docs/mongodb-connection.md
 
 pure-export-and-validate: local/mongo_as_nmdc_database_validation.log
 

--- a/project.Makefile
+++ b/project.Makefile
@@ -102,10 +102,13 @@ examples/output/Biosample-exhaustive-pretty-sorted.yaml: src/data/valid/Database
 		-i $< \
 		-o $@
 
-# this setup is required if you want to retreive any content or statistics from PyMongo
+# this setup is required if you want to retrieve any content or statistics from PyMongo
 # pure-export doesn't require a PyMongo connection when run in the --skip-collection-check mode
-#   1. . ~/sshproxy.sh -u {YOUR_NERSC_USERNAME}
-#   2. ssh -i ~/.ssh/nersc -L27777:mongo-loadbalancer.nmdc.production.svc.spin.nersc.org:27017 -o ServerAliveInterval=60 {YOUR_NERSC_USERNAME}@dtn01.nersc.gov
+# Production MongoDB is reached through the cloud gateway, not NERSC. Open a tunnel with:
+#   ssh -i {YOUR_GATEWAY_KEY} -L 27124:runtime-api-mongodb-headless.nmdc-prod.svc.cluster.local:27017 \
+#       -o ServerAliveInterval=60 ssh-mongo@jump-dev.microbiomedata.org
+# then connect to localhost:27124 with directConnection=true. The authoritative procedure, including
+# how to obtain the gateway key, is microbiomedata/nmdc-lakehouse/docs/mongodb-connection.md
 
 pure-export-and-validate: local/mongo_as_nmdc_database_validation.log
 

--- a/tests/test_nmdc_schema_validation_plugin.py
+++ b/tests/test_nmdc_schema_validation_plugin.py
@@ -54,7 +54,7 @@ def nmdc_schema_validator():
         schema=SCHEMA_FILE,
         validation_plugins=[
             NmdcSchemaValidationPlugin(),
-        ]
+        ],
     )
 
 
@@ -72,7 +72,7 @@ def fully_validating_validator():
         validation_plugins=[
             JsonschemaValidationPlugin(closed=True),
             NmdcSchemaValidationPlugin(),
-        ]
+        ],
     )
 
 

--- a/tests/test_nmdc_schema_validation_plugin.py
+++ b/tests/test_nmdc_schema_validation_plugin.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from linkml.validator import Validator
+from linkml.validator.plugins import JsonschemaValidationPlugin
 
 from nmdc_schema_validation_plugin import NmdcSchemaValidationPlugin
 from tests import SCHEMA_FILE, ROOT
@@ -11,6 +12,7 @@ def minimal_biosample():
     return {
         "id": "nmdc:bsm-99-dtTMNb",
         "type": "nmdc:Biosample",
+        "name": "minimal biosample",
         "associated_studies": ["nmdc:sty-00-abc123"],
         "env_broad_scale": {
             "type": "nmdc:ControlledIdentifiedTermValue",
@@ -41,9 +43,34 @@ def minimal_biosample():
 
 @pytest.fixture(scope="module")
 def nmdc_schema_validator():
+    """Validator that runs ONLY the NMDC plugin, for unit-testing the plugin itself.
+
+    Passing ``validation_plugins`` replaces linkml's default ``JsonschemaValidationPlugin``
+    rather than adding to it, so this validator does no structural validation at all. That is
+    what the two tests below want: they assert on the plugin's own results in isolation. Any
+    test that means "this instance is valid" needs ``fully_validating_validator`` instead.
+    """
     return Validator(
         schema=SCHEMA_FILE,
         validation_plugins=[
+            NmdcSchemaValidationPlugin(),
+        ]
+    )
+
+
+@pytest.fixture(scope="module")
+def fully_validating_validator():
+    """Validator that runs structural validation AND the NMDC plugin.
+
+    ``JsonschemaValidationPlugin`` is linkml's default and covers required slots, id patterns,
+    enum membership, and (in closed mode) unexpected properties. ``NmdcSchemaValidationPlugin``
+    adds the QuantityValue unit-alignment check that the schema alone cannot express. Neither
+    subsumes the other, so example data needs both.
+    """
+    return Validator(
+        schema=SCHEMA_FILE,
+        validation_plugins=[
+            JsonschemaValidationPlugin(closed=True),
             NmdcSchemaValidationPlugin(),
         ]
     )
@@ -55,7 +82,7 @@ def test_valid_instance(nmdc_schema_validator, minimal_biosample):
         **minimal_biosample,
         "samp_store_temp": {
             "type": "nmdc:QuantityValue",
-            "has_value": -80,
+            "has_numeric_value": -80,
             "has_unit": "Cel"
         }
     }
@@ -70,7 +97,7 @@ def test_invalid_instance(nmdc_schema_validator, minimal_biosample):
         **minimal_biosample,
         "samp_store_temp": {
             "type": "nmdc:QuantityValue",
-            "has_value": -80,
+            "has_numeric_value": -80,
             "has_unit": "INVALID_UNIT"
         }
     }
@@ -81,11 +108,49 @@ def test_invalid_instance(nmdc_schema_validator, minimal_biosample):
     assert "Cel" in report.results[0].message, "message should include the expected unit"
 
 
-def test_all_valid_examples(nmdc_schema_validator):
+def test_structural_defects_need_the_jsonschema_plugin(
+    nmdc_schema_validator, fully_validating_validator, minimal_biosample
+):
+    """Guard the plugin-replacement trap that let structural defects through.
+
+    Passing ``validation_plugins`` to ``Validator`` REPLACES linkml's default
+    ``JsonschemaValidationPlugin`` rather than adding to it. A validator built with the NMDC plugin
+    alone therefore accepts an instance with a broken id, a missing required slot, or an invented
+    property. This test pins both halves of that: the plugin-only validator stays silent, and the
+    fully validating one does not. If someone later drops ``JsonschemaValidationPlugin`` from
+    ``fully_validating_validator``, this fails instead of quietly widening what passes.
+    """
+    structurally_broken = {
+        **minimal_biosample,
+        "id": "NOT-AN-NMDC-ID",
+        "invented_slot": "no such slot in the schema",
+    }
+
+    plugin_only_report = nmdc_schema_validator.validate(
+        structurally_broken, target_class="Biosample"
+    )
+    assert not plugin_only_report.results, (
+        "the NMDC plugin alone is not expected to catch structural defects; "
+        "if it now does, this test's premise has changed"
+    )
+
+    full_report = fully_validating_validator.validate(
+        structurally_broken, target_class="Biosample"
+    )
+    assert full_report.results, "structural defects must be caught when jsonschema runs"
+
+
+def test_all_valid_examples(fully_validating_validator):
     """Test that all example files in src/data/valid validate successfully.
 
     This would be better as part of the `linkml-run-examples` command, but that CLI doesn't allow
-    specifying custom validation plugins at present.
+    specifying custom validation plugins at present. That is why the unit-alignment check is
+    repeated here rather than left to `make test`'s examples runner.
+
+    Use `fully_validating_validator`, not `nmdc_schema_validator`. The latter runs the NMDC plugin
+    alone, which checks unit alignment and nothing else, so a file with a bad id pattern, a missing
+    required slot, or an unexpected property passes it. The examples runner in `make test` catches
+    those, but only there, which makes a green `pytest tests/` mean less than it appears to.
 
     If any example file's target class is absent from the materialized-patterns artifact, the
     test is marked skipped at the end with a list of affected files. This happens during feature
@@ -111,7 +176,7 @@ def test_all_valid_examples(nmdc_schema_validator):
             skipped.append(f"{example_file.name} (class '{target_class}' not in artifact)")
             continue
 
-        report = nmdc_schema_validator.validate(instance, target_class=target_class)
+        report = fully_validating_validator.validate(instance, target_class=target_class)
         assert not report.results, f"Validation errors in {example_file}"
 
     if skipped:

--- a/tests/test_nmdc_schema_validation_plugin.py
+++ b/tests/test_nmdc_schema_validation_plugin.py
@@ -47,7 +47,7 @@ def nmdc_schema_validator():
 
     Passing ``validation_plugins`` replaces linkml's default ``JsonschemaValidationPlugin``
     rather than adding to it, so this validator does no structural validation at all. That is
-    what the two tests below want: they assert on the plugin's own results in isolation. Any
+    what the plugin unit tests want: they assert on the plugin's own results in isolation. Any
     test that means "this instance is valid" needs ``fully_validating_validator`` instead.
     """
     return Validator(


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-schema/issues/3360

`CLAUDE.md` has warned since May that "the pytest validation plugin can be more permissive, so this can pass unit tests and still fail the build at the examples step" (b3f57735e). This is the cause of that, and the fix.

`Validator(schema=..., validation_plugins=[...])` **replaces** linkml's default `JsonschemaValidationPlugin` rather than adding to it. `test_all_valid_examples` was built that way, so despite its name it checked QuantityValue unit alignment and nothing else. Measured against a file merged yesterday, one mutation at a time:

| planted defect | before | after |
|---|---|---|
| `has_output` set to a non-CURIE string | passes | fails |
| `id` violating the class id pattern | passes | fails |
| required `type` or `analyte_category` removed | passes | fails |
| invented slot added | passes | fails |

`make test` was never fooled, because the examples runner does full validation, so nothing bad reached `main` through this. The cost was local: `pytest tests/` reported green on 161 files it had barely inspected, and anyone iterating that way got no signal until CI.

The two tests that unit-test the plugin keep the plugin-only validator, since folding jsonschema results into them would make `test_invalid_instance`'s single-result assertion a statement about two different checkers. The corpus test gets a second fixture that runs both.

Along the way this exposed that `minimal_biosample` set `has_value` on a QuantityValue. That slot does not exist (it is `has_numeric_value`, which `CLAUDE.md` documents), and the fixture also omitted the required `name`. So the shared fixture described an instance shape that could never occur in real data, and nothing noticed because it was only ever run through the validator that does not check structure.

`test_structural_defects_need_the_jsonschema_plugin` asserts both halves: the plugin-only validator stays silent on a broken instance, the full one does not. Dropping the plugin again fails that test rather than quietly widening what passes.

**Unrelated one-comment fix in the same PR**, at Mark's request rather than as a drive-by: the Mongo tunnel instructions in `project.Makefile` pointed at `mongo-loadbalancer.nmdc.production.svc.spin.nersc.org` through a NERSC login node. Production Mongo is reached through the `jump-dev.microbiomedata.org` cloud gateway now, so anyone following those lines was aiming at a decommissioned host.

Verified: full suite 93 passed. A defect planted in a valid example fails the corpus test now and passed it before.
