### PR TITLE
Attach ontology_class_set to Database and add the missing ontology_relation_set slot

### DIFF
--- a/src/schema/nmdc.yaml
+++ b/src/schema/nmdc.yaml
@@ -455,6 +455,8 @@ classes:
       - instrument_set
       - manifest_set
       - material_processing_set
+      - ontology_class_set
+      - ontology_relation_set
       - organism_sample_set
       - organism_set
       - processed_sample_set
@@ -1350,6 +1352,13 @@ slots:
     range: OntologyClass
     description:
       This property links a database object to the set of ontology classes
+      within it.
+  ontology_relation_set:
+    mixins:
+      - object_set
+    range: OntologyRelation
+    description:
+      This property links a database object to the set of ontology relations
       within it.
   biosample_set:
     mixins:


### PR DESCRIPTION
## Why

Production holds two collections the schema does not attach to `Database`:

| collection | documents in prod |
|---|---:|
| `ontology_class_set` | 22,722 |
| `ontology_relation_set` | 561,169 |

Both are written weekly by the ontology loader, currently UBERON, ENVO and PO.

Because nothing declares them, reference scanning does not check them. Confirmed by @eecavanna on 2026-09-10: refscan detects no references going to or from the `ontology_*` collections. So nothing today would report an `OntologyRelation` pointing at an `OntologyClass` that is not there.

Closes https://github.com/microbiomedata/nmdc-schema/issues/3407

## What changed

Two edits to `src/schema/nmdc.yaml`, nine lines.

`ontology_class_set` already existed as a slot and was correctly shaped: `object_set` as a mixin, `OntologyClass` as its range, identical in form to `biosample_set`. It was used by no class. It is now in `Database.slots`.

`ontology_relation_set` did not exist. Added with the same shape, ranging on `OntologyRelation`, which was already defined as a class. Also attached.

Both induce as `multivalued: true, inlined_as_list: true` from the mixin, matching the other 19. `Database` goes from 19 slots to 21.

## Two things a reviewer should know

**This changes what the nightly validation job looks at.** `validate_mongo_data` in nmdc-runtime derives its eligible collections from the schema, logging them as "schema-described collections". Those two collections are not schema-described today, so the job skips them. After this, 583,891 existing documents become eligible on the next run, which is at 8pm Pacific. That is the intended effect, and it is worth knowing before it happens rather than after. The op takes `exclude_collections` if the first run turns up a backlog worth triaging separately.

**It interacts with an existing issue.** `ontology_class_set` appears on the removal list in https://github.com/microbiomedata/nmdc-schema/issues/2297, which proposes deleting slots no class uses. Acting on that list would delete the slot describing a live production collection. This resolves the conflict by fixing the underlying condition, so the slot leaves the orphan report rather than needing an exception. That matters more once https://github.com/microbiomedata/nmdc-schema/issues/3202 runs orphan detection in CI.

## No migrator

Per `CONTRIBUTING.md`, a migrator is needed when a change would make previously-compliant data non-compliant. This adds optional slots, so it does not.

## Validation

`make test` passes, 94 tests. `linkml-lint` reports no problems. Verified through `SchemaView` that both slots attach to `Database` and induce the expected range, multivalued and inlined_as_list.

Source-only change. Generated artifacts are rebuilt by CI, matching the convention in recent schema commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGdbAo1cW9QBR2u8JBWDdK