### PR TITLE
Correct the enforcement claim in the element URI section

### DIFF
--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -275,8 +275,15 @@ matched pair from PROV's qualified-relation pattern. Whether it should change wa
 examined in [#3325](https://github.com/microbiomedata/nmdc-schema/issues/3325) and
 left as-is.
 
-None of this is enforced. `tests/test_all_classes_assert_a_class_uri.py` checks
-only that a `class_uri` is declared, not what it is.
+The correspondence is enforced, but the choice is not. `type` is required on
+every class and the generated JSON Schema constrains it to a single-value
+`enum`, so a `Biosample` record whose `type` reads `nmdc:Study` fails
+validation, and a `CreditAssociation` record must carry exactly
+`prov:Association`. What nothing checks is whether a foreign `class_uri` should
+have been picked in the first place: `tests/test_all_classes_assert_a_class_uri.py`
+asserts only that a `class_uri` is declared, not what it is. So a new concrete
+class could take a foreign URI and every downstream artifact would enforce that
+choice faithfully.
 
 ---
 

--- a/src/docs/ontology-governance-current-state.md
+++ b/src/docs/ontology-governance-current-state.md
@@ -275,15 +275,15 @@ matched pair from PROV's qualified-relation pattern. Whether it should change wa
 examined in [#3325](https://github.com/microbiomedata/nmdc-schema/issues/3325) and
 left as-is.
 
-The correspondence is enforced, but the choice is not. `type` is required on
-every class and the generated JSON Schema constrains it to a single-value
-`enum`, so a `Biosample` record whose `type` reads `nmdc:Study` fails
-validation, and a `CreditAssociation` record must carry exactly
-`prov:Association`. What nothing checks is whether a foreign `class_uri` should
-have been picked in the first place: `tests/test_all_classes_assert_a_class_uri.py`
-asserts only that a `class_uri` is declared, not what it is. So a new concrete
-class could take a foreign URI and every downstream artifact would enforce that
-choice faithfully.
+The correspondence is enforced, but the choice is not. `type` is `required` with
+`range: uriorcurie`, and because it is `designates_type: true` the generated
+JSON Schema pins it to one permitted value per class, so a `Biosample` record
+whose `type` reads `nmdc:Study` fails validation, and a `CreditAssociation`
+record must carry exactly `prov:Association`. What nothing checks is whether a
+foreign `class_uri` should have been picked in the first place:
+`tests/test_all_classes_assert_a_class_uri.py` asserts only that a `class_uri`
+is declared, not what it is. So a new concrete class could take a foreign URI
+and every downstream artifact would enforce that choice faithfully.
 
 ---
 


### PR DESCRIPTION
Two corrections to the section added in https://github.com/microbiomedata/nmdc-schema/pull/3377. Both were raised by @turbomam after that PR merged, so they never made it onto main.

The merged text said "None of this is enforced," which is wrong. The record-to-class correspondence is enforced firmly: `type` is `required` with `range: uriorcurie`, and because it is `designates_type: true` the generated JSON Schema pins it to one permitted value per class. A `Biosample` record whose `type` reads `nmdc:Study` fails validation. What is genuinely unchecked is narrower, and is the point the paragraph was trying to make: nothing looks at whether a foreign `class_uri` should have been chosen for a class in the first place.

The first draft of that correction described the pinning as an "enum," which is misleading in this repo. No `EnumDefinition` is involved. The single permitted value comes from the JSON Schema generator responding to `designates_type`, and the text now says that.

Documentation only, one file, one paragraph.
