### PR TITLE
Document foreign class_uri and slot_uri conventions

### DIFF
--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -250,8 +250,15 @@ identity in RDF and OWL.
 The second is how far a wrong answer travels, which depends on whether the class
 is abstract. `type` is `designates_type: true`
 (`src/schema/attribute_values.yaml`), so LinkML writes a class's `class_uri` into
-every instance of it. An abstract class has no instances, so its `class_uri`
-never reaches data. `PlannedProcess` is abstract. `CreditAssociation` is not, so
+every instance of it. An abstract class is not instantiated
+directly, so its `class_uri` does not reach production data. `PlannedProcess` is abstract, and no record in
+production carries `OBI:0000011`; every `PlannedProcess` descendant in the data
+carries its own concrete `nmdc:` type. That is a modelling convention rather
+than something the build enforces: `abstract: true` does not stop the generated
+Python dataclass or the JSON Schema definition from accepting a direct instance,
+so the guarantee comes from how data is produced, not from validation.
+
+`CreditAssociation` is not abstract, so
 every credit association record in production carries `type: prov:Association`
 rather than `nmdc:CreditAssociation`. It is the only class whose `class_uri`
 reaches data this way.

--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -244,8 +244,7 @@ abstract. `type` is `designates_type: true`, so LinkML writes a class's
 foreign `class_uri` there is invisible to data. `PlannedProcess` is abstract.
 `CreditAssociation` is not, and every credit association record in production
 carries `type: prov:Association` rather than `nmdc:CreditAssociation`, making it
-the only place a foreign URI appears in NMDC data. (Criterion identified by
-Katherine Heal, 2026-08-20.)
+the only place a foreign URI appears in NMDC data.
 
 `CreditAssociation` is deliberate rather than incidental: `has_credit_associations`
 carries `slot_uri: prov:qualifiedAssociation`, so the class and the slot are a

--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -238,13 +238,23 @@ All 502 slots carrying an explicit `slot_uri` use a foreign URI; none is
 Only two of the 80 classes have a foreign `class_uri`: `PlannedProcess`
 (`OBI:0000011`, above) and `CreditAssociation` (`prov:Association`).
 
-Whether a foreign `class_uri` reaches data depends on whether the class is
-abstract. `type` is `designates_type: true`, so LinkML writes a class's
-`class_uri` into every instance of it. An abstract class has no instances, so a
-foreign `class_uri` there is invisible to data. `PlannedProcess` is abstract.
-`CreditAssociation` is not, and every credit association record in production
-carries `type: prov:Association` rather than `nmdc:CreditAssociation`, making it
-the only place a foreign URI appears in NMDC data.
+Two separate questions arise here and are easily conflated.
+
+The first is whether the foreign term is the right one. A foreign `class_uri` is
+asserted where the external term is judged a faithful match for the NMDC class,
+on the view that reusing an established term beats minting a local one. That
+judgement is made per term and is not recorded anywhere per class. It applies
+whether or not the value is ever serialised, because `class_uri` is the class's
+identity in RDF and OWL.
+
+The second is how far a wrong answer travels, which depends on whether the class
+is abstract. `type` is `designates_type: true`
+(`src/schema/attribute_values.yaml`), so LinkML writes a class's `class_uri` into
+every instance of it. An abstract class has no instances, so its `class_uri`
+never reaches data. `PlannedProcess` is abstract. `CreditAssociation` is not, so
+every credit association record in production carries `type: prov:Association`
+rather than `nmdc:CreditAssociation`, making it the only place a foreign URI
+appears in NMDC data.
 
 `CreditAssociation` is deliberate rather than incidental: `has_credit_associations`
 carries `slot_uri: prov:qualifiedAssociation`, so the class and the slot are a

--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -253,8 +253,14 @@ is abstract. `type` is `designates_type: true`
 every instance of it. An abstract class has no instances, so its `class_uri`
 never reaches data. `PlannedProcess` is abstract. `CreditAssociation` is not, so
 every credit association record in production carries `type: prov:Association`
-rather than `nmdc:CreditAssociation`, making it the only place a foreign URI
-appears in NMDC data.
+rather than `nmdc:CreditAssociation`. It is the only class whose `class_uri`
+reaches data this way.
+
+This is narrower than it may sound. Foreign CURIEs are common in NMDC data
+generally: every biosample carries an ENVO term in `env_broad_scale`, and
+`has_function` values are drawn from fifteen external prefixes. What is unusual
+about `CreditAssociation` is a foreign URI serving as a class identity in `type`,
+not a foreign URI appearing in a record.
 
 `CreditAssociation` is deliberate rather than incidental: `has_credit_associations`
 carries `slot_uri: prov:qualifiedAssociation`, so the class and the slot are a

--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -225,6 +225,37 @@ enforcement *could* work elsewhere.
 `PlannedProcess` but is deprecated in OBI; the recommended replacement is
 `COB:0000035`. COB is not yet declared in the schema. See [#2843](https://github.com/microbiomedata/nmdc-schema/issues/2843).
 
+### Foreign `class_uri` and `slot_uri` values
+
+Counts as of 2026-08-20. Foreign URIs are the norm for slots and the exception
+for classes.
+
+All 502 slots carrying an explicit `slot_uri` use a foreign URI; none is
+`nmdc:`. 495 come from MIxS. The other seven are `dcterms:description`,
+`dcterms:isPartOf`, `rdf:type`, `schema:email`, `wgs84:lat`, `wgs84:long` and
+`prov:qualifiedAssociation`.
+
+Only two of the 80 classes have a foreign `class_uri`: `PlannedProcess`
+(`OBI:0000011`, above) and `CreditAssociation` (`prov:Association`).
+
+Whether a foreign `class_uri` reaches data depends on whether the class is
+abstract. `type` is `designates_type: true`, so LinkML writes a class's
+`class_uri` into every instance of it. An abstract class has no instances, so a
+foreign `class_uri` there is invisible to data. `PlannedProcess` is abstract.
+`CreditAssociation` is not, and every credit association record in production
+carries `type: prov:Association` rather than `nmdc:CreditAssociation`, making it
+the only place a foreign URI appears in NMDC data. (Criterion identified by
+Katherine Heal, 2026-08-20.)
+
+`CreditAssociation` is deliberate rather than incidental: `has_credit_associations`
+carries `slot_uri: prov:qualifiedAssociation`, so the class and the slot are a
+matched pair from PROV's qualified-relation pattern. Whether it should change was
+examined in [#3325](https://github.com/microbiomedata/nmdc-schema/issues/3325) and
+left as-is.
+
+None of this is enforced. `tests/test_all_classes_assert_a_class_uri.py` checks
+only that a `class_uri` is declared, not what it is.
+
 ---
 
 ## Active work on ontology alignment


### PR DESCRIPTION
@kheal asked why `CreditAssociation` declares `class_uri: prov:Association` rather than an `nmdc:` value, and there was nothing in the repo that answered it. The reasoning existed only in https://github.com/microbiomedata/nmdc-schema/issues/3325, which is closed and titled after a different problem, so it was unfindable without already knowing it was there.

The new section separates two questions that get conflated. Whether the foreign term is the right one is a judgement about faithfulness, and it applies whether or not the value is ever serialised. Whether a wrong answer reaches data is a separate question that turns on whether the class is abstract, which is the distinction @kheal drew about `PlannedProcess`.

Documentation only. No schema change, and no change proposed to either URI. The absence of a test that would enforce this is recorded on https://github.com/microbiomedata/nmdc-schema/issues/3368 rather than fixed here.

The file has 38 pre-existing vale errors. This PR adds none and fixes none, to keep a prose cleanup out of a content change.
