### PR TITLE
Remove internal spreadsheet reference from CreditAssociation

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -300,8 +300,6 @@ classes:
     description: >-
       This class supports binding associated researchers to studies.
       There will be at least a slot for a CRediT Contributor Role and for a person value.
-      Specifically see the associated researchers tab on the NMDC_SampleMetadata-V4_CommentsForUpdates
-      at https://docs.google.com/spreadsheets/d/1INlBo5eoqn2efn4H2P2i8rwRBtnbDVTqXrochJEAPko/edit#gid=0
     slots:
       - applies_to_person
       - applied_roles


### PR DESCRIPTION
## Summary

Remove the internal NMDC spreadsheet and tab reference from the public `CreditAssociation` description, as requested in #3300.

The remaining description continues to explain that the class binds associated researchers to studies through a CRediT contributor role and a person value.

Fixes #3300.

## Validation

- `make squeaky-clean all test linkml-lint`
- LinkML metamodel validation passed
- 93 Python tests passed
- Example generation and doctests passed
- All LinkML lint checks passed
- `git diff --check`

## Generated artifacts

The clean build exposed unrelated existing drift in tracked generated files under `nmdc_schema/`. Those files are intentionally excluded from this atomic source change, following the policy tracked in #1230. The observed drift was documented there for follow-up.