### PR TITLE
Say what add_date and mod_date actually hold on ProvenanceMetadata

### DIFF
--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -676,22 +676,21 @@ classes:
         range: datetime
         description: The date and time at which a record was added to the NMDC database.
         comments:
-          - Measured 2026-09-10, all 10,689 production biosamples whose
-            source_system_of_record was NCBI had an add_date later than their mod_date. That
-            ordering is impossible for two NMDC-asserted timestamps. The evidence points at
-            mod_date as the slot carrying an outside value, not this one; see its comment and
-            https://github.com/microbiomedata/nmdc-schema/issues/3399.
+          - Populated per record at ingest, as far as has been checked. The 10,689
+            NCBI-ingested biosamples carry two add_date values one second apart, consistent
+            with a single ingest run, while their mod_date is one constant. See the comment
+            on mod_date and https://github.com/microbiomedata/nmdc-schema/issues/3399.
       mod_date:
         range: datetime
         description: The date and time at which a record was last modified in the NMDC database.
         comments:
-          - Records ingested from outside NMDC may carry the source system's date here
-            rather than an NMDC-asserted timestamp. Measured 2026-09-10, all 10,689
-            production biosamples whose source_system_of_record was NCBI had an add_date
-            later than their mod_date, and a record cannot be modified in NMDC before it was
-            added, so that mod_date came from NCBI. A further 3,417 biosamples record no
-            source_system_of_record at all, so the origin of their dates is unknown. Counts
-            move as more records are ingested; method and current figures are in
+          - This is not always an NMDC-asserted timestamp. Measured 2026-09-11, all
+            10,689 production biosamples whose source_system_of_record was NCBI shared one
+            identical mod_date, earlier than their add_date, so it says nothing about any
+            individual record. The 13,246 submission-portal biosamples carry 27 distinct
+            values and the 3,417 with no recorded source carry 28, so the problem is one
+            ingest path rather than the slot. Counts move as more records are ingested;
+            method and current figures are in
             https://github.com/microbiomedata/nmdc-schema/issues/3399.
       version:
         description: The version tag of the software used to generate the NMDC metadata record

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -676,12 +676,24 @@ classes:
         range: datetime
         description: The date and time at which a record was added to the NMDC database.
         comments:
-          - Biosample and NucleotideSequencing records brought in from GOLD before 2026-03-23 may carry GOLD-sourced dates rather than NMDC-asserted timestamps.
+          - Records ingested from outside NMDC may carry the source system's dates rather
+            than NMDC-asserted timestamps. All 10,689 production biosamples whose
+            source_system_of_record is NCBI have an add_date later than their mod_date, and a
+            record cannot be modified in NMDC before it was added to NMDC, so that mod_date
+            came from NCBI. Records brought in from GOLD before 2026-03-23 may have the same
+            problem. Counts and method are in
+            https://github.com/microbiomedata/nmdc-schema/issues/3399.
       mod_date:
         range: datetime
         description: The date and time at which a record was last modified in the NMDC database.
         comments:
-          - Biosample and NucleotideSequencing records brought in from GOLD before 2026-03-23 may carry GOLD-sourced dates rather than NMDC-asserted timestamps.
+          - Records ingested from outside NMDC may carry the source system's dates rather
+            than NMDC-asserted timestamps. All 10,689 production biosamples whose
+            source_system_of_record is NCBI have an add_date later than their mod_date, and a
+            record cannot be modified in NMDC before it was added to NMDC, so that mod_date
+            came from NCBI. Records brought in from GOLD before 2026-03-23 may have the same
+            problem. Counts and method are in
+            https://github.com/microbiomedata/nmdc-schema/issues/3399.
       version:
         description: The version tag of the software used to generate the NMDC metadata record
       git_url:

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -677,22 +677,24 @@ classes:
         description: The date and time at which a record was added to the NMDC database.
         comments:
           - Records ingested from outside NMDC may carry the source system's dates rather
-            than NMDC-asserted timestamps. All 10,689 production biosamples whose
-            source_system_of_record is NCBI have an add_date later than their mod_date, and a
-            record cannot be modified in NMDC before it was added to NMDC, so that mod_date
-            came from NCBI. Records brought in from GOLD before 2026-03-23 may have the same
-            problem. Counts and method are in
+            than NMDC-asserted timestamps. Measured 2026-09-10, all 10,689 production
+            biosamples whose source_system_of_record was NCBI had an add_date later than
+            their mod_date, and a record cannot be modified in NMDC before it was added to
+            NMDC, so that mod_date came from NCBI. Records brought in from GOLD before
+            2026-03-23 may have the same problem. The count moves as more records are
+            ingested; method and current figures are in
             https://github.com/microbiomedata/nmdc-schema/issues/3399.
       mod_date:
         range: datetime
         description: The date and time at which a record was last modified in the NMDC database.
         comments:
           - Records ingested from outside NMDC may carry the source system's dates rather
-            than NMDC-asserted timestamps. All 10,689 production biosamples whose
-            source_system_of_record is NCBI have an add_date later than their mod_date, and a
-            record cannot be modified in NMDC before it was added to NMDC, so that mod_date
-            came from NCBI. Records brought in from GOLD before 2026-03-23 may have the same
-            problem. Counts and method are in
+            than NMDC-asserted timestamps. Measured 2026-09-10, all 10,689 production
+            biosamples whose source_system_of_record was NCBI had an add_date later than
+            their mod_date, and a record cannot be modified in NMDC before it was added to
+            NMDC, so that mod_date came from NCBI. Records brought in from GOLD before
+            2026-03-23 may have the same problem. The count moves as more records are
+            ingested; method and current figures are in
             https://github.com/microbiomedata/nmdc-schema/issues/3399.
       version:
         description: The version tag of the software used to generate the NMDC metadata record

--- a/src/schema/basic_classes.yaml
+++ b/src/schema/basic_classes.yaml
@@ -676,25 +676,22 @@ classes:
         range: datetime
         description: The date and time at which a record was added to the NMDC database.
         comments:
-          - Records ingested from outside NMDC may carry the source system's dates rather
-            than NMDC-asserted timestamps. Measured 2026-09-10, all 10,689 production
-            biosamples whose source_system_of_record was NCBI had an add_date later than
-            their mod_date, and a record cannot be modified in NMDC before it was added to
-            NMDC, so that mod_date came from NCBI. Records brought in from GOLD before
-            2026-03-23 may have the same problem. The count moves as more records are
-            ingested; method and current figures are in
+          - Measured 2026-09-10, all 10,689 production biosamples whose
+            source_system_of_record was NCBI had an add_date later than their mod_date. That
+            ordering is impossible for two NMDC-asserted timestamps. The evidence points at
+            mod_date as the slot carrying an outside value, not this one; see its comment and
             https://github.com/microbiomedata/nmdc-schema/issues/3399.
       mod_date:
         range: datetime
         description: The date and time at which a record was last modified in the NMDC database.
         comments:
-          - Records ingested from outside NMDC may carry the source system's dates rather
-            than NMDC-asserted timestamps. Measured 2026-09-10, all 10,689 production
-            biosamples whose source_system_of_record was NCBI had an add_date later than
-            their mod_date, and a record cannot be modified in NMDC before it was added to
-            NMDC, so that mod_date came from NCBI. Records brought in from GOLD before
-            2026-03-23 may have the same problem. The count moves as more records are
-            ingested; method and current figures are in
+          - Records ingested from outside NMDC may carry the source system's date here
+            rather than an NMDC-asserted timestamp. Measured 2026-09-10, all 10,689
+            production biosamples whose source_system_of_record was NCBI had an add_date
+            later than their mod_date, and a record cannot be modified in NMDC before it was
+            added, so that mod_date came from NCBI. A further 3,417 biosamples record no
+            source_system_of_record at all, so the origin of their dates is unknown. Counts
+            move as more records are ingested; method and current figures are in
             https://github.com/microbiomedata/nmdc-schema/issues/3399.
       version:
         description: The version tag of the software used to generate the NMDC metadata record


### PR DESCRIPTION
Closes https://github.com/microbiomedata/nmdc-schema/issues/3399.

The comment on `add_date` and `mod_date` blamed GOLD records from before 2026-03-23. No production biosample records GOLD as its source system at all.

What is there instead: on the 10,689 biosamples ingested from NCBI, `mod_date` is one constant, `2026-06-30T17:35:41.517537+00:00`, identical on every record to the microsecond. It says nothing about any individual record. `add_date` on those records is fine.

| source_system_of_record | records | distinct mod_date |
| --- | ---: | ---: |
| NMDC_Submission_Portal | 13,246 | 27 |
| NCBI | 10,689 | 1 |
| none recorded | 3,417 | 28 |

Measured 2026-09-11 across all 27,352 records from `https://api.microbiomedata.org/nmdcschema/biosample_set`.

Comments only. Both descriptions are unchanged, because they say what the slots are meant to hold and that is still the intent. Fixing the data is https://github.com/microbiomedata/nmdc-schema/issues/1874, where @aclum reads the cause as a key-mapping bug in the ingest code.

Earlier commits on this branch said the value came from NCBI. That was wrong. I left them in the history rather than squashing.

