### PR TITLE
Make `name` required on `PersonValue` and implement migrator

### DIFF
--- a/nmdc_schema/migrators/migrator_from_11_23_0_to_11_24_0.py
+++ b/nmdc_schema/migrators/migrator_from_11_23_0_to_11_24_0.py
@@ -14,6 +14,9 @@ class Migrator(MigratorBase):
 
     Partial 2 standardizes remaining ``PersonValue.orcid`` values onto the
     Bioregistry ``orcid:`` CURIE (nmdc-schema#3327).
+
+    Partial 3 copies ``has_raw_value`` onto missing ``PersonValue.name`` so
+    name can be required (nmdc-schema#2458).
     """
 
     _from_version = "11.23.0"
@@ -46,7 +49,8 @@ class Migrator(MigratorBase):
         ...         {
         ...             "id": "nmdc:dgns-1",
         ...             "type": "nmdc:NucleotideSequencing",
-        ...             "principal_investigator": {"type": "nmdc:PersonValue", "name": "C",
+        ...             "principal_investigator": {"type": "nmdc:PersonValue",
+        ...                                       "has_raw_value": "C",
         ...                                       "orcid": "0000-0002-9108-5083"},
         ...         },
         ...     ],
@@ -60,6 +64,8 @@ class Migrator(MigratorBase):
         False
         >>> db["data_generation_set"][0]["has_credit_associations"][0]["applies_to_person"]["orcid"]
         'orcid:0000-0002-9108-5083'
+        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applies_to_person"]["name"]
+        'C'
         >>> db["data_generation_set"][0]["has_credit_associations"][0]["applied_roles"]
         ['Principal Investigator']
 

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/__init__.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/__init__.py
@@ -4,6 +4,7 @@ from nmdc_schema.migrators.migrator_base import MigratorBase
 from nmdc_schema.migrators.partials.migrator_from_11_23_0_to_11_24_0 import (
     migrator_from_11_23_0_to_11_24_0_part_1,
     migrator_from_11_23_0_to_11_24_0_part_2,
+    migrator_from_11_23_0_to_11_24_0_part_3,
 )
 
 
@@ -13,8 +14,9 @@ def get_migrator_classes() -> List[Type[MigratorBase]]:
     were designed to be run.
 
     Part 1 removes `principal_investigator` (copying it onto DataGeneration
-    `has_credit_associations` first). Part 2 then standardizes remaining
-    `PersonValue.orcid` values, including those copied in part 1.
+    `has_credit_associations` first). Part 2 standardizes remaining
+    `PersonValue.orcid` values. Part 3 copies `has_raw_value` onto missing
+    `PersonValue.name` so name can be required.
 
     >>> migrator_classes = get_migrator_classes()
     >>> type(migrator_classes) is list and len(migrator_classes) > 0  # the function returns a list
@@ -29,4 +31,5 @@ def get_migrator_classes() -> List[Type[MigratorBase]]:
     return [
         migrator_from_11_23_0_to_11_24_0_part_1.Migrator,
         migrator_from_11_23_0_to_11_24_0_part_2.Migrator,
+        migrator_from_11_23_0_to_11_24_0_part_3.Migrator,
     ]

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_3.py
@@ -3,8 +3,6 @@
 See https://github.com/microbiomedata/nmdc-schema/issues/2458
 """
 
-from __future__ import annotations
-
 from nmdc_schema.migrators.adapters.mongo_adapter import MongoAdapter
 from nmdc_schema.migrators.migrator_base import MigratorBase
 

--- a/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_3.py
+++ b/nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_3.py
@@ -1,0 +1,119 @@
+"""Fill PersonValue.name from has_raw_value when name is missing.
+
+See https://github.com/microbiomedata/nmdc-schema/issues/2458
+"""
+
+from __future__ import annotations
+
+from nmdc_schema.migrators.migrator_base import MigratorBase
+
+
+class Migrator(MigratorBase):
+    r"""Require PersonValue.name by copying has_raw_value onto missing names.
+
+    Walks ``has_credit_associations[].applies_to_person`` on ``study_set`` and
+    ``data_generation_set`` after part 1 has already moved DataGeneration
+    principal investigators onto credit associations. Production snapshot
+    2026-08-24 had 405 fillable DataGeneration PIs and 0 records missing both
+    slots; unfillable values raise.
+    """
+
+    _from_version = "11.24.0.part_2"
+    _to_version = "11.24.0.part_3"
+
+    def upgrade(self, commit_changes: bool = False) -> None:
+        r"""
+        >>> from nmdc_schema.migrators.adapters.dictionary_adapter import DictionaryAdapter
+        >>> db = {
+        ...     "study_set": [
+        ...         {
+        ...             "id": "nmdc:sty-1",
+        ...             "type": "nmdc:Study",
+        ...             "has_credit_associations": [
+        ...                 {"type": "prov:Association",
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "name": "A"}},
+        ...                 {"type": "prov:Association",
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "has_raw_value": "B"}},
+        ...             ],
+        ...         },
+        ...     ],
+        ...     "data_generation_set": [
+        ...         {
+        ...             "id": "nmdc:dgns-1",
+        ...             "type": "nmdc:NucleotideSequencing",
+        ...             "has_credit_associations": [
+        ...                 {"type": "prov:Association",
+        ...                  "applied_roles": ["Principal Investigator"],
+        ...                  "applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                       "has_raw_value": "James Stegen"}},
+        ...             ],
+        ...         },
+        ...     ],
+        ... }
+        >>> Migrator(adapter=DictionaryAdapter(database=db)).upgrade()
+        >>> db["study_set"][0]["has_credit_associations"][0]["applies_to_person"]["name"]
+        'A'
+        >>> db["study_set"][0]["has_credit_associations"][1]["applies_to_person"]["name"]
+        'B'
+        >>> db["data_generation_set"][0]["has_credit_associations"][0]["applies_to_person"]["name"]
+        'James Stegen'
+        """
+        self._warn_if_commit_ignored(commit_changes)
+        self.adapter.process_each_document(
+            "study_set", [self.fill_document_personvalue_names]
+        )
+        self.adapter.process_each_document(
+            "data_generation_set", [self.fill_document_personvalue_names]
+        )
+
+    def fill_document_personvalue_names(self, document: dict) -> dict:
+        r"""Copy has_raw_value onto missing name on each credit-association PersonValue.
+
+        Existing non-whitespace ``name`` is left unchanged, including casing.
+        Missing, empty, or whitespace ``name`` is filled from ``has_raw_value``.
+
+        >>> m = Migrator()
+        >>> m.fill_document_personvalue_names(
+        ...     {"id": "nmdc:dgns-1",
+        ...      "has_credit_associations": [
+        ...          {"applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                "name": "Nancy Hess",
+        ...                                "has_raw_value": "Nancy hess"}},
+        ...          {"applies_to_person": {"type": "nmdc:PersonValue",
+        ...                                "has_raw_value": "James Stegen"}},
+        ...          {"applies_to_person": {"name": "", "has_raw_value": "Eoin Brodie"}},
+        ...          {"applies_to_person": {"name": "   ", "has_raw_value": "  Jennifer Pett-Ridge  "}},
+        ...      ]}
+        ... )
+        {'id': 'nmdc:dgns-1', 'has_credit_associations': [{'applies_to_person': {'type': 'nmdc:PersonValue', 'name': 'Nancy Hess', 'has_raw_value': 'Nancy hess'}}, {'applies_to_person': {'type': 'nmdc:PersonValue', 'has_raw_value': 'James Stegen', 'name': 'James Stegen'}}, {'applies_to_person': {'name': 'Eoin Brodie', 'has_raw_value': 'Eoin Brodie'}}, {'applies_to_person': {'name': 'Jennifer Pett-Ridge', 'has_raw_value': '  Jennifer Pett-Ridge  '}}]}
+        >>> m.fill_document_personvalue_names({"id": "nmdc:sty-2"})
+        {'id': 'nmdc:sty-2'}
+        >>> m.fill_document_personvalue_names(
+        ...     {"id": "nmdc:dgns-3",
+        ...      "has_credit_associations": [{"applies_to_person": {"type": "nmdc:PersonValue"}}]}
+        ... )
+        Traceback (most recent call last):
+            ...
+        ValueError: In nmdc:dgns-3: PersonValue has no usable name or has_raw_value
+        """
+        document_id = document.get("id", "<unknown id>")
+        try:
+            for association in document.get("has_credit_associations") or []:
+                if not isinstance(association, dict):
+                    continue
+                person = association.get("applies_to_person")
+                if not isinstance(person, dict):
+                    continue
+                name = person.get("name")
+                if isinstance(name, str) and name.strip():
+                    continue
+                raw = person.get("has_raw_value")
+                if isinstance(raw, str) and raw.strip():
+                    person["name"] = raw.strip()
+                    continue
+                raise ValueError("PersonValue has no usable name or has_raw_value")
+        except ValueError as exc:
+            raise ValueError(f"In {document_id}: {exc}") from None
+        return document

--- a/src/data/invalid/PersonValue-missing-name.yaml
+++ b/src/data/invalid/PersonValue-missing-name.yaml
@@ -1,0 +1,2 @@
+type: nmdc:PersonValue
+has_raw_value: J. Craig Venter

--- a/src/data/valid/Study-credit-1.yaml
+++ b/src/data/valid/Study-credit-1.yaml
@@ -6,11 +6,13 @@ has_credit_associations:
       - Data curation
     applies_to_person:
       type: nmdc:PersonValue
+      name: Josiah Carberry
       orcid: 'orcid:0000-0002-1825-0097'
     type: prov:Association
   - applied_roles:
       - Software
     applies_to_person:
       type: nmdc:PersonValue
+      name: Mark Andrew Miller
       orcid: 'orcid:0000-0001-9076-6066'
     type: prov:Association

--- a/src/schema/attribute_values.yaml
+++ b/src/schema/attribute_values.yaml
@@ -82,6 +82,7 @@ classes:
         notes:
           - May eventually be deprecated in favor of "name".
       name:
+        required: true
         description: >-
           The full name of the Investigator.
           It should follow the format FIRST [MIDDLE NAME| MIDDLE INITIAL] LAST, where MIDDLE NAME| MIDDLE INITIAL is optional.


### PR DESCRIPTION
Closes #2458.

**Schema changes**
- Made `name` required on `PersonValue` class

**Migrator**
- From schema `11.23.0` to `11.24.0`.
- `study_set` and `data_generation_set`: normalize `name` on each of the values in the `has_credit_associations` by filling in from `has_raw_value` as needed and after whitespace stripping.  Raises error if it cannot be filled from `has_raw_value`. Migrator is `nmdc_schema/migrators/partials/migrator_from_11_23_0_to_11_24_0/migrator_from_11_23_0_to_11_24_0_part_3.py`
- migrator was tested locally against production mongo data using `make test-migrator-on-database MIGRATOR=migrator_from_11_23_0_to_11_24_0 SELECTED_COLLECTIONS=study_set` and `make test-migrator-on-database MIGRATOR=migrator_from_11_23_0_to_11_24_0 SELECTED_COLLECTIONS=data_generation_set` with no issues found

**Example Data**
- Added `name` slot on all `PersonValue` instances in `src/data/valid/` (several locations)
- Added `src/data/invalid/PersonValue-missing-name.yaml`: fails only because `name` is not present