### PR TITLE
Record created_on, last_updated_on and modified_by on the badge subsets

### DIFF
--- a/src/schema/basic_slots.yaml
+++ b/src/schema/basic_slots.yaml
@@ -65,6 +65,9 @@ subsets:
         ProvenanceMetadata.source_system_of_record rather than from slot
         completeness, so it has no badge_topic subset.
   biogeochemistry:
+    created_on: "2026-08-13T00:00:00Z"
+    last_updated_on: "2026-08-13T00:00:00Z"
+    modified_by: orcid:0000-0001-9076-6066
     description: >-
       Biosample slots holding measured biogeochemical analytes: nitrogen,
       phosphorus, carbon, sulfur, iron, core physicochemistry, and dissolved
@@ -75,6 +78,9 @@ subsets:
     in_subset:
       - badge_topic
   host_information:
+    created_on: "2026-08-13T00:00:00Z"
+    last_updated_on: "2026-08-13T00:00:00Z"
+    modified_by: orcid:0000-0001-9076-6066
     description: >-
       Biosample slots describing the host organism a sample was taken from or
       associated with: host taxonomy, anatomy, physiology, life stage, and

--- a/tests/test_badge_subset_sync.py
+++ b/tests/test_badge_subset_sync.py
@@ -17,6 +17,14 @@ squad decision, 2026-08-05).
 See https://github.com/microbiomedata/nmdc-schema/issues/3227 (badges slot and
 enum), https://github.com/microbiomedata/nmdc-schema/issues/3228 (subsets) and
 https://github.com/microbiomedata/nmdc-schema/issues/3326 (qualifying bar).
+
+Badge-topic subsets carry created_on, last_updated_on and modified_by so a
+re-evaluation job can tell that a badge definition changed and score every
+record against it again, instead of re-running badge logic over every
+biosample on every release. See
+https://github.com/microbiomedata/nmdc-schema/issues/3374, and
+https://github.com/microbiomedata/issues/issues/1820 for the job that reads
+them.
 """
 
 import unittest
@@ -114,6 +122,22 @@ class TestBadgeSubsetSync(unittest.TestCase):
                 f"'{badge}' is exempted as a provenance badge but a subset of "
                 f"that name is declared; it is one or the other",
             )
+
+    def test_every_badge_subset_declares_provenance(self):
+        """Each badge topic records its dates and modifier (issue 3374).
+
+        The datetime format needs no assertion here because LinkML refuses to
+        generate the schema when a datetime metaslot holds a value it cannot parse.
+        """
+        for name in _badge_topic_subsets(self.schema_view):
+            subset = self.schema_view.get_subset(name)
+            for metaslot in ("created_on", "last_updated_on", "modified_by"):
+                value = getattr(subset, metaslot)
+                self.assertTrue(
+                    value,
+                    f"badge subset '{name}' has no {metaslot}; add {metaslot} "
+                    f"to record the subset's provenance.",
+                )
 
     def test_every_badge_subset_declares_a_qualifying_bar(self):
         """Each completeness badge records how many slots earn it (issue 3326).


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-schema/issues/3374.

Adds `created_on`, `last_updated_on` and `modified_by` to the two badge-topic subsets, with a test that fails when a badge subset lacks one.

Both dates are 2026-08-13 because `git blame` shows nothing has changed either subset since they were created. Today's date would be false, and it would make the first re-evaluation run think both subsets had just changed.

The test checks presence only. linkml refuses to generate the schema when a datetime metaslot holds a value it cannot parse, so a format check here could never fail.

Two things that will trip a reviewer. A fresh checkout fails the new test until `nmdc_schema/nmdc_materialized_patterns.yaml` is regenerated, because the tests read that file and feature branches do not commit it. CI regenerates, so CI is fine. And the values render nowhere on subset pages: https://github.com/microbiomedata/nmdc-schema/issues/3406.

https://github.com/microbiomedata/nmdc-schema/issues/3405 proposes versioning badges instead, which would remove the rationale https://github.com/microbiomedata/nmdc-schema/issues/3374 gives. The metaslots still stand as element attribution, and `last_updated_on` with `modified_by` is the pair `src/docs/schema_element_deprecation_guide.md` already requires.

