### PR TITLE
Enforce pattern on `PersonValue`'s `orcid` slot and implement migrator

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_23_0_to_11_24_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_23_0_to_11_24_0.py
@@ -26,43 +26,6 @@ class Migrator(MigratorBase):
         This migrator uses partial migrators. It runs them in the order in which they are returned by
         the `get_migrator_classes` function.
 
-        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
-        >>> db = {
-        ...     "study_set": [
-        ...         {
-        ...             "id": "nmdc:sty-1",
-        ...             "type": "nmdc:Study",
-        ...             "principal_investigator": {"type": "nmdc:PersonValue", "name": "A",
-        ...                                       "orcid": "0000-0002-1195-1608"},
-        ...             "has_credit_associations": [
-        ...                 {"type": "prov:Association",
-        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
-        ...                                       "name": "B",
-        ...                                       "orcid": "0000-0003-2254-399x"}},
-        ...             ],
-        ...         },
-        ...     ],
-        ...     "data_generation_set": [
-        ...         {
-        ...             "id": "nmdc:dgns-1",
-        ...             "type": "nmdc:NucleotideSequencing",
-        ...             "principal_investigator": {"type": "nmdc:PersonValue", "name": "C",
-        ...                                       "orcid": "0000-0002-9108-5083"},
-        ...         },
-        ...     ],
-        ... }
-        >>> Migrator(adapter=DictionaryAdapter(database=db)).upgrade()
-        >>> "principal_investigator" in db["study_set"][0]
-        False
-        >>> db["study_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
-        'orcid:0000-0003-2254-399X'
-        >>> "principal_investigator" in db["data_generation_set"][0]
-        False
-        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
-        'orcid:0000-0002-9108-5083'
-        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applied_roles"]
-        ['Principal Investigator']
-
         Args:
             commit_changes: If True, commits the changes. If False (default), performs a dry run or rollback.
         """

--- a/nmdc_schema/migrators/migrator_from_11_23_0_to_11_24_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_23_0_to_11_24_0.py
@@ -1,15 +1,19 @@
 from nmdc_schema.migrators.migrator_base import MigratorBase
+from nmdc_schema.migrators.partials.migrator_from_11_23_0_to_11_24_0 import (
+    get_migrator_classes,
+)
 
 
 class Migrator(MigratorBase):
-    r"""Remove principal_investigator from Study and DataGeneration records.
+    r"""
+    Migrates a database between two schemas.
 
-    Study: delete the slot. PI information is expected to already live on
-    has_credit_associations (issues#1837).
+    Partial 1 removes ``principal_investigator`` from Study (delete) and
+    DataGeneration (copy onto ``has_credit_associations`` with applied role
+    Principal Investigator, then delete).
 
-    DataGeneration: that class did not previously allow has_credit_associations,
-    so copy principal_investigator into a new Principal Investigator credit
-    association and delete the old slot.
+    Partial 2 standardizes remaining ``PersonValue.orcid`` values onto the
+    Bioregistry ``orcid:`` CURIE (nmdc-schema#3327).
     """
 
     _from_version = "11.23.0"
@@ -17,73 +21,59 @@ class Migrator(MigratorBase):
 
     def upgrade(self, commit_changes: bool = False) -> None:
         r"""
+        Migrates the database from conforming to the original schema, to conforming to the new schema.
+
+        This migrator uses partial migrators. It runs them in the order in which they are returned by
+        the `get_migrator_classes` function.
+
         >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
         >>> db = {
         ...     "study_set": [
-        ...         {"id": "nmdc:sty-1", "type": "nmdc:Study",
-        ...          "principal_investigator": {"type": "nmdc:PersonValue", "name": "A"}},
-        ...         {"id": "nmdc:sty-2", "type": "nmdc:Study"},
+        ...         {
+        ...             "id": "nmdc:sty-1",
+        ...             "type": "nmdc:Study",
+        ...             "principal_investigator": {"type": "nmdc:PersonValue", "name": "A",
+        ...                                       "orcid": "0000-0002-1195-1608"},
+        ...             "has_credit_associations": [
+        ...                 {"type": "prov:Association",
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "name": "B",
+        ...                                       "orcid": "0000-0003-2254-399x"}},
+        ...             ],
+        ...         },
         ...     ],
         ...     "data_generation_set": [
-        ...         {"id": "nmdc:dgns-1", "type": "nmdc:NucleotideSequencing",
-        ...          "principal_investigator": {"type": "nmdc:PersonValue", "name": "B", "email": "b@x.org"}},
-        ...         {"id": "nmdc:dgns-2", "type": "nmdc:NucleotideSequencing"},
+        ...         {
+        ...             "id": "nmdc:dgns-1",
+        ...             "type": "nmdc:NucleotideSequencing",
+        ...             "principal_investigator": {"type": "nmdc:PersonValue", "name": "C",
+        ...                                       "orcid": "0000-0002-9108-5083"},
+        ...         },
         ...     ],
         ... }
         >>> Migrator(adapter=DictionaryAdapter(database=db)).upgrade()
         >>> "principal_investigator" in db["study_set"][0]
         False
-        >>> "principal_investigator" in db["study_set"][1]
-        False
-        >>> db["data_generation_set"][0]["has_credit_associations"]
-        [{'type': 'prov:Association', 'applies_to_person': {'type': 'nmdc:PersonValue', 'name': 'B', 'email': 'b@x.org'}, 'applied_roles': ['Principal Investigator']}]
+        >>> db["study_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
+        'orcid:0000-0003-2254-399X'
         >>> "principal_investigator" in db["data_generation_set"][0]
         False
-        >>> "has_credit_associations" in db["data_generation_set"][1]
-        False
+        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
+        'orcid:0000-0002-9108-5083'
+        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applied_roles"]
+        ['Principal Investigator']
+
+        Args:
+            commit_changes: If True, commits the changes. If False (default), performs a dry run or rollback.
         """
-        self._warn_if_commit_ignored(commit_changes)
-        self.adapter.process_each_document("study_set", [self.drop_study_principal_investigator])
-        self.adapter.process_each_document(
-            "data_generation_set", [self.move_data_generation_principal_investigator]
-        )
 
-    def drop_study_principal_investigator(self, study: dict) -> dict:
-        r"""Delete principal_investigator from a Study document. Do not copy it.
-
-        >>> m = Migrator()
-        >>> m.drop_study_principal_investigator(
-        ...     {"id": "nmdc:sty-1", "principal_investigator": {"name": "A"}}
-        ... )
-        {'id': 'nmdc:sty-1'}
-        >>> m.drop_study_principal_investigator({"id": "nmdc:sty-2"})
-        {'id': 'nmdc:sty-2'}
-        """
-        if "principal_investigator" in study:
-            study.pop("principal_investigator")
-        return study
-
-    def move_data_generation_principal_investigator(self, record: dict) -> dict:
-        r"""Move principal_investigator onto a new has_credit_associations list.
-
-        >>> m = Migrator()
-        >>> m.move_data_generation_principal_investigator(
-        ...     {"id": "nmdc:dgns-1",
-        ...      "principal_investigator": {"type": "nmdc:PersonValue", "name": "B", "email": "b@x.org"}}
-        ... )
-        {'id': 'nmdc:dgns-1', 'has_credit_associations': [{'type': 'prov:Association', 'applies_to_person': {'type': 'nmdc:PersonValue', 'name': 'B', 'email': 'b@x.org'}, 'applied_roles': ['Principal Investigator']}]}
-        >>> m.move_data_generation_principal_investigator({"id": "nmdc:dgns-2"})
-        {'id': 'nmdc:dgns-2'}
-        """
-        pi = record.pop("principal_investigator", None)
-        if not isinstance(pi, dict):
-            return record
-
-        record["has_credit_associations"] = [
-            {
-                "type": "prov:Association",
-                "applies_to_person": pi,
-                "applied_roles": ["Principal Investigator"],
-            }
-        ]
-        return record
+        migrator_classes = get_migrator_classes()
+        num_migrators = len(migrator_classes)
+        for idx, migrator_class in enumerate(migrator_classes):
+            self.logger.info(f"Running migrator {idx + 1} of {num_migrators}")
+            self.logger.debug(
+                f"Migrating from {migrator_class.get_origin_version()} "
+                f"to {migrator_class.get_destination_version()}"
+            )
+            migrator = migrator_class(adapter=self.adapter, logger=self.logger)
+            migrator.upgrade(commit_changes=commit_changes)

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/__init__.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/__init__.py
@@ -1,0 +1,32 @@
+from typing import List, Type
+
+from nmdc_schema.migrators.migrator_base import MigratorBase
+from nmdc_schema.migrators.partials.migrator_from_11_23_0_to_11_24_0 import (
+    migrator_from_11_23_0_to_11_24_0_part_1,
+    migrator_from_11_23_0_to_11_24_0_part_2,
+)
+
+
+def get_migrator_classes() -> List[Type[MigratorBase]]:
+    r"""
+    Returns a list of migrator classes in the order in which they (i.e. their `upgrade` methods)
+    were designed to be run.
+
+    Part 1 removes `principal_investigator` (copying it onto DataGeneration
+    `has_credit_associations` first). Part 2 then standardizes remaining
+    `PersonValue.orcid` values, including those copied in part 1.
+
+    >>> migrator_classes = get_migrator_classes()
+    >>> type(migrator_classes) is list and len(migrator_classes) > 0  # the function returns a list
+    True
+    >>> from inspect import isclass
+    >>> all(isclass(c) for c in migrator_classes)  # each list item is a class
+    True
+    >>> all(callable(getattr(c, "upgrade")) for c in migrator_classes)  # each class has an `upgrade` method
+    True
+    """
+
+    return [
+        migrator_from_11_23_0_to_11_24_0_part_1.Migrator,
+        migrator_from_11_23_0_to_11_24_0_part_2.Migrator,
+    ]

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_1.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_1.py
@@ -1,3 +1,4 @@
+from nmdc_schema.migrators.adapters.mongo_adapter import MongoAdapter
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 
@@ -43,10 +44,41 @@ class Migrator(MigratorBase):
         False
         """
         self._warn_if_commit_ignored(commit_changes)
-        self.adapter.process_each_document("study_set", [self.drop_study_principal_investigator])
-        self.adapter.process_each_document(
-            "data_generation_set", [self.move_data_generation_principal_investigator]
-        )
+
+        if isinstance(self.adapter, MongoAdapter):
+            try:
+                def migrate_collections(adapter, session) -> None:
+                    adapter.process_each_document(
+                        "study_set", [self.drop_study_principal_investigator], session
+                    )
+                    adapter.process_each_document(
+                        "data_generation_set",
+                        [self.move_data_generation_principal_investigator],
+                        session,
+                    )
+
+                self.adapter.execute_in_transaction(
+                    operations_callback=migrate_collections,
+                    commit_changes=commit_changes,
+                )
+                if commit_changes:
+                    self.logger.info("Transaction committed (changes have been saved)")
+                else:
+                    self.logger.info("Transaction rolled back (no changes were committed)")
+            except Exception as e:
+                self.logger.error(f"Migration failed: {e}")
+                raise
+        else:
+            self.adapter.process_each_document(
+                "study_set", [self.drop_study_principal_investigator]
+            )
+            self.adapter.process_each_document(
+                "data_generation_set", [self.move_data_generation_principal_investigator]
+            )
+            if not commit_changes:
+                self.logger.info(
+                    "Note: Non-MongoDB adapter doesn't support rollback - changes are applied immediately"
+                )
 
     def drop_study_principal_investigator(self, study: dict) -> dict:
         r"""Delete principal_investigator from a Study document. Do not copy it.

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_1.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_1.py
@@ -1,0 +1,89 @@
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Remove principal_investigator from Study and DataGeneration records.
+
+    Study: delete the slot. PI information is expected to already live on
+    has_credit_associations (issues#1837).
+
+    DataGeneration: that class did not previously allow has_credit_associations,
+    so copy principal_investigator into a new Principal Investigator credit
+    association and delete the old slot.
+    """
+
+    _from_version = "11.23.0"
+    _to_version = "11.24.0.part_1"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> db = {
+        ...     "study_set": [
+        ...         {"id": "nmdc:sty-1", "type": "nmdc:Study",
+        ...          "principal_investigator": {"type": "nmdc:PersonValue", "name": "A"}},
+        ...         {"id": "nmdc:sty-2", "type": "nmdc:Study"},
+        ...     ],
+        ...     "data_generation_set": [
+        ...         {"id": "nmdc:dgns-1", "type": "nmdc:NucleotideSequencing",
+        ...          "principal_investigator": {"type": "nmdc:PersonValue", "name": "B", "email": "b@x.org"}},
+        ...         {"id": "nmdc:dgns-2", "type": "nmdc:NucleotideSequencing"},
+        ...     ],
+        ... }
+        >>> Migrator(adapter=DictionaryAdapter(database=db)).upgrade()
+        >>> "principal_investigator" in db["study_set"][0]
+        False
+        >>> "principal_investigator" in db["study_set"][1]
+        False
+        >>> db["data_generation_set"][0]["has_credit_associations"]
+        [{'type': 'prov:Association', 'applies_to_person': {'type': 'nmdc:PersonValue', 'name': 'B', 'email': 'b@x.org'}, 'applied_roles': ['Principal Investigator']}]
+        >>> "principal_investigator" in db["data_generation_set"][0]
+        False
+        >>> "has_credit_associations" in db["data_generation_set"][1]
+        False
+        """
+        self._warn_if_commit_ignored(commit_changes)
+        self.adapter.process_each_document("study_set", [self.drop_study_principal_investigator])
+        self.adapter.process_each_document(
+            "data_generation_set", [self.move_data_generation_principal_investigator]
+        )
+
+    def drop_study_principal_investigator(self, study: dict) -> dict:
+        r"""Delete principal_investigator from a Study document. Do not copy it.
+
+        >>> m = Migrator()
+        >>> m.drop_study_principal_investigator(
+        ...     {"id": "nmdc:sty-1", "principal_investigator": {"name": "A"}}
+        ... )
+        {'id': 'nmdc:sty-1'}
+        >>> m.drop_study_principal_investigator({"id": "nmdc:sty-2"})
+        {'id': 'nmdc:sty-2'}
+        """
+        if "principal_investigator" in study:
+            study.pop("principal_investigator")
+        return study
+
+    def move_data_generation_principal_investigator(self, record: dict) -> dict:
+        r"""Move principal_investigator onto a new has_credit_associations list.
+
+        >>> m = Migrator()
+        >>> m.move_data_generation_principal_investigator(
+        ...     {"id": "nmdc:dgns-1",
+        ...      "principal_investigator": {"type": "nmdc:PersonValue", "name": "B", "email": "b@x.org"}}
+        ... )
+        {'id': 'nmdc:dgns-1', 'has_credit_associations': [{'type': 'prov:Association', 'applies_to_person': {'type': 'nmdc:PersonValue', 'name': 'B', 'email': 'b@x.org'}, 'applied_roles': ['Principal Investigator']}]}
+        >>> m.move_data_generation_principal_investigator({"id": "nmdc:dgns-2"})
+        {'id': 'nmdc:dgns-2'}
+        """
+        pi = record.pop("principal_investigator", None)
+        if not isinstance(pi, dict):
+            return record
+
+        record["has_credit_associations"] = [
+            {
+                "type": "prov:Association",
+                "applies_to_person": pi,
+                "applied_roles": ["Principal Investigator"],
+            }
+        ]
+        return record

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_2.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_2.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import re
 import unicodedata
 
+from nmdc_schema.migrators.adapters.mongo_adapter import MongoAdapter
 from nmdc_schema.migrators.migrator_base import MigratorBase
 
 # Destination pattern from nmdc-schema#3327. Shape only; does not verify the
@@ -154,12 +155,32 @@ class Migrator(MigratorBase):
         'orcid:0000-0003-2254-399X'
         """
         self._warn_if_commit_ignored(commit_changes)
-        self.adapter.process_each_document(
-            "study_set", [self.normalize_document_personvalue_orcids]
-        )
-        self.adapter.process_each_document(
-            "data_generation_set", [self.normalize_document_personvalue_orcids]
-        )
+
+        if isinstance(self.adapter, MongoAdapter):
+            try:
+                self.adapter.process_collections_in_transaction(
+                    collection_names=["study_set", "data_generation_set"],
+                    document_processor=self.normalize_document_personvalue_orcids,
+                    commit_changes=commit_changes,
+                )
+                if commit_changes:
+                    self.logger.info("Transaction committed (changes have been saved)")
+                else:
+                    self.logger.info("Transaction rolled back (no changes were committed)")
+            except Exception as e:
+                self.logger.error(f"Migration failed: {e}")
+                raise
+        else:
+            self.adapter.process_each_document(
+                "study_set", [self.normalize_document_personvalue_orcids]
+            )
+            self.adapter.process_each_document(
+                "data_generation_set", [self.normalize_document_personvalue_orcids]
+            )
+            if not commit_changes:
+                self.logger.info(
+                    "Note: Non-MongoDB adapter doesn't support rollback - changes are applied immediately"
+                )
 
     def normalize_document_personvalue_orcids(self, document: dict) -> dict:
         r"""Normalize or drop ``orcid`` on each credit-association PersonValue.

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_2.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_2.py
@@ -1,0 +1,204 @@
+"""Standardize PersonValue.orcid onto the Bioregistry ``orcid:`` CURIE.
+
+See https://github.com/microbiomedata/nmdc-schema/issues/3327
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+# Destination pattern from nmdc-schema#3327. Shape only; does not verify the
+# ISO 7064 mod 11-2 check digit.
+TARGET = re.compile(r"^orcid:\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$")
+URL_PREFIXES = ("https://orcid.org/", "http://orcid.org/")
+# Confirmed one-off: Michael SanClements on nmdc:sty-11-8bjf2432 is missing a digit.
+# Do not generalize this into a "pad a zero" rule.
+KNOWN_BARE_FIXES = {
+    "000-0002-1962-3561": "0000-0002-1962-3561",
+}
+
+
+def normalize_orcid(value: str | None) -> str | None:
+    """Return an ``orcid:`` CURIE, or None to drop the key.
+
+    Values that already match the destination pattern are returned unchanged.
+
+    Already conforming:
+    >>> normalize_orcid('orcid:0000-0002-4439-2398')
+    'orcid:0000-0002-4439-2398'
+
+    Adds the ``orcid:`` prefix:
+    >>> normalize_orcid('0000-0002-1195-1608')
+    'orcid:0000-0002-1195-1608'
+
+    Uppercases a lowercase checksum:
+    >>> normalize_orcid('0000-0003-2254-399x')
+    'orcid:0000-0003-2254-399X'
+
+    Strips whitespace and control characters:
+    >>> normalize_orcid('\\t0000-0002-1057-7239')
+    'orcid:0000-0002-1057-7239'
+    >>> normalize_orcid('0000-0001-9557-3001\\u202c')
+    'orcid:0000-0001-9557-3001'
+
+    Extracts the identifier from an ORCID URL:
+    >>> normalize_orcid(' https://orcid.org/0000-0002-9108-5083')
+    'orcid:0000-0002-9108-5083'
+
+    Drops empty strings and None:
+    >>> normalize_orcid('') is None
+    True
+    >>> normalize_orcid(None) is None
+    True
+
+    Fixes the confirmed SanClements typo:
+    >>> normalize_orcid('000-0002-1962-3561')
+    'orcid:0000-0002-1962-3561'
+
+    Raises on unrepairable values:
+    >>> normalize_orcid('not-an-orcid')
+    Traceback (most recent call last):
+        ...
+    ValueError: unrepairable orcid: 'not-an-orcid'
+    >>> normalize_orcid(123)
+    Traceback (most recent call last):
+        ...
+    ValueError: orcid is not a string: 123
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"orcid is not a string: {value!r}")
+    if TARGET.fullmatch(value):
+        return value
+    cleaned = "".join(ch for ch in value if unicodedata.category(ch) not in {"Cc", "Cf"})
+    cleaned = cleaned.strip()
+    if cleaned == "":
+        return None
+    lowered = cleaned.lower()
+    for prefix in URL_PREFIXES:
+        if lowered.startswith(prefix):
+            cleaned = cleaned[len(prefix) :].strip().rstrip("/")
+            break
+    if cleaned.lower().startswith("orcid:"):
+        cleaned = cleaned.split(":", 1)[1]
+    if cleaned.endswith("x"):
+        cleaned = cleaned[:-1] + "X"
+    cleaned = KNOWN_BARE_FIXES.get(cleaned, cleaned)
+    curie = f"orcid:{cleaned}"
+    if TARGET.fullmatch(curie):
+        return curie
+    raise ValueError(f"unrepairable orcid: {value!r}")
+
+
+class Migrator(MigratorBase):
+    r"""Rewrite PersonValue.orcid onto the Bioregistry ``orcid:`` CURIE.
+
+    Walks ``has_credit_associations[].applies_to_person`` on ``study_set`` and
+    ``data_generation_set`` after part 1 has already removed
+    ``principal_investigator``. Empty strings drop the key; unrepairable
+    values raise so leftover strings cannot fail the new slot pattern silently.
+    """
+
+    _from_version = "11.24.0.part_1"
+    _to_version = "11.24.0.part_2"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> db = {
+        ...     "study_set": [
+        ...         {
+        ...             "id": "nmdc:sty-1",
+        ...             "type": "nmdc:Study",
+        ...             "has_credit_associations": [
+        ...                 {"type": "prov:Association",
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "name": "A",
+        ...                                       "orcid": "0000-0002-1195-1608"}},
+        ...                 {"type": "prov:Association",
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "name": "B",
+        ...                                       "orcid": ""}},
+        ...                 {"type": "prov:Association",
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "name": "C"}},
+        ...             ],
+        ...         },
+        ...     ],
+        ...     "data_generation_set": [
+        ...         {
+        ...             "id": "nmdc:dgns-1",
+        ...             "type": "nmdc:NucleotideSequencing",
+        ...             "has_credit_associations": [
+        ...                 {"type": "prov:Association",
+        ...                  "applied_roles": ["Principal Investigator"],
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "name": "D",
+        ...                                       "orcid": "0000-0003-2254-399x"}},
+        ...             ],
+        ...         },
+        ...     ],
+        ... }
+        >>> Migrator(adapter=DictionaryAdapter(database=db)).upgrade()
+        >>> db["study_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
+        'orcid:0000-0002-1195-1608'
+        >>> "orcid" in db["study_set"][0]["has_credit_associations"][1]["applies_to_person"]
+        False
+        >>> "orcid" in db["study_set"][0]["has_credit_associations"][2]["applies_to_person"]
+        False
+        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
+        'orcid:0000-0003-2254-399X'
+        """
+        self._warn_if_commit_ignored(commit_changes)
+        self.adapter.process_each_document(
+            "study_set", [self.normalize_document_personvalue_orcids]
+        )
+        self.adapter.process_each_document(
+            "data_generation_set", [self.normalize_document_personvalue_orcids]
+        )
+
+    def normalize_document_personvalue_orcids(self, document: dict) -> dict:
+        r"""Normalize or drop ``orcid`` on each credit-association PersonValue.
+
+        >>> m = Migrator()
+        >>> m.normalize_document_personvalue_orcids(
+        ...     {"id": "nmdc:sty-1",
+        ...      "has_credit_associations": [
+        ...          {"applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                "orcid": "0000-0002-1195-1608"}},
+        ...          {"applies_to_person": {"orcid": "000-0002-1962-3561"}},
+        ...          {"applies_to_person": {"orcid": ""}},
+        ...          {"applies_to_person": {"name": "C"}},
+        ...      ]}
+        ... )
+        {'id': 'nmdc:sty-1', 'has_credit_associations': [{'applies_to_person': {'type': 'nmdc:PersonValue', 'orcid': 'orcid:0000-0002-1195-1608'}}, {'applies_to_person': {'orcid': 'orcid:0000-0002-1962-3561'}}, {'applies_to_person': {}}, {'applies_to_person': {'name': 'C'}}]}
+        >>> m.normalize_document_personvalue_orcids({"id": "nmdc:sty-2"})
+        {'id': 'nmdc:sty-2'}
+        >>> m.normalize_document_personvalue_orcids(
+        ...     {"id": "nmdc:sty-3",
+        ...      "has_credit_associations": [{"applies_to_person": {"orcid": "not-an-orcid"}}]}
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: In nmdc:sty-3: unrepairable orcid: 'not-an-orcid'
+        """
+        document_id = document.get("id", "<unknown id>")
+        try:
+            for association in document.get("has_credit_associations") or []:
+                if not isinstance(association, dict):
+                    continue
+                person = association.get("applies_to_person")
+                if not isinstance(person, dict) or "orcid" not in person:
+                    continue
+                normalized = normalize_orcid(person["orcid"])
+                if normalized is None:
+                    person.pop("orcid", None)
+                else:
+                    person["orcid"] = normalized
+        except ValueError as exc:
+            raise ValueError(f"In {document_id}: {exc}") from None
+        return document

--- a/src/data/invalid/PersonValue-orcid-bare-identifier.yaml
+++ b/src/data/invalid/PersonValue-orcid-bare-identifier.yaml
@@ -1,0 +1,3 @@
+type: nmdc:PersonValue
+name: J. Craig Venter
+orcid: 0000-0002-7086-765X

--- a/src/data/invalid/Study-include-emsl_project_dois.yaml
+++ b/src/data/invalid/Study-include-emsl_project_dois.yaml
@@ -55,7 +55,7 @@ has_credit_associations:
   - applies_to_person:
       has_raw_value: Craig Venter
       type: nmdc:PersonValue
-      orcid: ORCID:0000-0002-7086-765X
+      orcid: orcid:0000-0002-7086-765X
       profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
       email: jcventer@jcvi.org
       name: J. Craig Venter

--- a/src/data/invalid/Study-using-retired-relevant_protocols-slot.yaml
+++ b/src/data/invalid/Study-using-retired-relevant_protocols-slot.yaml
@@ -64,7 +64,7 @@ funding_sources:
 has_credit_associations:
   - applies_to_person:
       has_raw_value: Craig Venter
-      orcid: ORCID:0000-0002-7086-765X
+      orcid: orcid:0000-0002-7086-765X
       profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
       email: jcventer@jcvi.org
       name: J. Craig Venter

--- a/src/data/valid/CreditAssociation-1.yaml
+++ b/src/data/valid/CreditAssociation-1.yaml
@@ -3,7 +3,7 @@ applies_to_person:
   has_raw_value: Craig Venter
   email: jcventer@jcvi.org
   name: J. Craig Venter
-  orcid: ORCID:0000-0002-7086-765X
+  orcid: orcid:0000-0002-7086-765X
   profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
   websites:
     - https://www.jcvi.org/

--- a/src/data/valid/Study-credit-1.yaml
+++ b/src/data/valid/Study-credit-1.yaml
@@ -6,7 +6,7 @@ has_credit_associations:
       - Data curation
     applies_to_person:
       type: nmdc:PersonValue
-      orcid: 'orcid:0000-0002-1825-00'
+      orcid: 'orcid:0000-0002-1825-0097'
     type: prov:Association
   - applied_roles:
       - Software

--- a/src/data/valid/Study-exhaustive.yaml
+++ b/src/data/valid/Study-exhaustive.yaml
@@ -60,7 +60,7 @@ has_credit_associations:
   - applies_to_person:
       type: nmdc:PersonValue
       has_raw_value: Craig Venter
-      orcid: ORCID:0000-0002-7086-765X
+      orcid: orcid:0000-0002-7086-765X
       profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
       email: jcventer@jcvi.org
       name: J. Craig Venter

--- a/src/data/valid/Study-tidy.yaml
+++ b/src/data/valid/Study-tidy.yaml
@@ -52,7 +52,7 @@ has_credit_associations:
       has_raw_value: Craig Venter
       email: jcventer@jcvi.org
       name: J. Craig Venter
-      orcid: ORCID:0000-0002-7086-765X
+      orcid: orcid:0000-0002-7086-765X
       profile_image_url: https://en.wikipedia.org/wiki/Craig_Venter#/media/File:Craigventer2.jpg
       websites:
         - https://www.jcvi.org/

--- a/src/schema/attribute_values.yaml
+++ b/src/schema/attribute_values.yaml
@@ -240,7 +240,6 @@ slots:
       - value: orcid:0000-0002-7086-765X
     see_also:
       - https://bioregistry.io/registry/orcid
-      - https://github.com/microbiomedata/nmdc-schema/issues/3327
 
   language:
     range: language_code

--- a/src/schema/attribute_values.yaml
+++ b/src/schema/attribute_values.yaml
@@ -233,6 +233,14 @@ slots:
   orcid:
     description: The ORCID of a person.
     range: string
+    pattern: '^orcid:\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$'
+    comments:
+      - Canonical form is the Bioregistry CURIE with prefix `orcid`.
+    examples:
+      - value: orcid:0000-0002-7086-765X
+    see_also:
+      - https://bioregistry.io/registry/orcid
+      - https://github.com/microbiomedata/nmdc-schema/issues/3327
 
   language:
     range: language_code

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -760,7 +760,7 @@ slots:
       using the CreditEnum value Principal Investigator.
     deprecated_element_has_possible_replacement: has_credit_associations
     last_updated_on: "2026-08-21T00:00:00Z"
-    modified_by: ORCID:0000-0002-4504-1039
+    modified_by: orcid:0000-0002-4504-1039
 
   was_generated_by:
     range: DataEmitterProcess

--- a/src/schema/core.yaml
+++ b/src/schema/core.yaml
@@ -244,8 +244,8 @@ classes:
     description: >
       A process that results in the interconversion of chemical species by a reaction to transform the reagents into products.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-1368-8217 #Yuri Corilo
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-1368-8217 #Yuri Corilo
     is_a: MaterialProcessing
     comments:
       - The values of both has_reagents slot and has_input slot are considered the reagents of a chemical process.
@@ -1742,8 +1742,8 @@ slots:
       - "Not to be confused with the MIXS:0000113"
     description: The value of a temperature measurement or temperature used in a process.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
     annotations:
       storage_units: Cel
 
@@ -1873,8 +1873,8 @@ slots:
     range: QuantityValue
     description: The volume of a substance.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
     annotations:
       storage_units: mL|uL
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -53,7 +53,6 @@ prefixes:
   NCIT: "http://purl.obolibrary.org/obo/NCIT_" # for Biosample, Study, StudyCategoryEnum PVs, doi_provider, funding_sources, extraction_targets, 'BAI File' only
   OBI: "http://purl.obolibrary.org/obo/OBI_"
   OMIT: "http://purl.obolibrary.org/obo/OMIT_" # for RNA subtypes only
-  ORCID: "https://orcid.org/"
   PANTHER.FAMILY: "https://bioregistry.io/panther.family:" # https://bioregistry.io/panther.family:PTHR12345
   PATO: "http://purl.obolibrary.org/obo/PATO_"
   PFAM.CLAN: "https://bioregistry.io/pfam.clan:" # https://bioregistry.io/pfam.clan:CL0192
@@ -102,6 +101,7 @@ prefixes:
   neon.identifier: "http://example.org/neon/identifier/"
   neon.schema: "http://example.org/neon/schema/"
   nmdc: "https://w3id.org/nmdc/"
+  orcid: "https://orcid.org/"  # Bioregistry canonical prefix; PersonValue.orcid and schema contributor metadata
   owl: "http://www.w3.org/2002/07/owl#"
   prov: "http://www.w3.org/ns/prov#" # for startedAtTime, endedAtTime, Association, Activity, wasInformedBy, wasGeneratedBy, qualifiedAssociation
   qudt: "http://qudt.org/1.1/schema/qudt#"
@@ -129,6 +129,7 @@ emit_prefixes:
   - img.taxon
   - jgi.proposal
   - kegg
+  - orcid
   - rdf
   - rdfs
   - skos
@@ -640,10 +641,10 @@ classes:
         In practice, the meaning is usually apparent from the context or is defined.
       - TODO - Montana to visit slot descriptions
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
-      - ORCID:0000-0001-9076-6066 #Mark Miller
-      - ORCID:0009-0008-4013-7737 #James Tessmer
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
+      - orcid:0000-0001-9076-6066 #Mark Miller
+      - orcid:0009-0008-4013-7737 #James Tessmer
     is_a: MaterialProcessing
     slots:
       - container_size
@@ -668,8 +669,8 @@ classes:
     description: >
       The combining of components, particles or layers into a more homogeneous state.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
     is_a: MaterialProcessing
     comments:
       - The mixing may be achieved manually or mechanically by shifting the material with stirrers or pumps
@@ -696,10 +697,10 @@ classes:
     related_mappings:
       - CHMO:0001640
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
-      - ORCID:0000-0001-9076-6066 #Mark Miller
-      - ORCID:0009-0008-4013-7737 #James Tessmer
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
+      - orcid:0000-0001-9076-6066 #Mark Miller
+      - orcid:0009-0008-4013-7737 #James Tessmer
     is_a: MaterialProcessing
     slots:
       - conditionings
@@ -757,8 +758,8 @@ classes:
     description:
       The process of using a selective partitioning of the analyte or interferent between two immiscible phases.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-1368-8217 #Yuri Corilo
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-1368-8217 #Yuri Corilo
     is_a: MaterialProcessing
     slots:
       - chromatographic_category
@@ -783,8 +784,8 @@ classes:
     exact_mappings:
       - CHMO:0002773
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-1368-8217 #Yuri Corilo
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-1368-8217 #Yuri Corilo
     is_a: MaterialProcessing
     slots:
       - duration
@@ -965,8 +966,8 @@ enums:
   ContainerCategoryEnum:
     description: The permitted types of containers used in processing metabolomic samples.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
     permissible_values:
       v-bottom_conical_tube:
       falcon_tube:
@@ -974,8 +975,8 @@ enums:
   SeparationMethodEnum:
     description: The tool/substance used to separate or filter a solution or mixture.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
     permissible_values:
       ptfe_96_well_filter_plate:
       syringe:
@@ -983,8 +984,8 @@ enums:
   StationaryPhaseEnum:
     description: The type of stationary phase used in a chromatography process.
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-4504-1039 #Katherine Heal
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-4504-1039 #Katherine Heal
     permissible_values:
       BEH-HILIC:
         description: Hydrophilic Interaction Chromatography (HILIC) employing BEH (Bridged Ethylene Hybrid) particles as the stationary phase.
@@ -1490,8 +1491,8 @@ slots:
     range: QuantityValue
     description: The volume of the container an analyte is stored in or an activity takes place in
     contributors:
-      - ORCID:0009-0001-1555-1601 #Anastasiya Prymolenna
-      - ORCID:0000-0002-8683-0050 #Montana Smith
+      - orcid:0009-0001-1555-1601 #Anastasiya Prymolenna
+      - orcid:0000-0002-8683-0050 #Montana Smith
     annotations:
       storage_units: mL
 

--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -101,7 +101,7 @@ prefixes:
   neon.identifier: "http://example.org/neon/identifier/"
   neon.schema: "http://example.org/neon/schema/"
   nmdc: "https://w3id.org/nmdc/"
-  orcid: "https://orcid.org/"  # Bioregistry canonical prefix; PersonValue.orcid and schema contributor metadata
+  orcid: "https://orcid.org/"
   owl: "http://www.w3.org/2002/07/owl#"
   prov: "http://www.w3.org/ns/prov#" # for startedAtTime, endedAtTime, Association, Activity, wasInformedBy, wasGeneratedBy, qualifiedAssociation
   qudt: "http://qudt.org/1.1/schema/qudt#"

--- a/src/schema/portal_mixs_inspired.yaml
+++ b/src/schema/portal_mixs_inspired.yaml
@@ -23,10 +23,10 @@ slots:
       See https://github.com/microbiomedata/nmdc-schema/issues/2658 and the example
       src/data/valid/Database-incubation-as-culturing.yaml.
     last_updated_on: "2026-07-21T00:00:00Z"
-    modified_by: ORCID:0009-0008-4013-7737 #James Tessmer
+    modified_by: orcid:0009-0008-4013-7737 #James Tessmer
     contributors:
-      - ORCID:0009-0008-4013-7737 #James Tessmer
-      - ORCID:0000-0001-9076-6066 #Mark Miller
+      - orcid:0009-0008-4013-7737 #James Tessmer
+      - orcid:0000-0001-9076-6066 #Mark Miller
     description: Date the incubation was harvested/collected/ended. Only relevant
       for incubation samples.
     title: incubation collection date


### PR DESCRIPTION
Closes #3327 
Closes https://github.com/microbiomedata/issues/issues/1817
Closes https://github.com/microbiomedata/nmdc-schema/issues/2307

**Schema changes**
- Added `pattern` metaslot to `orcid`'s slots definition with `^orcid:\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$` value. Also added examples to slot's definition.
- Fixed the orcid values to metaslots throughout schema to comply with format.
- Added a "orcid' prefix to schema 

**Migrator**
- From schema `11.23.0` to `11.24.0`.
- Converted migrator associated with #3381 to partial migrator (part_1), migrator associated with these schema changes is nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_2.py 
- `study_set` and `data_generation_set`: normalize `orcid` on each of the values in the `has_credit_associations` list with helper function to strip errant characters, add prefix, and fix known typo
- migrator was tested locally against production mongo data using `make test-migrator-on-database MIGRATOR=migrator_from_11_23_0_to_11_24_0 SELECTED_COLLECTIONS=study_set` and `make test-migrator-on-database MIGRATOR=migrator_from_11_23_0_to_11_24_0 SELECTED_COLLECTIONS=data_generation_set` with no issues found

**Example Data**
- Standardized every use of `orcid` slot win `src/data/valid/` (several locations)
- Added `src/data/invalid/PersonValue-orcid-bare-identifier.yaml`: fails only because `orcid` does not follow slot's `pattern` (no orcid: prefix)